### PR TITLE
Move platform/architecture detection into libretro-config.sh

### DIFF
--- a/libretro-build.sh
+++ b/libretro-build.sh
@@ -2,55 +2,6 @@
 
 . ./libretro-config.sh
 
-if [ "$platform" ]; then
-   if [ "$platform" = "win" ]; then
-      FORMAT_EXT="dll"
-      FORMAT_COMPILER_TARGET=win
-      FORMAT_COMPILER_TARGET_ALT=win
-      DIST_DIR=win
-   elif [ "$platform" = "osx" ]; then
-      FORMAT_EXT="dylib"
-      FORMAT_COMPILER_TARGET=osx
-      FORMAT_COMPILER_TARGET_ALT=osx
-      DIST_DIR=osx
-   else
-      FORMAT_EXT="so"
-      FORMAT_COMPILER_TARGET=unix
-      FORMAT_COMPILER_TARGET_ALT=unix
-      DIST_DIR=unix
-   fi
-else
-   UNAME=$(uname)
-
-   if [ $(echo $UNAME | grep Linux) ]; then
-      FORMAT_EXT="so"
-      FORMAT_COMPILER_TARGET=unix
-      FORMAT_COMPILER_TARGET_ALT=unix
-      DIST_DIR=unix
-   elif [ $(echo $UNAME | grep BSD) ]; then
-      FORMAT_EXT="so"
-      FORMAT_COMPILER_TARGET=unix
-      FORMAT_COMPILER_TARGET_ALT=unix
-      DIST_DIR=bsd
-   elif [ $(echo $UNAME | grep Darwin) ]; then
-      FORMAT_EXT="dylib"
-      FORMAT_COMPILER_TARGET=osx
-      FORMAT_COMPILER_TARGET_ALT=osx
-      DIST_DIR=osx
-   elif [ $(echo $UNAME | grep -i MINGW) ]; then
-      FORMAT_EXT="dll"
-      FORMAT_COMPILER_TARGET=win
-      FORMAT_COMPILER_TARGET_ALT=win
-      DIST_DIR=win
-   else
-      # assume this is UNIX-based at least
-      FORMAT_EXT="so"
-      FORMAT_COMPILER_TARGET=unix
-      FORMAT_COMPILER_TARGET_ALT=unix
-      DIST_DIR=unix
-   fi
-fi
-
 # BSDs don't have readlink -f
 read_link()
 {
@@ -87,21 +38,6 @@ die()
    echo $1
    #exit 1
 }
-
-case "$(uname -m)" in
-   x86_64) X86=true && X86_64=true;;
-   i686)   X86=true;;
-   armv*)
-      ARM=true && export FORMAT_COMPILER_TARGET=armv
-      case "$(uname -m)" in
-         armv5tel) ARMV5=true;;
-         armv6l)   ARMV6=true;;
-         armv7l)   ARMV7=true;;
-      esac;;
-esac
-
-echo "$(uname -m) CPU detected"
-export FORMAT_COMPILER_TARGET_ALT="$FORMAT_COMPILER_TARGET"
 
 if [ "$HOST_CC" ]; then
    CC="${HOST_CC}-gcc"

--- a/libretro-config.sh
+++ b/libretro-config.sh
@@ -1,5 +1,61 @@
 #!/bin/sh
 
+# Architecture Assignment
+ARCH="$(uname -m)"
+case "$ARCH" in
+   x86_64) X86=true && X86_64=true;;
+   i686)   X86=true;;
+   armv*)
+      ARM=true && export FORMAT_COMPILER_TARGET=armv
+      export RARCHCFLAGS="${RARCHCFLAGS} -marm"
+      case "$ARCH" in
+         armv5tel) ARMV5=true;;
+         armv6l)   ARMV6=true;;
+         armv7l)   ARMV7=true;;
+      esac;;
+esac
+echo "$ARCH CPU detected"
+
+# Platform Assignment
+if [ "$platform" ]; then
+   case "$platform" in
+      win)
+         FORMAT_EXT='dll'
+         FORMAT_COMPILER_TARGET=win
+         DIST_DIR=win;;
+      osx)
+         FORMAT_EXT='dylib'
+         FORMAT_COMPILER_TARGET=osx
+         DIST_DIR=osx;;
+      *)
+         FORMAT_EXT='so'
+         FORMAT_COMPILER_TARGET=unix
+         DIST_DIR=unix;;
+   esac
+else
+   UNAME="$(uname)"
+   case "$UNAME" in
+      *BSD*)
+         FORMAT_EXT='so'
+         FORMAT_COMPILER_TARGET=unix
+         DIST_DIR=bsd;;
+      *Darwin*)
+         FORMAT_EXT='dylib'
+         FORMAT_COMPILER_TARGET=osx
+         DIST_DIR=osx;;
+      *mingw*|*MINGW*)
+         FORMAT_EXT='dll'
+         FORMAT_COMPILER_TARGET=win
+         DIST_DIR=win;;
+      *)
+         FORMAT_EXT='so'
+         FORMAT_COMPILER_TARGET=unix
+         DISTT_DIR=unix;;
+   esac
+fi
+
+export FORMAT_COMPILER_TARGET_ALT="$FORMAT_COMPILER_TARGET"
+
 #USER DEFINES
 #------------
 #These options should be defined inside your own

--- a/libretro-install.sh
+++ b/libretro-install.sh
@@ -1,19 +1,6 @@
 #!/bin/sh
 
-if [ "$platform" ]; then
-   case "$platform" in
-      win) DIST_DIR=win;;
-      osx) DIST_DIR=osx;;
-      *)   DIST_DIR=unix;;
-   esac
-else
-   case "$(uname)" in
-      *BSD*) DIST_DIR=bsd;;
-      *Darwin*) DIST_DIR=osx;;
-      *mingw*|*MINGW*) DIST_DIR=win;;
-      *) DIST_DIR=unix;;
-   esac
-fi
+. ./libretro-config.sh
 
 # BSDs don't have readlink -f
 read_link()

--- a/retroarch-build.sh
+++ b/retroarch-build.sh
@@ -2,55 +2,6 @@
 
 . ./libretro-config.sh
 
-if [ "$platform" ]; then
-   if [ "$platform" = "win" ]; then
-      FORMAT_EXT="dll"
-      FORMAT_COMPILER_TARGET=win
-      FORMAT_COMPILER_TARGET_ALT=win
-      DIST_DIR=win
-   elif [ "$platform" = "osx" ]; then
-      FORMAT_EXT="dylib"
-      FORMAT_COMPILER_TARGET=osx
-      FORMAT_COMPILER_TARGET_ALT=osx
-      DIST_DIR=osx
-   else
-      FORMAT_EXT="so"
-      FORMAT_COMPILER_TARGET=unix
-      FORMAT_COMPILER_TARGET_ALT=unix
-      DIST_DIR=unix
-   fi
-else
-   UNAME=$(uname)
-
-   if [ $(echo $UNAME | grep Linux) ]; then
-      FORMAT_EXT="so"
-      FORMAT_COMPILER_TARGET=unix
-      FORMAT_COMPILER_TARGET_ALT=unix
-      DIST_DIR=unix
-   elif [ $(echo $UNAME | grep BSD) ]; then
-      FORMAT_EXT="so"
-      FORMAT_COMPILER_TARGET=unix
-      FORMAT_COMPILER_TARGET_ALT=unix
-      DIST_DIR=bsd
-   elif [ $(echo $UNAME | grep Darwin) ]; then
-      FORMAT_EXT="dylib"
-      FORMAT_COMPILER_TARGET=osx
-      FORMAT_COMPILER_TARGET_ALT=osx
-      DIST_DIR=osx
-   elif [ $(echo $UNAME | grep -i MINGW) ]; then
-      FORMAT_EXT="dll"
-      FORMAT_COMPILER_TARGET=win
-      FORMAT_COMPILER_TARGET_ALT=win
-      DIST_DIR=win
-   else
-      # assume this is UNIX-based at least
-      FORMAT_EXT="so"
-      FORMAT_COMPILER_TARGET=unix
-      FORMAT_COMPILER_TARGET_ALT=unix
-      DIST_DIR=unix
-   fi
-fi
-
 # BSDs don't have readlink -f
 read_link()
 {
@@ -87,43 +38,6 @@ die()
    echo $1
    #exit 1
 }
-
-ARCH=$(uname -m)
-X86=false
-X86_64=false
-ARM=false
-ARMV5=false
-ARMV6=false
-ARMV7=false
-if [ $ARCH = x86_64 ]; then
-   echo "x86_64 CPU detected"
-   X86=true
-   X86_64=true
-elif [ $ARCH = i686 ]; then
-   echo "x86_32 CPU detected"
-   X86=true
-elif [ $ARCH = armv5tel ]; then
-   echo "ARMv5 CPU detected"
-   ARM=true
-   ARMV5=true
-   export FORMAT_COMPILER_TARGET=armv
-   export FORMAT_COMPILER_TARGET_ALT=$FORMAT_COMPILER_TARGET
-   export RARCHCFLAGS="${RARCHCFLAGS} -marm"
-elif [ $ARCH = armv6l ]; then
-   echo "ARMv6 CPU detected"
-   ARM=true
-   ARMV6=true
-   export FORMAT_COMPILER_TARGET=armv
-   export FORMAT_COMPILER_TARGET_ALT=$FORMAT_COMPILER_TARGET
-   export RARCHCFLAGS="${RARCHCFLAGS} -marm"
-elif [ $ARCH = armv7l ]; then
-   echo "ARMv7 CPU detected"
-   ARM=true
-   ARMV7=true
-   export FORMAT_COMPILER_TARGET=armv
-   export FORMAT_COMPILER_TARGET_ALT=$FORMAT_COMPILER_TARGET
-   export RARCHCFLAGS="${RARCHCFLAGS} -marm"
-fi
 
 if [ "$HOST_CC" ]; then
    CC="${HOST_CC}-gcc"


### PR DESCRIPTION
I did my best to clean out all files that use these detection systems to put them into `libretro-config.sh`. I am not sure that this script is the best place for them, but it will at least clean up several of the other scripts.
