### PR TITLE
Initial clean-up (and softfloat target declaration fix) for ARM opts

### DIFF
--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -21,6 +21,7 @@ echo "Compiler: $COMPILER"
 [[ "$ARM_SOFTFLOAT" ]] && echo "=== ARM softfloat ABI enabled... ===" && export FORMAT_COMPILER_TARGET="${FORMAT_COMPILER_TARGET}-softfloat"
 
 export FORMAT_COMPILER_TARGET_ALT="$FORMAT_COMPILER_TARGET"
+echo "${FORMAT_COMPILER_TARGET}"
 
 check_opengl()
 {


### PR DESCRIPTION
This not only makes the declarations much cleaner, but the quoting standards used should ensure correct expansion (if this is well-received, I may go through the rest of the scripts and redo the variable-quoting so all of them use this unambiguous standard).

It also corrects the softfloat declaration which was missing the `$`.
