### PR TITLE
Convert all hashbangs to point to bash, not whatever happens to be the distro's default shell

### DIFF
--- a/libretro-build-android-mk.sh
+++ b/libretro-build-android-mk.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # BSDs don't have readlink -f
 read_link()

--- a/libretro-build-common-gx.sh
+++ b/libretro-build-common-gx.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 build_libretro_fba()
 {

--- a/libretro-build-common-xdk.sh
+++ b/libretro-build-common-xdk.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 die()
 {

--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 die() {
    echo $1

--- a/libretro-build-ios.sh
+++ b/libretro-build-ios.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/libretro-build-ngc.sh
+++ b/libretro-build-ngc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT=$(readlink -f $0)
 BASE_DIR=$(dirname $SCRIPT)

--- a/libretro-build-ps3.sh
+++ b/libretro-build-ps3.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT=$(readlink -f $0)
 BASE_DIR=$(dirname $SCRIPT)

--- a/libretro-build-qnx.sh
+++ b/libretro-build-qnx.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT=$(readlink -f $0)
 BASE_DIR=$(dirname $SCRIPT)

--- a/libretro-build-wii.sh
+++ b/libretro-build-wii.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT=$(readlink -f $0)
 BASE_DIR=$(dirname $SCRIPT)

--- a/libretro-build-xdk1.sh
+++ b/libretro-build-xdk1.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 BASE_DIR=$(pwd)
 RARCH_DIR=$BASE_DIR/dist

--- a/libretro-build-xdk360.sh
+++ b/libretro-build-xdk360.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 BASE_DIR=$(pwd)
 RARCH_DIR=$BASE_DIR/dist

--- a/libretro-build.sh
+++ b/libretro-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . ./libretro-config.sh
 

--- a/libretro-config.sh
+++ b/libretro-config.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Architecture Assignment
 [[ -z "$ARCH" ]] && ARCH="$(uname -m)"

--- a/libretro-fetch.sh
+++ b/libretro-fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . ./libretro-config.sh
 

--- a/libretro-install.sh
+++ b/libretro-install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . ./libretro-config.sh
 

--- a/retroarch-build.sh
+++ b/retroarch-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . ./libretro-config.sh
 


### PR DESCRIPTION
tl;dr: This makes your build system work easily on any Debian-based systems.

Debian-based systems' (Debian, Ubuntu, Mint, etc) /bin/sh leads to dash which does NOT support the Bashisms you are using in all your scripts (chiefly, double-square-bracket comparisons).

Any sane system will place bash in /bin/bash, or at least provide a symlink at /bin/bash to wherever bash actually is located. Therefore, this change should not harm any existing systems.
