### PR TITLE
Dynamically set the number of jobs when compiling

### DIFF
--- a/libretro-build.sh
+++ b/libretro-build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+NUM_JOBS=$(($(nproc) * 3 / 2))
+
 die()
 {
    echo $1
@@ -15,7 +17,7 @@ build_libretro_bsnes()
    if [ -d "libretro-bsnes/perf" ]; then
       echo "=== Building bSNES performance ==="
       cd libretro-bsnes/perf/higan
-      make compiler="$CC" ui=target-libretro profile=performance -j4 || die "Failed to build bSNES performance core"
+      make compiler="$CC" ui=target-libretro profile=performance -j $NUM_JOBS || die "Failed to build bSNES performance core"
       cp -f out/libretro.so ../../libretro-bsnes-performance.so
       cd ../../..
    else
@@ -25,7 +27,7 @@ build_libretro_bsnes()
    if [ -d "libretro-bsnes/balanced" ]; then
       echo "=== Building bSNES balanced ==="
       cd libretro-bsnes/balanced/higan
-      make compiler="$CC" ui=target-libretro profile=balanced -j4 || die "Failed to build bSNES balanced core"
+      make compiler="$CC" ui=target-libretro profile=balanced -j $NUM_JOBS || die "Failed to build bSNES balanced core"
       cp -f out/libretro.so ../../libretro-bsnes-balanced.so
       cd ../../..
    else
@@ -35,7 +37,7 @@ build_libretro_bsnes()
    if [ -d "libretro-bsnes" ]; then
       echo "=== Building bSNES accuracy ==="
       cd libretro-bsnes/higan
-      make compiler="$CC" ui=target-libretro profile=accuracy -j4 || die "Failed to build bSNES accuracy core"
+      make compiler="$CC" ui=target-libretro profile=accuracy -j $NUM_JOBS || die "Failed to build bSNES accuracy core"
       cp -f out/libretro.so ../libretro-bsnes-accuracy.so
       cd ../..
    fi
@@ -51,7 +53,7 @@ build_libretro_mednafen()
       do
          if [ -d $core ]; then
             cd $core
-            make core=${core} -j4 || die "Failed to build mednafen/${core}"
+            make core=${core} -j $NUM_JOBS || die "Failed to build mednafen/${core}"
             cp mednafen_$(echo ${core} | tr '[\-]' '[_]')_libretro.so ../libretro-mednafen-${core}.so
             cd ..
          fi
@@ -67,7 +69,7 @@ build_libretro_s9x()
    if [ -d "libretro-s9x" ]; then
       echo "=== Building SNES9x ==="
       cd libretro-s9x/libretro
-      make -j4 || die "Failed to build SNES9x"
+      make -j $NUM_JOBS || die "Failed to build SNES9x"
       cp libretro.so ../libretro-snes9x.so
       cd ../..
    else
@@ -80,7 +82,7 @@ build_libretro_s9x_next()
    if [ -d "libretro-s9x-next" ]; then
       echo "=== Building SNES9x-Next ==="
       cd libretro-s9x-next/
-      make -f Makefile.libretro -j4 || die "Failed to build SNES9x-Next"
+      make -f Makefile.libretro -j $NUM_JOBS || die "Failed to build SNES9x-Next"
       cp snes9x_next_libretro.so libretro-snes9x-next.so
       cd ..
    else
@@ -93,7 +95,7 @@ build_libretro_genplus()
    if [ -d "libretro-genplus" ]; then
       echo "=== Building Genplus GX ==="
       cd libretro-genplus/
-      make -f Makefile.libretro -j4 || die "Failed to build Genplus GX"
+      make -f Makefile.libretro -j $NUM_JOBS || die "Failed to build Genplus GX"
       cp genesis_plus_gx_libretro.so libretro-genplus.so
       cd ..
    else
@@ -119,7 +121,7 @@ build_libretro_vba()
    if [ -d "libretro-vba" ]; then
       echo "=== Building VBA-Next ==="
       cd libretro-vba/
-      make -f Makefile.libretro -j4 || die "Failed to build VBA-Next"
+      make -f Makefile.libretro -j $NUM_JOBS || die "Failed to build VBA-Next"
       cp vba_next_libretro.so libretro-vba.so
       cd ..
    else
@@ -133,7 +135,7 @@ build_libretro_bnes()
       echo "=== Building bNES ==="
       cd libretro-bnes
       mkdir -p obj
-      make -j4 || die "Failed to build bNES"
+      make -j $NUM_JOBS || die "Failed to build bNES"
       cp libretro.so libretro-bnes.so
       cd ..
    else
@@ -146,7 +148,7 @@ build_libretro_fceu()
    if [ -d "libretro-fceu" ]; then
       echo "=== Building FCEU ==="
       cd libretro-fceu
-      make -C fceumm-code -f Makefile.libretro -j4 || die "Failed to build FCEU"
+      make -C fceumm-code -f Makefile.libretro -j $NUM_JOBS || die "Failed to build FCEU"
       cp fceumm-code/fceumm_libretro.so libretro-fceu.so
       cd ..
    else
@@ -159,7 +161,7 @@ build_libretro_gambatte()
    if [ -d "libretro-gambatte" ]; then
       echo "=== Building Gambatte ==="
       cd libretro-gambatte/libgambatte
-      make -f Makefile.libretro -j4 || die "Failed to build Gambatte"
+      make -f Makefile.libretro -j $NUM_JOBS || die "Failed to build Gambatte"
       cp gambatte_libretro.so ../libretro-gambatte.so
       cd ../..
    else
@@ -172,7 +174,7 @@ build_libretro_meteor()
    if [ -d "libretro-meteor" ]; then
       echo "=== Building Meteor ==="
       cd libretro-meteor/libretro
-      make -j4 || die "Failed to build Meteor"
+      make -j $NUM_JOBS || die "Failed to build Meteor"
       cp libretro.so ../libretro-meteor.so
       cd ../..
    else
@@ -185,7 +187,7 @@ build_libretro_nx()
    if [ -d "libretro-nx" ]; then
       echo "=== Building NXEngine ==="
       cd libretro-nx
-      make -j4 || die "Failed to build NXEngine"
+      make -j $NUM_JOBS || die "Failed to build NXEngine"
       cp nxengine_libretro.so libretro-nx.so
       cd ..
    else
@@ -198,7 +200,7 @@ build_libretro_prboom()
    if [ -d "libretro-prboom" ]; then
       echo "=== Building PRBoom ==="
       cd libretro-prboom
-      make -j4 || die "Failed to build PRBoom"
+      make -j $NUM_JOBS || die "Failed to build PRBoom"
       cp prboom_libretro.so libretro-prboom.so
       cd ../
    else
@@ -211,7 +213,7 @@ build_libretro_stella()
    if [ -d "libretro-stella" ]; then
       echo "=== Building Stella ==="
       cd libretro-stella
-      make -j4 || die "Failed to build Stella"
+      make -j $NUM_JOBS || die "Failed to build Stella"
       cp libretro.so libretro-stella.so
       cd ../
    else
@@ -224,7 +226,7 @@ build_libretro_desmume()
    if [ -d "libretro-desmume" ]; then
       echo "=== Building Desmume ==="
       cd libretro-desmume
-      make -f Makefile.libretro -j4 || die "Failed to build Desmume"
+      make -f Makefile.libretro -j $NUM_JOBS || die "Failed to build Desmume"
       cp libretro.so libretro-desmume.so
       cd ../
    else
@@ -237,7 +239,7 @@ build_libretro_quicknes()
    if [ -d "libretro-quicknes" ]; then
       echo "=== Building QuickNES ==="
       cd libretro-quicknes/libretro
-      make -j4 || die "Failed to build QuickNES"
+      make -j $NUM_JOBS || die "Failed to build QuickNES"
       cp libretro.so ../libretro-quicknes.so
       cd ../..
    else
@@ -250,7 +252,7 @@ build_libretro_nestopia()
    if [ -d "libretro-nestopia" ]; then
       echo "=== Building Nestopia ==="
       cd libretro-nestopia/libretro
-      make -j4 || die "Failed to build Nestopia"
+      make -j $NUM_JOBS || die "Failed to build Nestopia"
       cp nestopia_libretro.so ../libretro-nestopia.so
       cd ../..
    else


### PR DESCRIPTION
Calculate the optimal number of jobs instead of hard-coding -j4 to the make commands. This drastically speeds up compilation time on machines with 4+ cores.

The number of jobs is calculated as number-of-threads \* 1.5 since running only one job per thread tends to not maximize CPU usage completely.
