### PR TITLE
Fixed a bug in which check_opengl() would add extraneous -opengl flags

### DIFF
--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -47,7 +47,6 @@ build_libretro_ffmpeg()
    cd "$BASE_DIR"
    if [ -d "libretro-ffmpeg" ]; then
       echo "=== Checking OpenGL dependencies ==="
-      check_opengl
       echo "=== Building FFmpeg ==="
       cd libretro-ffmpeg
       ${MAKE} platform=$FORMAT_COMPILER_TARGET -j$JOBS clean || die "Failed to clean FFmpeg"
@@ -400,7 +399,6 @@ build_libretro_modelviewer()
    cd "$BASE_DIR"
    if [ -d "libretro-gl-modelviewer" ]; then
       echo "=== Building Modelviewer (GL) ==="
-      check_opengl
       cd libretro-gl-modelviewer
       ${MAKE} -f Makefile platform=${FORMAT_COMPILER_TARGET} $COMPILER -j$JOBS clean || die "Failed to clean Modelviewer"
       ${MAKE} -f Makefile platform=${FORMAT_COMPILER_TARGET} $COMPILER -j$JOBS || die "Failed to build Modelviewer"
@@ -415,7 +413,6 @@ build_libretro_scenewalker()
    cd "$BASE_DIR"
    if [ -d "libretro-gl-scenewalker" ]; then
       echo "=== Building SceneWalker (GL) ==="
-      check_opengl
       cd libretro-gl-scenewalker
       ${MAKE} -f Makefile platform=${FORMAT_COMPILER_TARGET} $COMPILER -j$JOBS clean || die "Failed to clean SceneWalker"
       ${MAKE} -f Makefile platform=${FORMAT_COMPILER_TARGET} $COMPILER -j$JOBS || die "Failed to build SceneWalker"
@@ -430,7 +427,6 @@ build_libretro_instancingviewer()
    cd "$BASE_DIR"
    if [ -d "libretro-gl-instancingviewer" ]; then
       echo "=== Building Instancing Viewer (GL) ==="
-      check_opengl
       cd libretro-gl-instancingviewer
       ${MAKE} -f Makefile platform=${FORMAT_COMPILER_TARGET} $COMPILER -j$JOBS clean || die "Failed to clean InstancingViewer"
       ${MAKE} -f Makefile platform=${FORMAT_COMPILER_TARGET} $COMPILER -j$JOBS || die "Failed to build InstancingViewer"
@@ -524,7 +520,6 @@ build_libretro_mupen64()
 {
    cd "$BASE_DIR"
    if [ -d "libretro-mupen64plus" ]; then
-      check_opengl
       cd libretro-mupen64plus
       mkdir -p obj
       if [ "$X86" ] && [ "$X86_64" ]; then

--- a/libretro-build.sh
+++ b/libretro-build.sh
@@ -84,13 +84,6 @@ mkdir -p "$RARCH_DIST_DIR"
 if [ $1 ]; then
    $1
 else
-   build_libretro_modelviewer
-   build_libretro_scenewalker
-   build_libretro_instancingviewer
-if [ -z $BUILD_EXPERIMENTAL ]; then
-   build_libretro_mupen64
-   build_libretro_ffmpeg
-fi
    build_libretro_bsnes
    build_libretro_mednafen
    build_libretro_mednafen_gba
@@ -119,5 +112,13 @@ fi
 if [ $FORMAT_COMPILER_TARGET != "win" ]; then
    build_libretro_desmume
    build_libretro_pcsx_rearmed
+fi
+   check_opengl
+   build_libretro_modelviewer
+   build_libretro_scenewalker
+   build_libretro_instancingviewer
+if [ -z $BUILD_EXPERIMENTAL ]; then
+   build_libretro_mupen64
+   build_libretro_ffmpeg
 fi
 fi


### PR DESCRIPTION
Also, moved the libretro gl ports to the end of the build script so that check_opengl() modifies FORMAT_COMPILER_TARGET after the other libretro ports are built to ensure that the platform flag passed to the non-gl libetro cores are correct. This fixes libretro-super on my desktop running Debian 7 x86_64, but it's not perfect. A more ideal solution would be to give the libretro gl cores their own FORMAT_COMPILER_TARGET environment variable altogether. If you are interested, I wouldn't mind creating a second patch that does just that.
