### PR TITLE
Fix x86_64 detection in Git Bash on Windows, along with this error:

### DIFF
--- a/libretro-config.sh
+++ b/libretro-config.sh
@@ -17,7 +17,7 @@ case "$ARCH" in
       esac;;
 esac
 
-if [[ -n "$PROCESSOR_ARCHITEW6432" ]] && $PROCESSOR_ARCHITEW6432="AMD64"; then
+if [[ -n "$PROCESSOR_ARCHITEW6432" && $PROCESSOR_ARCHITEW6432 -eq "AMD64" ]]; then
    ARCH=x86_64
    X86=true && X86_64=true
 fi


### PR DESCRIPTION
```
libretro-config.sh: line 20: AMD64=AMD64: command not found
```
