### PR TITLE
Major iOS build stuff

### DIFF
--- a/iKarith-libretro-build-common.sh
+++ b/iKarith-libretro-build-common.sh
@@ -650,4 +650,3 @@ create_dist_dir() {
 }
 
 create_dist_dir
-

--- a/iKarith-libretro-build.sh
+++ b/iKarith-libretro-build.sh
@@ -150,4 +150,3 @@ else
 	build_libretro_emux
 	build_summary
 fi
-

--- a/iKarith-libretro-config.sh
+++ b/iKarith-libretro-config.sh
@@ -218,4 +218,3 @@ fi
 if [ -f "${WORKDIR}/libretro-config-user.sh" ]; then
 	. ${WORKDIR}/libretro-config-user.sh
 fi
-

--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -143,7 +143,7 @@ build_libretro_generic_makefile() {
 	build_dir="${WORKDIR}/libretro-${1}"
 	if [ -d "$build_dir" ]; then
 		echo "=== Building ${1} ==="
-		build_libretro_generic $1 $2 $3 $4 $build_dir
+		build_libretro_generic $1 $2 $3 $4 "$build_dir"
 		copy_core_to_dist $1
 	else
 		echo "${1} not fetched, skipping ..."
@@ -154,7 +154,7 @@ build_retroarch_generic_makefile() {
 	build_dir="${WORKDIR}/${1}"
 	if [ -d "$build_dir" ]; then
 		echo "=== Building ${2} ==="
-		build_libretro_generic $1 $2 $3 $4 $build_dir
+		build_libretro_generic $1 $2 $3 $4 "$build_dir"
 		copy_core_to_dist $5
 	else
 		echo "${1} not fetched, skipping ..."

--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -37,12 +37,10 @@ RESET_FORMAT_COMPILER_TARGET=$FORMAT_COMPILER_TARGET
 RESET_FORMAT_COMPILER_TARGET_ALT=$FORMAT_COMPILER_TARGET_ALT
 
 build_summary_log() {
-	if [ -n "${BUILD_SUMMARY}" ]; then
-		if [ "${1}" -eq "0" ]; then
-			echo ${2} >> ${BUILD_SUCCESS}
-		else
-			echo ${2} >> ${BUILD_FAIL}
-		fi
+	if [ "$1" -eq "0" ]; then
+		printf -v build_success "%s%s\n" "$build_success" "$2"
+	else
+		printf -v build_fail "%s%s\n" "$build_fail" "$2"
 	fi
 }
 
@@ -641,23 +639,24 @@ build_libretro_mupen64() {
 }
 
 build_summary() {
-	if [ -z "${NOBUILD_SUMMARY}" ]; then
-		echo "=== Core Build Summary ===" > ${BUILD_SUMMARY}
-		if [ -r "${BUILD_SUCCESS}" ]; then
-			echo "`wc -l < ${BUILD_SUCCESS}` core(s) successfully built:" >> ${BUILD_SUMMARY}
-			${BUILD_SUMMARY_FMT} ${BUILD_SUCCESS} >> ${BUILD_SUMMARY}
+	if [ -z "$NOBUILD_SUMMARY" ]; then
+		printf -v summary "=== Core Build Summary ===\n\n"
+		if [ -n "$build_success" ]; then
+			printf -v summary "%s%s\n" "$summary" "$(echo $build_success | wc -w) core(s) successfully built:"
+			printf -v summary "%s%s\n\n" "$summary" "$(echo $build_success)"
 		else
-			echo "		0 cores successfully built. :(" >> ${BUILD_SUMMARY}
-			echo "`wc -l < ${BUILD_FAIL}` core(s) failed to build:"
+			printf -v summary "%s%s\n\n" "$summary" "       0 cores successfully built. :("
 		fi
-		if [ -r "${BUILD_FAIL}" ]; then
-			echo "`wc -l < ${BUILD_FAIL}` core(s) failed to build:" >> ${BUILD_SUMMARY}
-			${BUILD_SUMMARY_FMT} ${BUILD_FAIL} >> ${BUILD_SUMMARY}
+		if [ -n "$build_fail" ]; then
+			printf -v summary "%s%s\n" "$summary" "$(echo $build_fail | wc -w) core(s) failed to build:"
+			printf -v summary "%s%s\n\n" "$summary" "$(echo $build_fail)"
 		else
-			echo "      0 cores failed to build! :D" >> ${BUILD_SUMMARY}
+			printf -v summary "%s%s\n\n" "$summary" "       0 cores failed to build! :D"
 		fi
-		rm -f $BUILD_SUCCESS $BUILD_FAIL
-		cat ${BUILD_SUMMARY}
+		if [ -n "$BUILD_SUMMARY" ]; then
+			echo "$summary" > "$BUILD_SUMMARY"
+		fi
+		echo "$summary"
 	fi
 }
 

--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -669,4 +669,3 @@ create_dist_dir() {
 }
 
 create_dist_dir
-

--- a/libretro-build-ios.sh
+++ b/libretro-build-ios.sh
@@ -151,7 +151,7 @@ else
 	build_libretro_tyrquake
 	build_libretro_mame078
 	build_libretro_mame
-	#build_libretro_dosbox
+	build_libretro_dosbox
 	build_libretro_scummvm
 	build_libretro_picodrive
 	build_libretro_handy

--- a/libretro-build-ios.sh
+++ b/libretro-build-ios.sh
@@ -106,7 +106,7 @@ echo "CXX11 = $CXX11"
 echo "STRIP = $STRIP"
 
 
-. $BASE_DIR/libretro-build-common.sh
+. "$BASE_DIR/libretro-build-common.sh"
 
 mkdir -p "$RARCH_DIST_DIR"
 
@@ -185,6 +185,6 @@ else
 	if [ $FORMAT_COMPILER_TARGET != "ios" ]; then
 		build_libretro_testgl
 	fi
-	build_summary
 fi
+build_summary
 

--- a/libretro-build-ios.sh
+++ b/libretro-build-ios.sh
@@ -1,39 +1,128 @@
 #! /usr/bin/env bash
 # vim: set ts=3 sw=3 noet ft=sh : bash
 
-set -e
-
-WORKDIR="${PWD}"
-BASE_DIR="$PWD"
-RARCH_DIR=$BASE_DIR/dist
-RARCH_DIST_DIR=$RARCH_DIR/ios
-FORMAT=_ios
 FORMAT_COMPILER_TARGET=ios
-FORMAT_COMPILER_TARGET_ALT=ios
-FORMAT_EXT=dylib
-JOBS=7
-MAKE=make
-CXX11="clang++ -std=c++11 -stdlib=libc++ -miphoneos-version-min=5.0"
-IOS=1
 
-IOSSDK=$(xcrun -sdk iphoneos -show-sdk-path)
-IOSVER_MAJOR=$(xcrun -sdk iphoneos -show-sdk-platform-version | cut -c '1')
-IOSVER_MINOR=$(xcrun -sdk iphoneos -show-sdk-platform-version | cut -c '3')
-IOSVER=${IOSVER_MAJOR}${IOSVER_MINOR}
-echo "iOS path: ${IOSSDK}"
-echo "iOS version: ${IOSVER}"
-export IOSSDK
+SCRIPT="${0#./}"
+BASE_DIR="${SCRIPT%/*}"
+WORKDIR=$PWD
 
-. ./libretro-build-common.sh
+if [ "$BASE_DIR" = "$SCRIPT" ]; then
+	BASE_DIR="$WORKDIR"
+else
+	if [[ "$0" != /* ]]; then
+		# Make the path absolute
+		BASE_DIR="$WORKDIR/$BASE_DIR"
+	fi
+fi
 
-if [ $1 ]; then
-	$1
+if [ "$FORMAT_COMPILER_TARGET" != "ios" ]; then
+	. ${BASE_DIR}/libretro-config.sh
+else
+	# FIXME: libretro-config.sh should eventually do this stuff for iOS
+	DIST_DIR="ios"
+	FORMAT_EXT=dylib
+	IOS=1
+	FORMAT=_ios
+	FORMAT_COMPILER_TARGET=ios
+	export IOSSDK=$(xcrun -sdk iphoneos -show-sdk-path)
+	IOSVER_MAJOR=$(xcrun -sdk iphoneos -show-sdk-platform-version | cut -c '1')
+	IOSVER_MINOR=$(xcrun -sdk iphoneos -show-sdk-platform-version | cut -c '3')
+	IOSVER=${IOSVER_MAJOR}${IOSVER_MINOR}
+fi
+
+if [ -z "$RARCH_DIST_DIR" ]; then
+	RARCH_DIR="$WORKDIR/dist"
+	RARCH_DIST_DIR="$RARCH_DIR/$DIST_DIR"
+fi
+
+if [ -z "$JOBS" ]; then
+	JOBS=7
+fi
+
+if [ "$HOST_CC" ]; then
+	CC="${HOST_CC}-gcc"
+	CXX="${HOST_CC}-g++"
+	CXX11="${HOST_CC}-g++"
+	STRIP="${HOST_CC}-strip"
+fi
+
+if [ -z "$MAKE" ]; then
+	if uname -s | grep -i MINGW32 > /dev/null 2>&1; then
+		MAKE=mingw32-make
+	else
+		if type gmake > /dev/null 2>&1; then
+			MAKE=gmake
+		else
+			MAKE=make
+		fi
+	fi
+fi
+
+if [ -z "$CC" ]; then
+	if [ "$FORMAT_COMPILER_TARGET" = "ios" ]; then
+		CC="clang -arch armv7 -miphoneos-version-min=5.0 -isysroot $IOSSDK"
+	elif [ $FORMAT_COMPILER_TARGET = "osx" ]; then
+		CC=cc
+	elif uname -s | grep -i MINGW32 > /dev/null 2>&1; then
+		CC=mingw32-gcc
+	else
+		CC=gcc
+	fi
+fi
+
+if [ -z "$CXX" ]; then
+	if [ "$FORMAT_COMPILER_TARGET" = "ios" ]; then
+		CXX="clang++ -arch armv7 -miphoneos-version-min=5.0 -isysroot $IOSSDK"
+		CXX11="clang++ -std=c++11 -stdlib=libc++ -arch armv7 -miphoneos-version-min=5.0 -isysroot $IOSSDK"
+	elif [ $FORMAT_COMPILER_TARGET = "osx" ]; then
+		CXX=c++
+		CXX11="clang++ -std=c++11 -stdlib=libc++"
+		# FIXME: Do this right later.
+		if [ "$ARCH" = "i386" ]; then
+			CC="cc -arch i386"
+			CXX="c++ -arch i386"
+			CXX11="clang++ -arch i386 -std=c++11 -stdlib=libc++"
+		fi
+	elif uname -s | grep -i MINGW32 > /dev/null 2>&1; then
+		CXX=mingw32-g++
+		CXX11=mingw32-g++
+	else
+		CXX=g++
+		CXX11=g++
+	fi
+fi
+
+FORMAT_COMPILER_TARGET_ALT=$FORMAT_COMPILER_TARGET
+
+
+if [ "$FORMAT_COMPILER_TARGET" = "ios" ]; then
+	echo "iOS path: ${IOSSDK}"
+	echo "iOS version: ${IOSVER}"
+fi
+echo "CC = $CC"
+echo "CXX = $CXX"
+echo "CXX11 = $CXX11"
+echo "STRIP = $STRIP"
+
+
+. $BASE_DIR/libretro-build-common.sh
+
+mkdir -p "$RARCH_DIST_DIR"
+
+if [ -n "$1" ]; then
+	while [ -n "$1" ]; do
+		"$1"
+		shift
+	done
 else
 	build_libretro_2048
+	build_libretro_4do
 	build_libretro_bluemsx
 	build_libretro_fmsx
 	build_libretro_bsnes_cplusplus98
 	build_libretro_bsnes
+	build_libretro_bsnes_mercury
 	build_libretro_beetle_lynx
 	build_libretro_beetle_gba
 	build_libretro_beetle_ngp
@@ -43,7 +132,7 @@ else
 	build_libretro_beetle_vb
 	build_libretro_beetle_wswan
 	build_libretro_mednafen_psx
-	#build_libretro_beetle_bsnes
+	build_libretro_beetle_snes
 	build_libretro_catsfc
 	build_libretro_snes9x
 	build_libretro_snes9x_next
@@ -67,19 +156,35 @@ else
 	build_libretro_picodrive
 	build_libretro_handy
 	build_libretro_desmume
-	build_libretro_pcsx_rearmed
-	build_libretro_pcsx_rearmed_interpreter
-	build_libretro_mupen64
+	if [ $FORMAT_COMPILER_TARGET != "win" ]; then
+		build_libretro_pcsx_rearmed
+	fi
+	if [ $FORMAT_COMPILER_TARGET = "ios" ]; then
+		# For self-signed iOS (without jailbreak)
+		build_libretro_pcsx_rearmed_interpreter
+	fi
 	build_libretro_yabause
-	#build_libretro_ffmpeg
-	build_libretro_3dengine
 	build_libretro_vecx
 	build_libretro_tgbdual
 	build_libretro_prosystem
 	build_libretro_dinothawr
 	build_libretro_virtualjaguar
+	build_libretro_mupen64
+	build_libretro_3dengine
+	if [ $FORMAT_COMPILER_TARGET != "ios" ]; then
+		# These don't currently build on iOS
+		build_libretro_bnes
+		build_libretro_ffmpeg
+		build_libretro_ppsspp
+	fi
 	build_libretro_o2em
-	build_libretro_4do
+	build_libretro_hatari
 	build_libretro_gpsp
 	build_libretro_emux
+	build_libretro_test
+	if [ $FORMAT_COMPILER_TARGET != "ios" ]; then
+		build_libretro_testgl
+	fi
+	build_summary
 fi
+

--- a/libretro-build.sh
+++ b/libretro-build.sh
@@ -104,7 +104,7 @@ echo "CXX11 = $CXX11"
 echo "STRIP = $STRIP"
 
 
-. $BASE_DIR/libretro-build-common.sh
+. "$BASE_DIR/libretro-build-common.sh"
 
 mkdir -p "$RARCH_DIST_DIR"
 
@@ -183,6 +183,6 @@ else
 	if [ $FORMAT_COMPILER_TARGET != "ios" ]; then
 		build_libretro_testgl
 	fi
-	build_summary
 fi
+build_summary
 

--- a/libretro-build.sh
+++ b/libretro-build.sh
@@ -14,22 +14,29 @@ else
 	fi
 fi
 
-. ${BASE_DIR}/libretro-config.sh
+if [ "$FORMAT_COMPILER_TARGET" != "ios" ]; then
+	. ${BASE_DIR}/libretro-config.sh
+else
+	# FIXME: libretro-config.sh should eventually do this stuff for iOS
+	DIST_DIR="ios"
+	FORMAT_EXT=dylib
+	IOS=1
+	FORMAT=_ios
+	FORMAT_COMPILER_TARGET=ios
+	export IOSSDK=$(xcrun -sdk iphoneos -show-sdk-path)
+	IOSVER_MAJOR=$(xcrun -sdk iphoneos -show-sdk-platform-version | cut -c '1')
+	IOSVER_MINOR=$(xcrun -sdk iphoneos -show-sdk-platform-version | cut -c '3')
+	IOSVER=${IOSVER_MAJOR}${IOSVER_MINOR}
+fi
 
 if [ -z "$RARCH_DIST_DIR" ]; then
-	RARCH_DIR="${WORKDIR}/dist"
+	RARCH_DIR="$WORKDIR/dist"
 	RARCH_DIST_DIR="$RARCH_DIR/$DIST_DIR"
 fi
 
 if [ -z "$JOBS" ]; then
 	JOBS=7
 fi
-
-die()
-{
-	echo $1
-	#exit 1
-}
 
 if [ "$HOST_CC" ]; then
 	CC="${HOST_CC}-gcc"
@@ -50,9 +57,10 @@ if [ -z "$MAKE" ]; then
 	fi
 fi
 
-
 if [ -z "$CC" ]; then
-	if [ $FORMAT_COMPILER_TARGET = "osx" ]; then
+	if [ "$FORMAT_COMPILER_TARGET" = "ios" ]; then
+		CC="clang -arch armv7 -miphoneos-version-min=5.0 -isysroot $IOSSDK"
+	elif [ $FORMAT_COMPILER_TARGET = "osx" ]; then
 		CC=cc
 	elif uname -s | grep -i MINGW32 > /dev/null 2>&1; then
 		CC=mingw32-gcc
@@ -62,7 +70,10 @@ if [ -z "$CC" ]; then
 fi
 
 if [ -z "$CXX" ]; then
-	if [ $FORMAT_COMPILER_TARGET = "osx" ]; then
+	if [ "$FORMAT_COMPILER_TARGET" = "ios" ]; then
+		CXX="clang++ -arch armv7 -miphoneos-version-min=5.0 -isysroot $IOSSDK"
+		CXX11="clang++ -std=c++11 -stdlib=libc++ -arch armv7 -miphoneos-version-min=5.0 -isysroot $IOSSDK"
+	elif [ $FORMAT_COMPILER_TARGET = "osx" ]; then
 		CXX=c++
 		CXX11="clang++ -std=c++11 -stdlib=libc++"
 		# FIXME: Do this right later.
@@ -81,19 +92,25 @@ if [ -z "$CXX" ]; then
 fi
 
 FORMAT_COMPILER_TARGET_ALT=$FORMAT_COMPILER_TARGET
+
+
+if [ "$FORMAT_COMPILER_TARGET" = "ios" ]; then
+	echo "iOS path: ${IOSSDK}"
+	echo "iOS version: ${IOSVER}"
+fi
 echo "CC = $CC"
 echo "CXX = $CXX"
 echo "CXX11 = $CXX11"
 echo "STRIP = $STRIP"
 
-. ${BASE_DIR}/libretro-build-common.sh
+
+. $BASE_DIR/libretro-build-common.sh
 
 mkdir -p "$RARCH_DIST_DIR"
 
-if [ -n "${1}" ]; then
-	NOBUILD_SUMMARY=1
-	while [ -n "${1}" ]; do
-		"${1}"
+if [ -n "$1" ]; then
+	while [ -n "$1" ]; do
+		"$1"
 		shift
 	done
 else
@@ -121,7 +138,6 @@ else
 	build_libretro_fb_alpha
 	build_libretro_vbam
 	build_libretro_vba_next
-	build_libretro_bnes
 	build_libretro_fceumm
 	build_libretro_gambatte
 	build_libretro_meteor
@@ -141,6 +157,10 @@ else
 	if [ $FORMAT_COMPILER_TARGET != "win" ]; then
 		build_libretro_pcsx_rearmed
 	fi
+	if [ $FORMAT_COMPILER_TARGET = "ios" ]; then
+		# For self-signed iOS (without jailbreak)
+		build_libretro_pcsx_rearmed_interpreter
+	fi
 	build_libretro_yabause
 	build_libretro_vecx
 	build_libretro_tgbdual
@@ -148,15 +168,21 @@ else
 	build_libretro_dinothawr
 	build_libretro_virtualjaguar
 	build_libretro_mupen64
-	build_libretro_ffmpeg
 	build_libretro_3dengine
-	build_libretro_ppsspp
+	if [ $FORMAT_COMPILER_TARGET != "ios" ]; then
+		# These don't currently build on iOS
+		build_libretro_bnes
+		build_libretro_ffmpeg
+		build_libretro_ppsspp
+	fi
 	build_libretro_o2em
 	build_libretro_hatari
 	build_libretro_gpsp
 	build_libretro_emux
 	build_libretro_test
-	build_libretro_testgl
+	if [ $FORMAT_COMPILER_TARGET != "ios" ]; then
+		build_libretro_testgl
+	fi
 	build_summary
 fi
 

--- a/libretro-build.sh
+++ b/libretro-build.sh
@@ -1,26 +1,18 @@
 #! /usr/bin/env bash
 # vim: set ts=3 sw=3 noet ft=sh : bash
 
-# BSDs don't have readlink -f
-read_link()
-{
-	TARGET_FILE="${1}"
-	cd "`dirname "${TARGET_FILE}"`"
-	TARGET_FILE="`basename "${TARGET_FILE}"`"
+SCRIPT="${0#./}"
+BASE_DIR="${SCRIPT%/*}"
+WORKDIR=$PWD
 
-	while [ -L "${TARGET_FILE}" ]; do
-		TARGET_FILE="`readlink "${TARGET_FILE}"`"
-		cd "`dirname "${TARGET_FILE}"`"
-		TARGET_FILE="`basename "${TARGET_FILE}"`"
-	done
-
-	PHYS_DIR="`pwd -P`"
-	RESULT="${PHYS_DIR}/${TARGET_FILE}"
-	echo ${RESULT}
-}
-SCRIPT="`read_link "$0"`"
-BASE_DIR="`dirname "${SCRIPT}"`"
-WORKDIR="`pwd`"
+if [ "$BASE_DIR" = "$SCRIPT" ]; then
+	BASE_DIR="$WORKDIR"
+else
+	if [[ "$0" != /* ]]; then
+		# Make the path absolute
+		BASE_DIR="$WORKDIR/$BASE_DIR"
+	fi
+fi
 
 . ${BASE_DIR}/libretro-config.sh
 

--- a/libretro-config.sh
+++ b/libretro-config.sh
@@ -206,7 +206,7 @@ BUILD_SUMMARY="$WORKDIR/build-summary.log"
 #local libretro-config-user.sh file rather than here.
 #The following below is just a sample.
 
-if [ -f "${WORKDIR}/libretro-config-user.sh" ]; then
-	. ${WORKDIR}/libretro-config-user.sh
+if [ -f "$WORKDIR/libretro-config-user.sh" ]; then
+	. "$WORKDIR/libretro-config-user.sh"
 fi
 

--- a/libretro-config.sh
+++ b/libretro-config.sh
@@ -209,4 +209,3 @@ BUILD_SUMMARY="$WORKDIR/build-summary.log"
 if [ -f "$WORKDIR/libretro-config-user.sh" ]; then
 	. "$WORKDIR/libretro-config-user.sh"
 fi
-

--- a/libretro-config.sh
+++ b/libretro-config.sh
@@ -194,19 +194,10 @@ fi
 #CORE BUILD SUMMARY
 #==================
 
-# Remove this to enable the core build summary
-export BUILD_SUMMARY=1
+# Uncomment this to disable the core build summary
+# NOBUILD_SUMMARY=1
 
-BUILD_SUMMARY=${WORKDIR}/build-summary.log
-BUILD_SUCCESS=${WORKDIR}/build-success.log
-BUILD_FAIL=${WORKDIR}/build-fail.log
-if [ -z "${BUILD_SUMMARY_FMT}" ]; then
-	if command -v column >/dev/null; then
-		BUILD_SUMMARY_FMT=column
-	else
-		BUILD_SUMMARY_FMT=cat
-	fi
-fi
+BUILD_SUMMARY="$WORKDIR/build-summary.log"
 
 
 #USER DEFINES

--- a/libretro-fetch.sh
+++ b/libretro-fetch.sh
@@ -368,4 +368,3 @@ else
 	fetch_libretro_emux
 	fetch_libretro_sdk
 fi
-

--- a/script-modules/cpu.sh
+++ b/script-modules/cpu.sh
@@ -53,4 +53,3 @@ cpu_isarmv7() {
 	esac
 	return 1
 }
-

--- a/script-modules/fetch-rules.sh
+++ b/script-modules/fetch-rules.sh
@@ -24,8 +24,10 @@ fetch_git() {
 			git submodule foreach git pull origin master
 		fi
 	else
-		echo "git clone \"$1\" \"$WORKDIR/$2\""
-		git clone "$1" "$WORKDIR/$2"
+		clone_type=
+		[ -n "$SHALLOW_CLONE" ] && depth="--depth 1"
+		echo "git clone $depth \"$1\" \"$WORKDIR/$2\""
+		git clone $depth "$1" "$WORKDIR/$2"
 		if [ -n "$4" ]; then
 			echo "cd \"$fetch_dir\""
 			cd "$fetch_dir"

--- a/script-modules/fetch-rules.sh
+++ b/script-modules/fetch-rules.sh
@@ -42,4 +42,3 @@ revision_git() {
 	cd "$WORKDIR/$1"
 	git log -n 1 --pretty=format:%H
 }
-


### PR DESCRIPTION
libretro-build-ios.sh is now basically unnecessary, though it's still around.  Its only difference now is that it sets FORMAT_COMPILER_TARGET=ios at the start of the script.  Set that in your environment before running libretro-build.sh and it will do the exact same thing.

This uglifies libretro-build.sh quite a bit because iOS doesn't use libretro-config.sh at all and needs to set paths to the iOS SDKs and whatnot, but that's something we can address after 1.1 is released.