### PR TITLE
Build for iOS

### DIFF
--- a/libretro-build-ios.sh
+++ b/libretro-build-ios.sh
@@ -15,7 +15,9 @@ fi
 
 export IOSSDK=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/
 
-if ! $SKIPFETCH ; then
+if [ $SKIPFETCH == "true" ] ; then
+  echo "Skipping fetch of emulator cores."
+else
   # clone/fetch the emulator core repos
   cd $CORES_DIR
   "$ROOT_DIR/libretro-fetch.sh"


### PR DESCRIPTION
This adds a builds script for building all of the cores for iOS. It builds all of the cores except:
- VBA
- FCEU
- QuickNES

These cores just need some pull requests sent in to add the iOS building to their makefiles.
## Running

Building is like the other scripts with the addition of the ability to skip fetching of the repos. This way if you've cloned down once, it won't pull down master on all the cores before building.

``` sh
./libretro-build-ios.sh 
```
#### Skip Fetch

``` sh
SKIPFETCH=true ./libretro-build-ios.sh 
```

This pull relates to Themaister/RetroArch#165 to get the building of iOS working better and easier.
