### PR TITLE
Remove extra newline from most files

### DIFF
--- a/iKarith-libretro-build-common.sh
+++ b/iKarith-libretro-build-common.sh
@@ -650,4 +650,3 @@ create_dist_dir() {
 }
 
 create_dist_dir
-

--- a/iKarith-libretro-build.sh
+++ b/iKarith-libretro-build.sh
@@ -150,4 +150,3 @@ else
 	build_libretro_emux
 	build_summary
 fi
-

--- a/iKarith-libretro-config.sh
+++ b/iKarith-libretro-config.sh
@@ -218,4 +218,3 @@ fi
 if [ -f "${WORKDIR}/libretro-config-user.sh" ]; then
 	. ${WORKDIR}/libretro-config-user.sh
 fi
-

--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -670,4 +670,3 @@ create_dist_dir() {
 }
 
 create_dist_dir
-

--- a/libretro-build.sh
+++ b/libretro-build.sh
@@ -167,4 +167,3 @@ else
 	build_libretro_testgl
 	build_summary
 fi
-

--- a/libretro-config.sh
+++ b/libretro-config.sh
@@ -218,4 +218,3 @@ fi
 if [ -f "${WORKDIR}/libretro-config-user.sh" ]; then
 	. ${WORKDIR}/libretro-config-user.sh
 fi
-

--- a/libretro-fetch.sh
+++ b/libretro-fetch.sh
@@ -368,4 +368,3 @@ else
 	fetch_libretro_emux
 	fetch_libretro_sdk
 fi
-

--- a/script-modules/cpu.sh
+++ b/script-modules/cpu.sh
@@ -53,4 +53,3 @@ cpu_isarmv7() {
 	esac
 	return 1
 }
-

--- a/script-modules/fetch-rules.sh
+++ b/script-modules/fetch-rules.sh
@@ -42,4 +42,3 @@ revision_git() {
 	cd "$WORKDIR/$1"
 	git log -n 1 --pretty=format:%H
 }
-


### PR DESCRIPTION
This removes the extra blank newline from most files. I was having trouble with my PKGBUILD running libretro-fetch.sh, where it would just fail and not say why. It turned out to be because of that extra line. No problem just running ./libretro-fetch.sh but running it from makepkg seemed to cause problems. I avoided radius files since I don't know if that could cause a problem with them (shouldn't, but you never know).