### PR TITLE
(Android) drop mips and x86 builds

### DIFF
--- a/libretro-config.sh
+++ b/libretro-config.sh
@@ -104,7 +104,7 @@ fi
 #ANDROID DEFINES
 #================
 
-export TARGET_ABIS="armeabi-v7a mips x86"
+export TARGET_ABIS="armeabi-v7a"
 
 #uncomment to define NDK standalone toolchain for ARM
 #export NDK_ROOT_DIR_ARM = 


### PR DESCRIPTION
Does anyone use these?
