### PR TITLE
ules based fetch = DONE. Twinaphex read devkit-rules.sh

### DIFF
--- a/core-rules.sh
+++ b/core-rules.sh
@@ -1,248 +1,251 @@
 # vim: set ts=3 sw=3 noet ft=sh : bash
 
-libretro_bsnes_fetch_url="https://github.com/libretro/bsnes-libretro.git"
+libretro_retroarch_name="RetroArch"
+libretro_retroarch_dir="retroarch"
+libretro_retroarch_git_url="https://github.com/libretro/RetroArch.git"
+libretro_retroarch_post_fetch_cmd="./fetch-submodules.sh"
+
+libretro_bsnes_git_url="https://github.com/libretro/bsnes-libretro.git"
 libretro_bsnes_name="bsnes/higan"
 
-libretro_snes9x_fetch_url="https://github.com/libretro/snes9x.git"
+libretro_snes9x_git_url="https://github.com/libretro/snes9x.git"
 libretro_snes9x_name="SNES9x"
 libretro_snes9x_build_subdir="libretro"
 
-libretro_snes9x_next_fetch_url="https://github.com/libretro/snes9x-next.git"
+libretro_snes9x_next_git_url="https://github.com/libretro/snes9x-next.git"
 libretro_snes9x_next_name="SNES9x Next"
 libretro_snes9x_next_build_makefile="Makefile.libretro"
 libretro_snes9x_next_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
-libretro_genesis_plus_gx_fetch_url="https://github.com/libretro/Genesis-Plus-GX.git"
+libretro_genesis_plus_gx_git_url="https://github.com/libretro/Genesis-Plus-GX.git"
 libretro_genesis_plus_gx_name="Genesis Plus GX"
 libretro_genesis_plus_gx_build_makefile="Makefile.libretro"
 
-libretro_fb_alpha_fetch_url="https://github.com/libretro/fba-libretro.git"
+libretro_fb_alpha_git_url="https://github.com/libretro/fba-libretro.git"
 libretro_fb_alpha_name="Final Burn Alpha"
 libretro_fb_alpha_build_subdir="svn-current/trunk"
 libretro_fb_alpha_build_makefile="makefile.libretro"
 
-libretro_vba_next_fetch_url="https://github.com/libretro/vba-next.git"
+libretro_vba_next_git_url="https://github.com/libretro/vba-next.git"
 libretro_vba_next_name="VBA Next"
 libretro_vba_next_build_makefile="Makefile.libretro"
 libretro_vba_next_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
-libretro_vbam_fetch_url="https://github.com/libretro/vbam-libretro.git"
+libretro_vbam_git_url="https://github.com/libretro/vbam-libretro.git"
 libretro_vbam_name="VBA-M"
 libretro_vbam_build_subdir="src/libretro"
 libretro_vbam_build_makefile="Makefile"
 libretro_vbam_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
-libretro_handy_fetch_url="https://github.com/libretro/libretro-handy.git"
+libretro_handy_git_url="https://github.com/libretro/libretro-handy.git"
 libretro_handy_name="Handy"
 # IMPLICIT
 
-libretro_bnes_fetch_url="https://github.com/libretro/bnes-libretro.git"
+libretro_bnes_git_url="https://github.com/libretro/bnes-libretro.git"
 libretro_bnes_name="bnes/higan"
 
-libretro_fceumm_fetch_url="https://github.com/libretro/libretro-fceumm.git"
+libretro_fceumm_git_url="https://github.com/libretro/libretro-fceumm.git"
 libretro_fceumm_name="FCEUmm"
 libretro_fceumm_build_makefile="Makefile.libretro"
 
-libretro_gambatte_fetch_url="https://github.com/libretro/gambatte-libretro.git"
+libretro_gambatte_git_url="https://github.com/libretro/gambatte-libretro.git"
 libretro_gambatte_name="Gambatte"
 libretro_gambatte_build_subdir="libgambatte"
 libretro_gambatte_build_makefile="Makefile.libretro"
 libretro_gambatte_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
-libretro_meteor_fetch_url="https://github.com/libretro/meteor-libretro.git"
+libretro_meteor_git_url="https://github.com/libretro/meteor-libretro.git"
 libretro_meteor_name="Meteor"
 libretro_meteor_build_subdir="libretro"
 
-libretro_nxengine_fetch_url="https://github.com/libretro/nxengine-libretro.git"
+libretro_nxengine_git_url="https://github.com/libretro/nxengine-libretro.git"
 libretro_nxengine_name="NXEngine"
 # IMPLICIT
 
-libretro_prboom_fetch_url="https://github.com/libretro/libretro-prboom.git"
+libretro_prboom_git_url="https://github.com/libretro/libretro-prboom.git"
 libretro_prboom_name="PrBoom"
 libretro_prboom_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
-libretro_stella_fetch_url="https://github.com/libretro/stella-libretro.git"
+libretro_stella_git_url="https://github.com/libretro/stella-libretro.git"
 libretro_stella_name="Stella"
 # IMPLICIT
 
-libretro_desmume_fetch_url="https://github.com/libretro/desmume.git"
+libretro_desmume_git_url="https://github.com/libretro/desmume.git"
 libretro_desmume_name="DeSmuME"
 libretro_desmume_build_subdir="desmume"
 libretro_desmume_build_makefile="Makefile.libretro"
 
-libretro_quicknes_fetch_url="https://github.com/libretro/QuickNES_Core.git"
+libretro_quicknes_git_url="https://github.com/libretro/QuickNES_Core.git"
 libretro_quicknes_name="QuickNES"
 libretro_quicknes_build_subdir="libretro"
 
-libretro_nestopia_fetch_url="https://github.com/libretro/nestopia.git"
+libretro_nestopia_git_url="https://github.com/libretro/nestopia.git"
 libretro_nestopia_name="Nestopia"
 libretro_nestopia_build_subdir="libretro"
 
-libretro_tyrquake_fetch_url="https://github.com/libretro/tyrquake.git"
+libretro_tyrquake_git_url="https://github.com/libretro/tyrquake.git"
 libretro_tyrquake_name="TyrQuake"
 libretro_tyrquake_build_makefile="Makefile.libretro"
 
-libretro_pcsx_rearmed_fetch_url="https://github.com/libretro/pcsx_rearmed.git"
+libretro_pcsx_rearmed_git_url="https://github.com/libretro/pcsx_rearmed.git"
 libretro_pcsx_rearmed_name="PCSX ReARMed"
 libretro_pcsx_rearmed_build_makefile="Makefile.libretro"
 
-libretro_mednafen_gba_fetch_url="https://github.com/libretro/beetle-gba-libretro.git"
+libretro_mednafen_gba_git_url="https://github.com/libretro/beetle-gba-libretro.git"
 libretro_mednafen_gba_name="Mednafen/Beetle GBA"
 # IMPLICIT
 
-libretro_mednafen_lynx_fetch_url="https://github.com/libretro/beetle-lynx-libretro.git"
+libretro_mednafen_lynx_git_url="https://github.com/libretro/beetle-lynx-libretro.git"
 libretro_mednafen_lynx_name="Mednafen/Beetle Lynx"
 # IMPLICIT
 
-libretro_mednafen_ngp_fetch_url="https://github.com/libretro/beetle-ngp-libretro.git"
+libretro_mednafen_ngp_git_url="https://github.com/libretro/beetle-ngp-libretro.git"
 libretro_mednafen_ngp_name="Mednafen/Beetle NeoPop"
 # IMPLICIT
 
-libretro_mednafen_pce_fast_fetch_url="https://github.com/libretro/beetle-pce-fast-libretro.git"
+libretro_mednafen_pce_fast_git_url="https://github.com/libretro/beetle-pce-fast-libretro.git"
 libretro_mednafen_pce_fast_name="Mednafen/Beetle PCE FAST"
 # IMPLICIT
 
-libretro_mednafen_supergrafx_fetch_url="https://github.com/libretro/beetle-supergrafx-libretro.git"
+libretro_mednafen_supergrafx_git_url="https://github.com/libretro/beetle-supergrafx-libretro.git"
 libretro_mednafen_supergrafx_name="Mednafen/Beetle SuperGrafx"
 # IMPLICIT
 
-libretro_mednafen_psx_fetch_url="https://github.com/libretro/mednafen-psx-libretro.git"
+libretro_mednafen_psx_git_url="https://github.com/libretro/mednafen-psx-libretro.git"
 libretro_mednafen_psx_name="Mednafen PSX"
 # IMPLICIT
 
-libretro_mednafen_pcfx_fetch_url="https://github.com/libretro/beetle-pcfx-libretro.git"
+libretro_mednafen_pcfx_git_url="https://github.com/libretro/beetle-pcfx-libretro.git"
 libretro_mednafen_pcfx_name="Mednafen/Beetle PC-FX"
 # IMPLICIT
 
-libretro_mednafen_snes_fetch_url="https://github.com/libretro/beetle-bsnes-libretro.git"
+libretro_mednafen_snes_git_url="https://github.com/libretro/beetle-bsnes-libretro.git"
 libretro_mednafen_snes_name="Mednafen/Beetle bsnes"
 # IMPLICIT
 
-libretro_mednafen_vb_fetch_url="https://github.com/libretro/beetle-vb-libretro.git"
+libretro_mednafen_vb_git_url="https://github.com/libretro/beetle-vb-libretro.git"
 libretro_mednafen_vb_name="Mednafen/Beetle VB"
 # IMPLICIT
 
-libretro_mednafen_wswan_fetch_url="https://github.com/libretro/beetle-wswan-libretro.git"
+libretro_mednafen_wswan_git_url="https://github.com/libretro/beetle-wswan-libretro.git"
 libretro_mednafen_wswan_name="Mednafen/Beetle WonderSwan"
 # IMPLICIT
 
-libretro_scummvm_fetch_url="https://github.com/libretro/scummvm.git"
+libretro_scummvm_git_url="https://github.com/libretro/scummvm.git"
 libretro_scummvm_name="ScummVM"
 libretro_scummvm_build_subdir="backends/platform/libretro/build"
 
-libretro_yabause_fetch_url="https://github.com/libretro/yabause.git"
+libretro_yabause_git_url="https://github.com/libretro/yabause.git"
 libretro_yabause_name="Yabause"
 libretro_yabause_build_subdir="libretro"
 
-libretro_dosbox_fetch_url="https://github.com/libretro/dosbox-libretro.git"
+libretro_dosbox_git_url="https://github.com/libretro/dosbox-libretro.git"
 libretro_dosbox_name="DOSBox"
 libretro_dosbox_makefile="Makefile.libretro"
 
-libretro_virtualjaguar_fetch_url="https://github.com/libretro/virtualjaguar-libretro.git"
+libretro_virtualjaguar_git_url="https://github.com/libretro/virtualjaguar-libretro.git"
 libretro_virtualjaguar_name="Virtual Jaguar"
 # IMPLICIT
 
-libretro_mame078_fetch_url="https://github.com/libretro/mame2003-libretro.git"
+libretro_mame078_git_url="https://github.com/libretro/mame2003-libretro.git"
 libretro_mame078_name="MAME 2003 (0.78)"
 # IMPLICIT
 
-libretro_mame139_fetch_url="https://github.com/libretro/mame2010-libretro.git"
+libretro_mame139_git_url="https://github.com/libretro/mame2010-libretro.git"
 libretro_mame139_name="MAME 2010 (0.139)"
 
-libretro_mame_fetch_url="https://github.com/libretro/mame.git"
+libretro_mame_git_url="https://github.com/libretro/mame.git"
 libretro_mame_name="MAME (git)"
 
-libretro_ffmpeg_fetch_url="https://github.com/libretro/FFmpeg.git"
+libretro_ffmpeg_git_url="https://github.com/libretro/FFmpeg.git"
 libretro_ffmpeg_name="FFmpeg"
 
-libretro_bsnes_cplusplus98_fetch_url="https://github.com/libretro/bsnes-libretro-cplusplus98.git"
+libretro_bsnes_cplusplus98_git_url="https://github.com/libretro/bsnes-libretro-cplusplus98.git"
 libretro_bsnes_cplusplus98_name="bsnes C++98 (v0.85)"
 
-libretro_bsnes_mercury_fetch_url="https://github.com/libretro/bsnes-mercury.git"
+libretro_bsnes_mercury_git_url="https://github.com/libretro/bsnes-mercury.git"
 libretro_bsnes_mercury_name="bsnes-mercury"
 
-libretro_picodrive_fetch_url="https://github.com/libretro/picodrive.git"
+libretro_picodrive_git_url="https://github.com/libretro/picodrive.git"
 libretro_picodrive_name="Picodrive"
-libretro_picodrive_git_submodules="1"
-libretro_picodrive_git_submodules_update="1"
+libretro_picodrive_git_submodules="yes"
 libretro_picodrive_build_makefile="Makefile.libretro"
 
-libretro_tgbdual_fetch_url="https://github.com/libretro/tgbdual-libretro.git"
+libretro_tgbdual_git_url="https://github.com/libretro/tgbdual-libretro.git"
 libretro_tgbdual_name="TGB Dual"
 # IMPLICIT
 
-libretro_mupen64plus_fetch_url="https://github.com/libretro/mupen64plus-libretro.git"
+libretro_mupen64plus_git_url="https://github.com/libretro/mupen64plus-libretro.git"
 libretro_mupen64plus_name="Mupen64Plus"
 
-libretro_dinothawr_fetch_url="https://github.com/libretro/Dinothawr.git"
+libretro_dinothawr_git_url="https://github.com/libretro/Dinothawr.git"
 libretro_dinothawr_name="Dinothawr"
 libretro_dinothawr_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
-libretro_uae_fetch_url="https://github.com/libretro/libretro-uae.git"
+libretro_uae_git_url="https://github.com/libretro/libretro-uae.git"
 libretro_uae_name="UAE"
 
-libretro_3dengine_fetch_url="https://github.com/libretro/libretro-3dengine.git"
+libretro_3dengine_git_url="https://github.com/libretro/libretro-3dengine.git"
 libretro_3dengine_name="3DEngine"
 
-libretro_remotejoy_fetch_url="https://github.com/libretro/libretro-remotejoy.git"
+libretro_remotejoy_git_url="https://github.com/libretro/libretro-remotejoy.git"
 libretro_remotejoy_name="RemoteJoy"
 
-libretro_bluemsx_fetch_url="https://github.com/libretro/blueMSX-libretro.git"
+libretro_bluemsx_git_url="https://github.com/libretro/blueMSX-libretro.git"
 libretro_bluemsx_name="blueMSX"
 libretro_bluemsx_build_makefile="Makefile.libretro"
 
-libretro_fmsx_fetch_url="https://github.com/libretro/fmsx-libretro.git"
+libretro_fmsx_git_url="https://github.com/libretro/fmsx-libretro.git"
 libretro_fmsx_name="fMSX"
 # IMPLICIT
 
-libretro_2048_fetch_url="https://github.com/libretro/libretro-2048.git"
+libretro_2048_git_url="https://github.com/libretro/libretro-2048.git"
 libretro_2048_build_makefile="Makefile.libretro"
 
-libretro_vecx_fetch_url="https://github.com/libretro/libretro-vecx.git"
+libretro_vecx_git_url="https://github.com/libretro/libretro-vecx.git"
 libretro_vecx_build_makefile="Makefile.libretro"
 
-libretro_ppsspp_fetch_url="https://github.com/libretro/ppsspp.git"
+libretro_ppsspp_git_url="https://github.com/libretro/ppsspp.git"
 libretro_ppsspp_name="PPSSPP"
-libretro_ppsspp_git_submodules="1"
-libretro_ppsspp_git_submodules_update="1"
+libretro_ppsspp_git_submodules="yes"
 
-libretro_prosystem_fetch_url="https://github.com/libretro/prosystem-libretro.git"
+libretro_prosystem_git_url="https://github.com/libretro/prosystem-libretro.git"
 libretro_prosystem_name="ProSystem"
 # IMPLICIT
 
-libretro_o2em_fetch_url="https://github.com/libretro/libretro-o2em.git"
+libretro_o2em_git_url="https://github.com/libretro/libretro-o2em.git"
 libretro_o2em_name="O2EM"
 # IMPLICIT
 
-libretro_4do_fetch_url="https://github.com/libretro/4do-libretro.git"
+libretro_4do_git_url="https://github.com/libretro/4do-libretro.git"
 libretro_4do_name="4DO"
 # IMPLICIT
 
-libretro_catsfc_fetch_url="https://github.com/libretro/CATSFC-libretro.git"
+libretro_catsfc_git_url="https://github.com/libretro/CATSFC-libretro.git"
 libretro_catsfc_name="CATSFC"
 # IMPLICIT
 
-libretro_stonesoup_fetch_url="https://github.com/libretro/crawl-ref.git"
+libretro_stonesoup_git_url="https://github.com/libretro/crawl-ref.git"
 libretro_stonesoup_name="Dungeon Crawl Stone Soup"
-libretro_stonesoup_git_submodules="1"
+libretro_stonesoup_git_submodules="clone"
 libretro_stonesoup_build_subdir="crawl-ref"
 libretro_stonesoup_build_makefile="Makefile.libretro"
 
-libretro_hatari_fetch_url="https://github.com/libretro/hatari.git"
+libretro_hatari_git_url="https://github.com/libretro/hatari.git"
 libretro_hatari_name="Hatari"
 libretro_hatari_build_makefile="Makefile.libretro"
 
-libretro_tempgba_fetch_url="https://github.com/libretro/TempGBA-libretro.git"
+libretro_tempgba_git_url="https://github.com/libretro/TempGBA-libretro.git"
 libretro_tempgba_name="TempGBA"
 
-libretro_gpsp_fetch_url="https://github.com/libretro/gpsp.git"
+libretro_gpsp_git_url="https://github.com/libretro/gpsp.git"
 libretro_gpsp_name="gpSP"
 # IMPLICIT
 
-libretro_emux_fetch_url="https://github.com/libretro/emux.git"
+libretro_emux_git_url="https://github.com/libretro/emux.git"
 libretro_emux_name="Emux"
 
-libretro_fuse_fetch_url="https://github.com/libretro/fuse-libretro.git"
+libretro_fuse_git_url="https://github.com/libretro/fuse-libretro.git"
 libretro_fuse_name="Fuse"
 libretro_fuse_build_makefile="Makefile.libretro"
 libretro_fuse_build_platform="$FORMAT_COMPILER_TARGET_ALT"
@@ -264,13 +267,11 @@ libretro_fuse_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 # fetch_rule				Name of the core's fetch rule
 # 								Always fetch_git for the time being
 #
-# fetch_url					Source to fetch via git
+# git_url					Source to fetch via git
 #								REQUIRED for fetch actions
 #
-# git_submodules			Set if core has git submodules that must be fetched
-#
-# git_submodules_update
-# 								Set if core has git submodules that require updating
+# git_submodules			Set to "yes" if core has git submodules
+#								Set to "clone" if they never need updating
 #
 # build_subdir				Subdir containing the libretro makefile
 #								Leave unset if in top level of core
@@ -283,7 +284,7 @@ libretro_fuse_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 #
 # Example:
 #
-#	libretro_dinothawr_fetch_url="https://github.com/libretro/Dinothawr.git"
+#	libretro_dinothawr_git_url="https://github.com/libretro/Dinothawr.git"
 #	libretro_dinothawr_name="Dinothawr"
 #	libretro_dinothawr_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 #

--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -4,7 +4,7 @@
 . "$BASE_DIR/script-modules/fetch-rules.sh"
 . "$BASE_DIR/script-modules/cpu.sh"
 
-. "$BASE_DIR/core-rules.sh"
+. "$BASE_DIR/rules.d/core-rules.sh"
 
 die() {
 	echo $1

--- a/libretro-fetch.sh
+++ b/libretro-fetch.sh
@@ -21,48 +21,52 @@ fi
 # Rules for fetching cores are in this file:
 . "$BASE_DIR/core-rules.sh"
 
-# libretro_fetch_core: Download the given core using its fetch rules
+# libretro_fetch: Download the given core using its fetch rules
 #
 # $1	Name of the core to fetch
-libretro_fetch_core() {
-	eval "core_name=\$libretro_${1}_name"
-	[ -z "$core_name" ] && core_name="$1"
-	echo "=== $core_name"
+libretro_fetch() {
+	local module_name
+	local module_dir
+	local fetch_rule
+	local post_fetch_cmd
 
-	eval "core_fetch_rule=\$libretro_${1}_fetch_rule"
-	[ -z "$core_fetch_rule" ] && core_fetch_rule=fetch_git
+	eval "module_name=\$libretro_${1}_name"
+	[ -z "$module_name" ] && module_name="$1"
+	echo "=== $module_name"
 
-	eval "core_dir=\$libretro_${1}_dir"
-	[ -z "$core_dir" ] && core_dir="libretro-$1"
+	eval "fetch_rule=\$libretro_${1}_fetch_rule"
+	[ -z "$fetch_rule" ] && fetch_rule=fetch_git
 
-	case "$core_fetch_rule" in
+	eval "module_dir=\$libretro_${1}_dir"
+	[ -z "$module_dir" ] && module_dir="libretro-$1"
+
+	case "$fetch_rule" in
 		fetch_git)
-			eval "core_fetch_url=\$libretro_${1}_fetch_url"
-			if [ -z "$core_fetch_url" ]; then
-				echo "libretro_fetch_core:No URL set to fetch $1 via git."
+			local git_url
+			local git_submodules
+			eval "git_url=\$libretro_${1}_git_url"
+			if [ -z "$git_url" ]; then
+				echo "libretro_fetch:No URL set to fetch $1 via git."
 				exit 1
 			fi
 
-			eval "core_git_submodules=\$libretro_${1}_git_submodules"
-			eval "core_git_submodules_update=\$libretro_${1}_git_submodules_update"
+			eval "git_submodules=\$libretro_${1}_git_submodules"
 
 			# TODO: Don't depend on fetch_rule being git
 			echo "Fetching ${1}..."
-			$core_fetch_rule "$core_fetch_url" "$core_dir" $core_git_submodules $core_git_submodules_update
+			$fetch_rule "$git_url" "$module_dir" $git_submodules
 			;;
 		*)
-			echo "libretro_fetch_core:Unknown fetch rule for $1: \"$core_fetch_rule\"."
+			echo "libretro_fetch:Unknown fetch rule for $1: \"$fetch_rule\"."
 			exit 1
 			;;
 	esac
-}
 
-fetch_retroarch() {
-	echo "=== RetroArch"
-	echo "Fetching retroarch..."
-	fetch_git "https://github.com/libretro/RetroArch.git" "retroarch"
-	echo_cmd "cd \"$WORKDIR/retroarch\""
-	echo_cmd "./fetch-submodules.sh"
+	eval "post_fetch_cmd=\$libretro_${1}_post_fetch_cmd"
+	if [ -n "$post_fetch_cmd" ]; then
+		echo_cmd "cd \"$WORKDIR/$module_dir\""
+		echo_cmd "$post_fetch_cmd"
+	fi
 }
 
 fetch_devkit() {
@@ -78,7 +82,7 @@ fetch_devkit() {
 if [ -n "$1" ]; then
 	while [ -n "$1" ]; do
 		case "$1" in
-			fetch_retroarch|fetch_devkit)
+			fetch_devkit)
 				# These don't have rule-based fetch yet.
 				$1
 				;;
@@ -88,75 +92,75 @@ if [ -n "$1" ]; then
 				;;
 			*)
 				# New style (just cores for now)
-				libretro_fetch_core $1
+				libretro_fetch $1
 				;;
 		esac
 		shift
 	done
 else
-	fetch_retroarch
+	libretro_fetch retroarch
 	fetch_devkit
 
-	libretro_fetch_core bsnes
-	libretro_fetch_core snes9x
-	libretro_fetch_core snes9x_next
-	libretro_fetch_core genesis_plus_gx
-	libretro_fetch_core fb_alpha
-	libretro_fetch_core vba_next
-	libretro_fetch_core vbam
-	libretro_fetch_core handy
-	libretro_fetch_core bnes
-	libretro_fetch_core fceumm
-	libretro_fetch_core gambatte
-	libretro_fetch_core meteor
-	libretro_fetch_core nxengine
-	libretro_fetch_core prboom
-	libretro_fetch_core stella
-	libretro_fetch_core desmume
-	libretro_fetch_core quicknes
-	libretro_fetch_core nestopia
-	libretro_fetch_core tyrquake
-	libretro_fetch_core pcsx_rearmed
-	libretro_fetch_core mednafen_gba
-	libretro_fetch_core mednafen_lynx
-	libretro_fetch_core mednafen_ngp
-	libretro_fetch_core mednafen_pce_fast
-	libretro_fetch_core mednafen_supergrafx
-	libretro_fetch_core mednafen_psx
-	libretro_fetch_core mednafen_pcfx
-	libretro_fetch_core mednafen_snes
-	libretro_fetch_core mednafen_vb
-	libretro_fetch_core mednafen_wswan
-	libretro_fetch_core scummvm
-	libretro_fetch_core yabause
-	libretro_fetch_core dosbox
-	libretro_fetch_core virtualjaguar
-	libretro_fetch_core mame078
-	libretro_fetch_core mame139
-	libretro_fetch_core mame
-	libretro_fetch_core ffmpeg
-	libretro_fetch_core bsnes_cplusplus98
-	libretro_fetch_core bsnes_mercury
-	libretro_fetch_core picodrive
-	libretro_fetch_core tgbdual
-	libretro_fetch_core mupen64plus
-	libretro_fetch_core dinothawr
-	libretro_fetch_core uae
-	libretro_fetch_core 3dengine
-	libretro_fetch_core remotejoy
-	libretro_fetch_core bluemsx
-	libretro_fetch_core fmsx
-	libretro_fetch_core 2048
-	libretro_fetch_core vecx
-	libretro_fetch_core ppsspp
-	libretro_fetch_core prosystem
-	libretro_fetch_core o2em
-	libretro_fetch_core 4do
-	libretro_fetch_core catsfc
-	libretro_fetch_core stonesoup
-	libretro_fetch_core hatari
-	libretro_fetch_core tempgba
-	libretro_fetch_core gpsp
-	libretro_fetch_core emux
-	libretro_fetch_core fuse
+	libretro_fetch bsnes
+	libretro_fetch snes9x
+	libretro_fetch snes9x_next
+	libretro_fetch genesis_plus_gx
+	libretro_fetch fb_alpha
+	libretro_fetch vba_next
+	libretro_fetch vbam
+	libretro_fetch handy
+	libretro_fetch bnes
+	libretro_fetch fceumm
+	libretro_fetch gambatte
+	libretro_fetch meteor
+	libretro_fetch nxengine
+	libretro_fetch prboom
+	libretro_fetch stella
+	libretro_fetch desmume
+	libretro_fetch quicknes
+	libretro_fetch nestopia
+	libretro_fetch tyrquake
+	libretro_fetch pcsx_rearmed
+	libretro_fetch mednafen_gba
+	libretro_fetch mednafen_lynx
+	libretro_fetch mednafen_ngp
+	libretro_fetch mednafen_pce_fast
+	libretro_fetch mednafen_supergrafx
+	libretro_fetch mednafen_psx
+	libretro_fetch mednafen_pcfx
+	libretro_fetch mednafen_snes
+	libretro_fetch mednafen_vb
+	libretro_fetch mednafen_wswan
+	libretro_fetch scummvm
+	libretro_fetch yabause
+	libretro_fetch dosbox
+	libretro_fetch virtualjaguar
+	libretro_fetch mame078
+	libretro_fetch mame139
+	libretro_fetch mame
+	libretro_fetch ffmpeg
+	libretro_fetch bsnes_cplusplus98
+	libretro_fetch bsnes_mercury
+	libretro_fetch picodrive
+	libretro_fetch tgbdual
+	libretro_fetch mupen64plus
+	libretro_fetch dinothawr
+	libretro_fetch uae
+	libretro_fetch 3dengine
+	libretro_fetch remotejoy
+	libretro_fetch bluemsx
+	libretro_fetch fmsx
+	libretro_fetch 2048
+	libretro_fetch vecx
+	libretro_fetch ppsspp
+	libretro_fetch prosystem
+	libretro_fetch o2em
+	libretro_fetch 4do
+	libretro_fetch catsfc
+	libretro_fetch stonesoup
+	libretro_fetch hatari
+	libretro_fetch tempgba
+	libretro_fetch gpsp
+	libretro_fetch emux
+	libretro_fetch fuse
 fi

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1,202 +1,208 @@
 # vim: set ts=3 sw=3 noet ft=sh : bash
 
-libretro_retroarch_name="RetroArch"
-libretro_retroarch_dir="retroarch"
-libretro_retroarch_git_url="https://github.com/libretro/RetroArch.git"
-libretro_retroarch_post_fetch_cmd="./fetch-submodules.sh"
-
-libretro_bsnes_git_url="https://github.com/libretro/bsnes-libretro.git"
 libretro_bsnes_name="bsnes/higan"
+libretro_bsnes_git_url="https://github.com/libretro/bsnes-libretro.git"
+# NEED CUSTOM RULE: bsnes
 
-libretro_snes9x_git_url="https://github.com/libretro/snes9x.git"
 libretro_snes9x_name="SNES9x"
+libretro_snes9x_git_url="https://github.com/libretro/snes9x.git"
 libretro_snes9x_build_subdir="libretro"
 
-libretro_snes9x_next_git_url="https://github.com/libretro/snes9x-next.git"
 libretro_snes9x_next_name="SNES9x Next"
+libretro_snes9x_next_git_url="https://github.com/libretro/snes9x-next.git"
 libretro_snes9x_next_build_makefile="Makefile.libretro"
 libretro_snes9x_next_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
-libretro_genesis_plus_gx_git_url="https://github.com/libretro/Genesis-Plus-GX.git"
 libretro_genesis_plus_gx_name="Genesis Plus GX"
+libretro_genesis_plus_gx_git_url="https://github.com/libretro/Genesis-Plus-GX.git"
 libretro_genesis_plus_gx_build_makefile="Makefile.libretro"
 
-libretro_fb_alpha_git_url="https://github.com/libretro/fba-libretro.git"
 libretro_fb_alpha_name="Final Burn Alpha"
+libretro_fb_alpha_git_url="https://github.com/libretro/fba-libretro.git"
 libretro_fb_alpha_build_subdir="svn-current/trunk"
 libretro_fb_alpha_build_makefile="makefile.libretro"
 
-libretro_vba_next_git_url="https://github.com/libretro/vba-next.git"
 libretro_vba_next_name="VBA Next"
+libretro_vba_next_git_url="https://github.com/libretro/vba-next.git"
 libretro_vba_next_build_makefile="Makefile.libretro"
 libretro_vba_next_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
-libretro_vbam_git_url="https://github.com/libretro/vbam-libretro.git"
 libretro_vbam_name="VBA-M"
+libretro_vbam_git_url="https://github.com/libretro/vbam-libretro.git"
 libretro_vbam_build_subdir="src/libretro"
 libretro_vbam_build_makefile="Makefile"
 libretro_vbam_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
-libretro_handy_git_url="https://github.com/libretro/libretro-handy.git"
 libretro_handy_name="Handy"
+libretro_handy_git_url="https://github.com/libretro/libretro-handy.git"
 # IMPLICIT
 
-libretro_bnes_git_url="https://github.com/libretro/bnes-libretro.git"
 libretro_bnes_name="bnes/higan"
+libretro_bnes_git_url="https://github.com/libretro/bnes-libretro.git"
+# NEED CUSTOM RULE: bnes
 
-libretro_fceumm_git_url="https://github.com/libretro/libretro-fceumm.git"
 libretro_fceumm_name="FCEUmm"
+libretro_fceumm_git_url="https://github.com/libretro/libretro-fceumm.git"
 libretro_fceumm_build_makefile="Makefile.libretro"
 
-libretro_gambatte_git_url="https://github.com/libretro/gambatte-libretro.git"
 libretro_gambatte_name="Gambatte"
+libretro_gambatte_git_url="https://github.com/libretro/gambatte-libretro.git"
 libretro_gambatte_build_subdir="libgambatte"
 libretro_gambatte_build_makefile="Makefile.libretro"
 libretro_gambatte_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
-libretro_meteor_git_url="https://github.com/libretro/meteor-libretro.git"
 libretro_meteor_name="Meteor"
+libretro_meteor_git_url="https://github.com/libretro/meteor-libretro.git"
 libretro_meteor_build_subdir="libretro"
 
-libretro_nxengine_git_url="https://github.com/libretro/nxengine-libretro.git"
 libretro_nxengine_name="NXEngine"
+libretro_nxengine_git_url="https://github.com/libretro/nxengine-libretro.git"
 # IMPLICIT
 
-libretro_prboom_git_url="https://github.com/libretro/libretro-prboom.git"
 libretro_prboom_name="PrBoom"
+libretro_prboom_git_url="https://github.com/libretro/libretro-prboom.git"
 libretro_prboom_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
-libretro_stella_git_url="https://github.com/libretro/stella-libretro.git"
 libretro_stella_name="Stella"
+libretro_stella_git_url="https://github.com/libretro/stella-libretro.git"
 # IMPLICIT
 
-libretro_desmume_git_url="https://github.com/libretro/desmume.git"
 libretro_desmume_name="DeSmuME"
+libretro_desmume_git_url="https://github.com/libretro/desmume.git"
 libretro_desmume_build_subdir="desmume"
 libretro_desmume_build_makefile="Makefile.libretro"
 
-libretro_quicknes_git_url="https://github.com/libretro/QuickNES_Core.git"
 libretro_quicknes_name="QuickNES"
+libretro_quicknes_git_url="https://github.com/libretro/QuickNES_Core.git"
 libretro_quicknes_build_subdir="libretro"
 
-libretro_nestopia_git_url="https://github.com/libretro/nestopia.git"
 libretro_nestopia_name="Nestopia"
+libretro_nestopia_git_url="https://github.com/libretro/nestopia.git"
 libretro_nestopia_build_subdir="libretro"
 
-libretro_tyrquake_git_url="https://github.com/libretro/tyrquake.git"
 libretro_tyrquake_name="TyrQuake"
+libretro_tyrquake_git_url="https://github.com/libretro/tyrquake.git"
 libretro_tyrquake_build_makefile="Makefile.libretro"
 
-libretro_pcsx_rearmed_git_url="https://github.com/libretro/pcsx_rearmed.git"
 libretro_pcsx_rearmed_name="PCSX ReARMed"
+libretro_pcsx_rearmed_git_url="https://github.com/libretro/pcsx_rearmed.git"
 libretro_pcsx_rearmed_build_makefile="Makefile.libretro"
 
-libretro_mednafen_gba_git_url="https://github.com/libretro/beetle-gba-libretro.git"
 libretro_mednafen_gba_name="Mednafen/Beetle GBA"
+libretro_mednafen_gba_git_url="https://github.com/libretro/beetle-gba-libretro.git"
 # IMPLICIT
 
-libretro_mednafen_lynx_git_url="https://github.com/libretro/beetle-lynx-libretro.git"
 libretro_mednafen_lynx_name="Mednafen/Beetle Lynx"
+libretro_mednafen_lynx_git_url="https://github.com/libretro/beetle-lynx-libretro.git"
 # IMPLICIT
 
-libretro_mednafen_ngp_git_url="https://github.com/libretro/beetle-ngp-libretro.git"
 libretro_mednafen_ngp_name="Mednafen/Beetle NeoPop"
+libretro_mednafen_ngp_git_url="https://github.com/libretro/beetle-ngp-libretro.git"
 # IMPLICIT
 
-libretro_mednafen_pce_fast_git_url="https://github.com/libretro/beetle-pce-fast-libretro.git"
 libretro_mednafen_pce_fast_name="Mednafen/Beetle PCE FAST"
+libretro_mednafen_pce_fast_git_url="https://github.com/libretro/beetle-pce-fast-libretro.git"
 # IMPLICIT
 
-libretro_mednafen_supergrafx_git_url="https://github.com/libretro/beetle-supergrafx-libretro.git"
 libretro_mednafen_supergrafx_name="Mednafen/Beetle SuperGrafx"
+libretro_mednafen_supergrafx_git_url="https://github.com/libretro/beetle-supergrafx-libretro.git"
 # IMPLICIT
 
-libretro_mednafen_psx_git_url="https://github.com/libretro/mednafen-psx-libretro.git"
 libretro_mednafen_psx_name="Mednafen PSX"
+libretro_mednafen_psx_git_url="https://github.com/libretro/mednafen-psx-libretro.git"
 # IMPLICIT
 
-libretro_mednafen_pcfx_git_url="https://github.com/libretro/beetle-pcfx-libretro.git"
 libretro_mednafen_pcfx_name="Mednafen/Beetle PC-FX"
+libretro_mednafen_pcfx_git_url="https://github.com/libretro/beetle-pcfx-libretro.git"
 # IMPLICIT
 
-libretro_mednafen_snes_git_url="https://github.com/libretro/beetle-bsnes-libretro.git"
 libretro_mednafen_snes_name="Mednafen/Beetle bsnes"
+libretro_mednafen_snes_git_url="https://github.com/libretro/beetle-bsnes-libretro.git"
 # IMPLICIT
 
-libretro_mednafen_vb_git_url="https://github.com/libretro/beetle-vb-libretro.git"
 libretro_mednafen_vb_name="Mednafen/Beetle VB"
+libretro_mednafen_vb_git_url="https://github.com/libretro/beetle-vb-libretro.git"
 # IMPLICIT
 
-libretro_mednafen_wswan_git_url="https://github.com/libretro/beetle-wswan-libretro.git"
 libretro_mednafen_wswan_name="Mednafen/Beetle WonderSwan"
+libretro_mednafen_wswan_git_url="https://github.com/libretro/beetle-wswan-libretro.git"
 # IMPLICIT
 
-libretro_scummvm_git_url="https://github.com/libretro/scummvm.git"
 libretro_scummvm_name="ScummVM"
+libretro_scummvm_git_url="https://github.com/libretro/scummvm.git"
 libretro_scummvm_build_subdir="backends/platform/libretro/build"
 
-libretro_yabause_git_url="https://github.com/libretro/yabause.git"
 libretro_yabause_name="Yabause"
+libretro_yabause_git_url="https://github.com/libretro/yabause.git"
 libretro_yabause_build_subdir="libretro"
 
-libretro_dosbox_git_url="https://github.com/libretro/dosbox-libretro.git"
 libretro_dosbox_name="DOSBox"
+libretro_dosbox_git_url="https://github.com/libretro/dosbox-libretro.git"
 libretro_dosbox_makefile="Makefile.libretro"
 
-libretro_virtualjaguar_git_url="https://github.com/libretro/virtualjaguar-libretro.git"
 libretro_virtualjaguar_name="Virtual Jaguar"
+libretro_virtualjaguar_git_url="https://github.com/libretro/virtualjaguar-libretro.git"
 # IMPLICIT
 
-libretro_mame078_git_url="https://github.com/libretro/mame2003-libretro.git"
 libretro_mame078_name="MAME 2003 (0.78)"
+libretro_mame078_git_url="https://github.com/libretro/mame2003-libretro.git"
 # IMPLICIT
 
-libretro_mame139_git_url="https://github.com/libretro/mame2010-libretro.git"
 libretro_mame139_name="MAME 2010 (0.139)"
+libretro_mame139_git_url="https://github.com/libretro/mame2010-libretro.git"
+# NEED A BUILD RULE: mame139
 
-libretro_mame_git_url="https://github.com/libretro/mame.git"
 libretro_mame_name="MAME (git)"
+libretro_mame_git_url="https://github.com/libretro/mame.git"
+# NEED CUSTOM RULE: mame
 
-libretro_ffmpeg_git_url="https://github.com/libretro/FFmpeg.git"
 libretro_ffmpeg_name="FFmpeg"
+libretro_ffmpeg_git_url="https://github.com/libretro/FFmpeg.git"
+# NEED OPENGL CHECK: ffmpeg
 
-libretro_bsnes_cplusplus98_git_url="https://github.com/libretro/bsnes-libretro-cplusplus98.git"
 libretro_bsnes_cplusplus98_name="bsnes C++98 (v0.85)"
+libretro_bsnes_cplusplus98_git_url="https://github.com/libretro/bsnes-libretro-cplusplus98.git"
+# NEED CUSTOM RULE: bsnes_cplusplus98
 
-libretro_bsnes_mercury_git_url="https://github.com/libretro/bsnes-mercury.git"
 libretro_bsnes_mercury_name="bsnes-mercury"
+libretro_bsnes_mercury_git_url="https://github.com/libretro/bsnes-mercury.git"
+# NEED CUSTOM RULE: bsnes_mercury
 
-libretro_picodrive_git_url="https://github.com/libretro/picodrive.git"
 libretro_picodrive_name="Picodrive"
+libretro_picodrive_git_url="https://github.com/libretro/picodrive.git"
 libretro_picodrive_git_submodules="yes"
 libretro_picodrive_build_makefile="Makefile.libretro"
 
-libretro_tgbdual_git_url="https://github.com/libretro/tgbdual-libretro.git"
 libretro_tgbdual_name="TGB Dual"
+libretro_tgbdual_git_url="https://github.com/libretro/tgbdual-libretro.git"
 # IMPLICIT
 
-libretro_mupen64plus_git_url="https://github.com/libretro/mupen64plus-libretro.git"
 libretro_mupen64plus_name="Mupen64Plus"
+libretro_mupen64plus_git_url="https://github.com/libretro/mupen64plus-libretro.git"
+# NEED CUSTOM RULE: mupen64plus
 
-libretro_dinothawr_git_url="https://github.com/libretro/Dinothawr.git"
 libretro_dinothawr_name="Dinothawr"
+libretro_dinothawr_git_url="https://github.com/libretro/Dinothawr.git"
 libretro_dinothawr_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
-libretro_uae_git_url="https://github.com/libretro/libretro-uae.git"
 libretro_uae_name="UAE"
+libretro_uae_git_url="https://github.com/libretro/libretro-uae.git"
+# NEED A BUILD RULE: uae
 
-libretro_3dengine_git_url="https://github.com/libretro/libretro-3dengine.git"
 libretro_3dengine_name="3DEngine"
+libretro_3dengine_git_url="https://github.com/libretro/libretro-3dengine.git"
+# NEED OPENGL CHECK: 3dengine
 
-libretro_remotejoy_git_url="https://github.com/libretro/libretro-remotejoy.git"
 libretro_remotejoy_name="RemoteJoy"
+libretro_remotejoy_git_url="https://github.com/libretro/libretro-remotejoy.git"
+# NEED A BUILD RULE: remotejoy
 
-libretro_bluemsx_git_url="https://github.com/libretro/blueMSX-libretro.git"
 libretro_bluemsx_name="blueMSX"
+libretro_bluemsx_git_url="https://github.com/libretro/blueMSX-libretro.git"
 libretro_bluemsx_build_makefile="Makefile.libretro"
 
-libretro_fmsx_git_url="https://github.com/libretro/fmsx-libretro.git"
 libretro_fmsx_name="fMSX"
+libretro_fmsx_git_url="https://github.com/libretro/fmsx-libretro.git"
 # IMPLICIT
 
 libretro_2048_git_url="https://github.com/libretro/libretro-2048.git"
@@ -205,48 +211,51 @@ libretro_2048_build_makefile="Makefile.libretro"
 libretro_vecx_git_url="https://github.com/libretro/libretro-vecx.git"
 libretro_vecx_build_makefile="Makefile.libretro"
 
-libretro_ppsspp_git_url="https://github.com/libretro/ppsspp.git"
 libretro_ppsspp_name="PPSSPP"
+libretro_ppsspp_git_url="https://github.com/libretro/ppsspp.git"
 libretro_ppsspp_git_submodules="yes"
+# NEED OPENGL CHECK: ppsspp
 
-libretro_prosystem_git_url="https://github.com/libretro/prosystem-libretro.git"
 libretro_prosystem_name="ProSystem"
+libretro_prosystem_git_url="https://github.com/libretro/prosystem-libretro.git"
 # IMPLICIT
 
-libretro_o2em_git_url="https://github.com/libretro/libretro-o2em.git"
 libretro_o2em_name="O2EM"
+libretro_o2em_git_url="https://github.com/libretro/libretro-o2em.git"
 # IMPLICIT
 
-libretro_4do_git_url="https://github.com/libretro/4do-libretro.git"
 libretro_4do_name="4DO"
+libretro_4do_git_url="https://github.com/libretro/4do-libretro.git"
 # IMPLICIT
 
-libretro_catsfc_git_url="https://github.com/libretro/CATSFC-libretro.git"
 libretro_catsfc_name="CATSFC"
+libretro_catsfc_git_url="https://github.com/libretro/CATSFC-libretro.git"
 # IMPLICIT
 
-libretro_stonesoup_git_url="https://github.com/libretro/crawl-ref.git"
 libretro_stonesoup_name="Dungeon Crawl Stone Soup"
+libretro_stonesoup_git_url="https://github.com/libretro/crawl-ref.git"
 libretro_stonesoup_git_submodules="clone"
 libretro_stonesoup_build_subdir="crawl-ref"
 libretro_stonesoup_build_makefile="Makefile.libretro"
 
-libretro_hatari_git_url="https://github.com/libretro/hatari.git"
 libretro_hatari_name="Hatari"
+libretro_hatari_git_url="https://github.com/libretro/hatari.git"
 libretro_hatari_build_makefile="Makefile.libretro"
 
-libretro_tempgba_git_url="https://github.com/libretro/TempGBA-libretro.git"
 libretro_tempgba_name="TempGBA"
+libretro_tempgba_git_url="https://github.com/libretro/TempGBA-libretro.git"
+# NEED A BUILD RULE: tempgba
 
-libretro_gpsp_git_url="https://github.com/libretro/gpsp.git"
 libretro_gpsp_name="gpSP"
+libretro_gpsp_git_url="https://github.com/libretro/gpsp.git"
 # IMPLICIT
 
-libretro_emux_git_url="https://github.com/libretro/emux.git"
 libretro_emux_name="Emux"
+libretro_emux_git_url="https://github.com/libretro/emux.git"
+# NEED CUSTOM RULE: emux
 
-libretro_fuse_git_url="https://github.com/libretro/fuse-libretro.git"
 libretro_fuse_name="Fuse"
+libretro_fuse_git_url="https://github.com/libretro/fuse-libretro.git"
 libretro_fuse_build_makefile="Makefile.libretro"
 libretro_fuse_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
@@ -265,7 +274,7 @@ libretro_fuse_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 # 								Defaults to "libretro-<core>"
 #
 # fetch_rule				Name of the core's fetch rule
-# 								Always fetch_git for the time being
+# 								Currently "git" (default) or "multi_git"
 #
 # git_url					Source to fetch via git
 #								REQUIRED for fetch actions

--- a/rules.d/devkit-rules.sh
+++ b/rules.d/devkit-rules.sh
@@ -1,0 +1,15 @@
+# vim: set ts=3 sw=3 noet ft=sh : bash
+
+libretro_devkit_name="libretro Developer's Kit"
+# FIXME: Twinaphex, uncomment next line for libretro-super/libretrodb etc or delete, your choice
+#libretro_devkit_dir="."
+libretro_devkit_fetch_rule=multi_git
+libretro_devkit_mgit_urls=4
+libretro_devkit_mgit_dir_0="libretro-manifest"
+libretro_devkit_mgit_url_0="https://github.com/libretro/libretro-manifest.git"
+libretro_devkit_mgit_dir_1="libretrodb"
+libretro_devkit_mgit_url_1="https://github.com/libretro/libretrodb.git"
+libretro_devkit_mgit_dir_2="libretro-dat-pull"
+libretro_devkit_mgit_url_2="https://github.com/libretro/libretro-dat-pull.git"
+libretro_devkit_mgit_dir_3="libretro-common"
+libretro_devkit_mgit_url_3="https://github.com/libretro/libretro-common.git"

--- a/rules.d/player-rules.sh
+++ b/rules.d/player-rules.sh
@@ -1,0 +1,7 @@
+# vim: set ts=3 sw=3 noet ft=sh : bash
+
+libretro_retroarch_name="RetroArch"
+libretro_retroarch_dir="retroarch"
+libretro_retroarch_git_url="https://github.com/libretro/RetroArch.git"
+libretro_retroarch_post_fetch_cmd="./fetch-submodules.sh"
+

--- a/script-modules/fetch-rules.sh
+++ b/script-modules/fetch-rules.sh
@@ -4,8 +4,7 @@
 #
 # $1	The URI to fetch
 # $2	The local directory to fetch to (relative)
-# $3	Set to clone --recursive
-# $4	Set to pull --recursive
+# $3	Recurse submodules (yes, no, clone)
 #
 # NOTE: git _now_ has a -C argument that would replace the cd commands in
 #       this rule, but this is a fairly recent addition to git, so we can't
@@ -15,14 +14,14 @@ fetch_git() {
 	if [ -d "$fetch_dir/.git" ]; then
 		echo_cmd "cd \"$fetch_dir\""
 		echo_cmd "git pull"
-		if [ -n "$4" ]; then
+		if [ "$3" = "yes" ]; then
 			echo_cmd "git submodule foreach git pull origin master"
 		fi
 	else
 		clone_type=
 		[ -n "$SHALLOW_CLONE" ] && depth="--depth 1 "
 		echo_cmd "git clone $depth\"$1\" \"$WORKDIR/$2\""
-		if [ -n "$3" ]; then
+		if [[ "$3" = "yes" || "$3" = "clone" ]]; then
 			echo_cmd "cd \"$fetch_dir\""
 			echo_cmd "git submodule update --init"
 		fi


### PR DESCRIPTION
The mgit fetch rule wants to put things in a subdir just like all the others.  But that means libretrodb and friends go into libretro-devkit/libretrodb etc.  If that's fine, remove the comments in rules.d/devkit-rules.sh.  If it's not, uncomment the line to put them in $WORKDIR without any subdirectory.  I'm good with it either way, and I had to test it both ways to make sure it worked.