### PR TITLE
Clean up platform assignment

### DIFF
--- a/libretro-install.sh
+++ b/libretro-install.sh
@@ -1,27 +1,18 @@
 #!/bin/sh
 
 if [ "$platform" ]; then
-   if [ "$platform" = "win" ]; then
-      DIST_DIR=win
-   elif [ "$platform" = "osx" ]; then
-      DIST_DIR=osx
-   else
-      DIST_DIR=unix
-   fi
+   case "$platform" in
+      win) DIST_DIR=win;;
+      osx) DIST_DIR=osx;;
+      *)   DIST_DIR=unix;;
+   esac
 else
-   UNAME=$(uname)
-
-   if [ $(echo $UNAME | grep Linux) ]; then
-      DIST_DIR=unix
-   elif [ $(echo $UNAME | grep BSD) ]; then
-      DIST_DIR=bsd
-   elif [ $(echo $UNAME | grep Darwin) ]; then
-      DIST_DIR=osx
-   elif [ $(echo $UNAME | grep -i MINGW) ]; then
-      DIST_DIR=win
-   else
-      DIST_DIR=unix
-   fi
+   case "$(uname)" in
+      *BSD*) DIST_DIR=bsd;;
+      *Darwin*) DIST_DIR=osx;;
+      *mingw*|*MINGW*) DIST_DIR=win;;
+      *) DIST_DIR=unix;;
+   esac
 fi
 
 # BSDs don't have readlink -f


### PR DESCRIPTION
By using `case` instead of giant `if…elif…else` statements, you can save a lot of space and power. In this commit, I favored using permissive conditions (using `*value*`), but I'm not sure this is even necessary.

I'm also unsure of the possible cases for the capitalization of `mingw`, but that case can probably be simplified as well.
