### PR TITLE
Win32 compiler flags

### DIFF
--- a/libretro-build-win32.sh
+++ b/libretro-build-win32.sh
@@ -12,12 +12,28 @@ if [ "$HOST_CC" ]; then
    STRIP="${HOST_CC}-strip"
 fi
 
+if [ -z "$MAKE" ]; then
+   if [ "$(expr substr $(uname -s) 1 7)" == "MINGW32" ]; then
+      MAKE=mingw32-make
+   else
+      MAKE=make
+   fi
+fi
+
 if [ -z "$CC" ]; then
-   CC=gcc
+   if [ "$(expr substr $(uname -s) 1 7)" == "MINGW32" ]; then
+      CC=mingw32-gcc
+   else
+      CC=gcc
+   fi
 fi
 
 if [ -z "$CXX" ]; then
-   CXX=g++
+   if [ "$(expr substr $(uname -s) 1 7)" == "MINGW32" ]; then
+      CXX=mingw32-g++
+   else
+      CXX=g++
+   fi
 fi
 
 build_libretro_bsnes()
@@ -25,7 +41,7 @@ build_libretro_bsnes()
    if [ -d "libretro-bsnes/perf" ]; then
       echo "=== Building bSNES performance ==="
       cd libretro-bsnes/perf/higan
-      make platform=win compiler="$CC" ui=target-libretro profile=performance -j4 || die "Failed to build bSNES performance core"
+      $MAKE platform=win compiler="$CC" ui=target-libretro profile=performance -j4 || die "Failed to build bSNES performance core"
       cp -f out/retro.dll ../../libretro-092-bsnes-performance.dll
       cd ../../..
    else
@@ -35,7 +51,7 @@ build_libretro_bsnes()
    if [ -d "libretro-bsnes/balanced" ]; then
       echo "=== Building bSNES balanced ==="
       cd libretro-bsnes/balanced/higan
-      make platform=win compiler="$CC" ui=target-libretro profile=balanced -j4 || die "Failed to build bSNES balanced core"
+      $MAKE platform=win compiler="$CC" ui=target-libretro profile=balanced -j4 || die "Failed to build bSNES balanced core"
       cp -f out/retro.dll ../../libretro-092-bsnes-balanced.dll
       cd ../../..
    else
@@ -45,7 +61,7 @@ build_libretro_bsnes()
    if [ -d "libretro-bsnes" ]; then
       echo "=== Building bSNES accuracy ==="
       cd libretro-bsnes/higan
-      make platform=win compiler="$CC" ui=target-libretro profile=accuracy -j4 || die "Failed to build bSNES accuracy core"
+      $MAKE platform=win compiler="$CC" ui=target-libretro profile=accuracy -j4 || die "Failed to build bSNES accuracy core"
       cp -f out/retro.dll ../libretro-092-bsnes-accuracy.dll
       cd ../..
    fi
@@ -58,19 +74,19 @@ build_libretro_mednafen()
       cd libretro-mednafen
 
       cd psx
-      make core=psx platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build mednafen/psx"
+      $MAKE core=psx platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build mednafen/psx"
       cp retro.dll ../libretro-0928-mednafen-psx.dll
       "$STRIP" ../libretro-0928-mednafen-psx.dll
       cd ..
 
       cd pce-fast
-      make core=pce-fast platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build mednafen/pce-fast"
+      $MAKE core=pce-fast platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build mednafen/pce-fast"
       cp retro.dll ../libretro-0928-mednafen-pce-fast.dll
       "$STRIP" ../libretro-0928-mednafen-pce-fast.dll
       cd ..
 
       cd wswan
-      make core=wswan platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build mednafen/wswan"
+      $MAKE core=wswan platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build mednafen/wswan"
       cp retro.dll ../libretro-0928-mednafen-wswan.dll
       "$STRIP" ../libretro-0928-mednafen-wswan.dll
       cd ..
@@ -86,7 +102,7 @@ build_libretro_s9x()
    if [ -d "libretro-s9x" ]; then
       echo "=== Building SNES9x ==="
       cd libretro-s9x/libretro
-      make CC=$CC CXX=$CXX platform=win -j4 || die "Failed to build SNES9x"
+      $MAKE CC=$CC CXX=$CXX platform=win -j4 || die "Failed to build SNES9x"
       cp libretro.dll ../libretro-git-snes9x.dll
       cd ../..
    else
@@ -99,7 +115,7 @@ build_libretro_s9x_next()
    if [ -d "libretro-s9x-next" ]; then
       echo "=== Building SNES9x-Next ==="
       cd libretro-s9x-next/
-      make CC=$CC CXX=$CXX platform=win -f Makefile.libretro -j4 || die "Failed to build SNES9x-Next"
+      $MAKE CC=$CC CXX=$CXX platform=win -f Makefile.libretro -j4 || die "Failed to build SNES9x-Next"
       cp snes9x_next_retro.dll libretro-git-snes9x-next.dll
       cd ..
    else
@@ -112,7 +128,7 @@ build_libretro_genplus()
    if [ -d "libretro-genplus" ]; then
       echo "=== Building Genplus GX ==="
       cd libretro-genplus/
-      make CC=$CC CXX=$CXX platform=win -f Makefile.libretro -j4 || die "Failed to build Genplus GX"
+      $MAKE CC=$CC CXX=$CXX platform=win -f Makefile.libretro -j4 || die "Failed to build Genplus GX"
       cp genesis_plus_gx_retro.dll libretro-git-genplus.dll
       cd ..
    else
@@ -125,7 +141,7 @@ build_libretro_fba()
    if [ -d "libretro-fba" ]; then
       echo "=== Building Final Burn Alpha ==="
       cd libretro-fba/svn-current/trunk
-      make CC=$CC CXX=$CXX platform=win -f makefile.libretro -j4 || die "Failed to build Final Burn Alpha"
+      $MAKE CC=$CC CXX=$CXX platform=win -f makefile.libretro -j4 || die "Failed to build Final Burn Alpha"
       cp fb_alpha_retro.dll ../../libretro-git-fba.dll
       cd ../../..
    else
@@ -138,7 +154,7 @@ build_libretro_vba()
    if [ -d "libretro-vba" ]; then
       echo "=== Building VBA-Next ==="
       cd libretro-vba/
-      make CC=$CC CXX=$CXX platform=win -f Makefile.libretro -j4 || die "Failed to build VBA-Next"
+      $MAKE CC=$CC CXX=$CXX platform=win -f Makefile.libretro -j4 || die "Failed to build VBA-Next"
       cp vba_next_retro.dll libretro-git-vba.dll
       cd ..
    else
@@ -152,7 +168,7 @@ build_libretro_bnes()
       echo "=== Building bNES ==="
       cd libretro-bnes
       mkdir -p obj
-      make CC=$CC CXX=$CXX platform=win -j4 || die "Failed to build bNES"
+      $MAKE CC=$CC CXX=$CXX platform=win -j4 || die "Failed to build bNES"
       cp retro.dll libretro-git-bnes.dll
       cd ..
    else
@@ -165,7 +181,7 @@ build_libretro_fceu()
    if [ -d "libretro-fceu" ]; then
       echo "=== Building FCEU ==="
       cd libretro-fceu
-      make CC=$CC CXX=$CXX platform=win -C fceumm-code -f Makefile.libretro -j4 || die "Failed to build FCEU"
+      $MAKE CC=$CC CXX=$CXX platform=win -C fceumm-code -f Makefile.libretro -j4 || die "Failed to build FCEU"
       cp fceumm-code/fceumm_retro.dll libretro-git-fceu.dll
       cd ..
    else
@@ -178,7 +194,7 @@ build_libretro_gambatte()
    if [ -d "libretro-gambatte" ]; then
       echo "=== Building Gambatte ==="
       cd libretro-gambatte/libgambatte
-      make CC=$CC CXX=$CXX platform=win -f Makefile.libretro -j4 || die "Failed to build Gambatte"
+      $MAKE CC=$CC CXX=$CXX platform=win -f Makefile.libretro -j4 || die "Failed to build Gambatte"
       cp gambatte_retro.dll ../libretro-git-gambatte.dll
       cd ../..
    else
@@ -191,7 +207,7 @@ build_libretro_meteor()
    if [ -d "libretro-meteor" ]; then
       echo "=== Building Meteor ==="
       cd libretro-meteor/libretro
-      make platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build Meteor"
+      $MAKE platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build Meteor"
       cp retro.dll ../libretro-git-meteor.dll
       cd ../..
    else
@@ -204,7 +220,7 @@ build_libretro_stella()
    if [ -d "libretro-stella" ]; then
       echo "=== Building Stella ==="
       cd libretro-stella
-      make platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build Stella"
+      $MAKE platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build Stella"
       cp stella_retro.dll libretro-git-stella.dll
       cd ../
    else
@@ -217,7 +233,7 @@ build_libretro_desmume()
    if [ -d "libretro-desmume" ]; then
       echo "=== Building Desmume ==="
       cd libretro-desmume
-      make platform=win CC=$CC CXX=$CXX -f Makefile.libretro -j4 || die "Failed to build Desmume"
+      $MAKE platform=win CC=$CC CXX=$CXX -f Makefile.libretro -j4 || die "Failed to build Desmume"
       cp retro.dll libretro-git-desmume.dll
       cd ../
    else
@@ -230,7 +246,7 @@ build_libretro_quicknes()
    if [ -d "libretro-quicknes" ]; then
       echo "=== Building QuickNES ==="
       cd libretro-quicknes/libretro
-      make platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build QuickNES"
+      $MAKE platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build QuickNES"
       cp quicknes_retro.dll ../libretro-git-quicknes.dll
       cd ../..
    else
@@ -243,7 +259,7 @@ build_libretro_nestopia()
    if [ -d "libretro-nestopia" ]; then
       echo "=== Building Nestopia ==="
       cd libretro-nestopia/libretro
-      make platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build Nestopia"
+      $MAKE platform=win CC=$CC CXX=$CXX -j4 || die "Failed to build Nestopia"
       cp nestopia_retro.dll ../libretro-144-nestopia.dll
       cd ../..
    else


### PR DESCRIPTION
The first commit fixes compilation of several emulator cores with c++ files.

The second commit enables the emulator cores to be compiled under a MINGW32 environment under windows. Tested under MinGW32 under Windows 7 x64.
