### PR TITLE
SOME color in the scripts, can be disabled in libretro-config{,-user}.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@
 /libretro-mame/
 /libretro-mame078/
 /libretro-mame139/
-/libretro-manifest/
 /libretro-mednafen_gba/
 /libretro-mednafen_lynx/
 /libretro-mednafen_ngp/
@@ -62,9 +61,9 @@
 /libretro-virtualjaguar/
 /libretro-yabause/
 /libretro-fuse/
-/libretro-dat-pull/
-/libretro-common/
-/libretrodb/
+/libretro-lutro/
+/libretro-gw/
+/libretro-devkit/
 /retroarch/
 /build-summary.log
 /build-revisions/

--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -255,7 +255,7 @@ libretro_build_core() {
 
 	eval "core_name=\$libretro_${1}_name"
 	[ -z "$core_name" ] && core_name="$1"
-	echo "=== $core_name"
+	echo "$(color 34)=== $(color 1)$core_name$(color)"
 
 	eval "core_build_rule=\$libretro_${1}_build_rule"
 	[ -z "$core_build_rule" ] && core_build_rule=build_makefile
@@ -600,7 +600,7 @@ build_summary() {
 		fi
 		printf -v summary "=== Core Build Summary ===\n\n"
 		if [ -n "$build_success" ]; then
-			printf -v summary "%s%d %s\n" "$summary" "$(echo $build_success | wc -w)" "core(s) successfully built:"
+			printf -v summary "%s%s%d%s\n" "$summary" "$(color 32)" "$(echo $build_success | wc -w)" " core(s)$(color) successfully built:"
 			if [ -n "$use_fmt" ]; then
 				printf -v summary "%s%s\n\n" "$summary" "$(echo "	$build_success" | fmt)"
 			else
@@ -608,7 +608,7 @@ build_summary() {
 			fi
 		fi
 		if [ -n "$build_fail" ]; then
-			printf -v summary "%s%d %s\n" "$summary" "$(echo $build_fail | wc -w)" "core(s) failed to build:"
+			printf -v summary "%s%s%d%s\n" "$summary" "$(color 31)" "$(echo $build_fail | wc -w)" " core(s)$(color) failed to build:"
 			if [ -n "$use_fmt" ]; then
 				printf -v summary "%s%s\n\n" "$summary" "$(echo "	$build_fail" | fmt)"
 			else
@@ -791,11 +791,9 @@ build_libretro_virtualjaguar() {
 build_libretro_yabause() {
 	libretro_build_core yabause
 }
-
 build_libretro_gw() {
 	libretro_build_core gw
 }
-
 build_libretro_lutro() {
 	libretro_build_core lutro
 }

--- a/libretro-config.sh
+++ b/libretro-config.sh
@@ -263,6 +263,15 @@ BUILD_SUMMARY="$WORKDIR/build-summary.log"
 #BUILD_REVISIONS_DIR="$WORKDIR/build-revisions"
 
 
+# COLOR IN OUTPUT
+# ===============
+#
+# If you don't like ANSI-style color in your output, uncomment this line.
+#NO_COLOR=1
+
+# If you want to force it even in log files, uncomment this line.
+#FORCE_COLOR=1
+
 #USER DEFINES
 #------------
 #These options should be defined inside your own

--- a/libretro-fetch.sh
+++ b/libretro-fetch.sh
@@ -36,7 +36,7 @@ libretro_fetch() {
 
 	eval "module_name=\$libretro_${1}_name"
 	[ -z "$module_name" ] && module_name="$1"
-	echo "=== $module_name"
+	echo "$(color 34)=== $(color 1)$module_name$(color)"
 
 	eval "fetch_rule=\$libretro_${1}_fetch_rule"
 	[ -z "$fetch_rule" ] && fetch_rule=git

--- a/script-modules/util.sh
+++ b/script-modules/util.sh
@@ -5,3 +5,16 @@ echo_cmd() {
 	eval "$@"
 	return $?
 }
+
+color() {
+	[ -n "$NO_COLOR" ] && return
+
+	echo -ne "\e[0;${1:-0}m"
+}
+
+
+if [ ! -t 1 ]; then
+	if [ -z "$FORCE_COLOR" ]; then
+		NO_COLOR=1
+	fi
+fi


### PR DESCRIPTION
An admonition: Just because you CAN use colors in the scripts now doesn't mean you always SHOULD.  If I find someone's made these scripts look like an angry fruit salad, I'll be reverting those changes as I already told Twinaphex I would.  Too much color makes the script output loud and distracting, less is more, etc.

Nutshell: As it stands, I consider libretro-fetch.sh to be too loud already.  The only reason it does any color at all is because at some point libretro-build.sh and libretro-fetch.sh will be special cases of libretro-super that (just) build and (just) fetch.  The normal thing will be to fetch, compile, and probably package.