### PR TITLE
Correct firmware names

### DIFF
--- a/dist/info/genesis_plus_gx_libretro.info
+++ b/dist/info/genesis_plus_gx_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Sega MS/GG/MD/CD (Genesis Plus GX)"
 authors = "Charles McDonald|Eke-Eke"
-supported_extensions = "md|smd|gen|sms|gg|sg|bin|cue|ios|flac"
+supported_extensions = "md|smd|gen|sms|gg|sg|bin|cue|ios"
 corename = "Genesis Plus GX"
 manufacturer = "Sega"
 systemname = "Sega 8/16bit (Various)"


### PR DESCRIPTION
I don't know why %sysdir% was used. Without this commit https://github.com/fr500/RetroArch/commit/08fadaaf8c00ce396cfd406028fe2f573ca29890 works
