### PR TITLE
Don't depend on \e (see if this fixes color Twinaphex!)

### DIFF
--- a/script-modules/util.sh
+++ b/script-modules/util.sh
@@ -9,7 +9,7 @@ echo_cmd() {
 color() {
 	[ -n "$NO_COLOR" ] && return
 
-	echo -ne "\e[0;${1:-0}m"
+	echo -ne "[0;${1:-0}m"
 }
 
 

--- a/script-modules/util.sh
+++ b/script-modules/util.sh
@@ -9,7 +9,7 @@ echo_cmd() {
 color() {
 	[ -n "$NO_COLOR" ] && return
 
-	echo -ne "[0;${1:-0}m"
+	echo -n "[0;${1:-0}m"
 }
 
 


### PR DESCRIPTION
I can change default still (just uncomment line in libretro-config.sh), but first want to be sure this works now.