### PR TITLE
No longer need to edit libretro-fetch.sh to add a new core

### DIFF
--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -258,7 +258,7 @@ libretro_build_core() {
 	echo "$(color 34)=== $(color 1)$core_name$(color)"
 
 	eval "core_build_rule=\$libretro_${1}_build_rule"
-	[ -z "$core_build_rule" ] && core_build_rule=build_makefile
+	[ -z "$core_build_rule" ] && core_build_rule=generic_makefile
 
 	eval "core_dir=\$libretro_${1}_dir"
 	[ -z "$core_dir" ] && core_dir="libretro-$1"
@@ -285,7 +285,7 @@ libretro_build_core() {
 	fi
 
 	case "$core_build_rule" in
-		build_makefile)
+		generic_makefile)
 			eval "core_build_makefile=\$libretro_${1}_build_makefile"
 			eval "core_build_subdir=\$libretro_${1}_build_subdir"
 
@@ -296,6 +296,9 @@ libretro_build_core() {
 			echo "Building ${1}..."
 			$core_build_rule $1
 
+			;;
+		none)
+			echo "Don't have a build rule for $1, skipping..."
 			;;
 		*)
 			echo "libretro_build_core:Unknown build rule for $1: \"$core_build_rule\"."

--- a/libretro-fetch.sh
+++ b/libretro-fetch.sh
@@ -17,6 +17,7 @@ fi
 . "$BASE_DIR/libretro-config.sh"
 . "$BASE_DIR/script-modules/util.sh"
 . "$BASE_DIR/script-modules/fetch-rules.sh"
+. "$BASE_DIR/script-modules/modules.sh"
 
 # Rules for fetching things are in these files:
 . "$BASE_DIR/rules.d/core-rules.sh"
@@ -119,68 +120,7 @@ else
 	libretro_fetch retroarch
 	libretro_fetch devkit
 
-	libretro_fetch bsnes
-	libretro_fetch snes9x
-	libretro_fetch snes9x_next
-	libretro_fetch genesis_plus_gx
-	libretro_fetch fb_alpha
-	libretro_fetch vba_next
-	libretro_fetch vbam
-	libretro_fetch handy
-	libretro_fetch bnes
-	libretro_fetch fceumm
-	libretro_fetch gambatte
-	libretro_fetch meteor
-	libretro_fetch nxengine
-	libretro_fetch prboom
-	libretro_fetch stella
-	libretro_fetch desmume
-	libretro_fetch quicknes
-	libretro_fetch nestopia
-	libretro_fetch tyrquake
-	libretro_fetch pcsx_rearmed
-	libretro_fetch mednafen_gba
-	libretro_fetch mednafen_lynx
-	libretro_fetch mednafen_ngp
-	libretro_fetch mednafen_pce_fast
-	libretro_fetch mednafen_supergrafx
-	libretro_fetch mednafen_psx
-	libretro_fetch mednafen_pcfx
-	libretro_fetch mednafen_snes
-	libretro_fetch mednafen_vb
-	libretro_fetch mednafen_wswan
-	libretro_fetch scummvm
-	libretro_fetch yabause
-	libretro_fetch dosbox
-	libretro_fetch virtualjaguar
-	libretro_fetch mame078
-	libretro_fetch mame139
-	libretro_fetch mame
-	libretro_fetch ffmpeg
-	libretro_fetch bsnes_cplusplus98
-	libretro_fetch bsnes_mercury
-	libretro_fetch picodrive
-	libretro_fetch tgbdual
-	libretro_fetch mupen64plus
-	libretro_fetch dinothawr
-	libretro_fetch uae
-	libretro_fetch 3dengine
-	libretro_fetch remotejoy
-	libretro_fetch bluemsx
-	libretro_fetch fmsx
-	libretro_fetch 2048
-	libretro_fetch vecx
-	libretro_fetch ppsspp
-	libretro_fetch prosystem
-	libretro_fetch o2em
-	libretro_fetch 4do
-	libretro_fetch catsfc
-	libretro_fetch stonesoup
-	libretro_fetch hatari
-	libretro_fetch tempgba
-	libretro_fetch gpsp
-	libretro_fetch emux
-	libretro_fetch fuse
-	libretro_fetch gw
-	libretro_fetch lutro
+	for a in $libretro_cores; do
+		libretro_fetch "${a%%:*}"
+	done
 fi

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1,282 +1,324 @@
 # vim: set ts=3 sw=3 noet ft=sh : bash
 
+register_module core "bsnes"
 libretro_bsnes_name="bsnes/higan"
 libretro_bsnes_git_url="https://github.com/libretro/bsnes-libretro.git"
 libretro_bsnes_build_rule=none
 # NEED CUSTOM RULE: bsnes
 
+register_core "snes9x"
 libretro_snes9x_name="SNES9x"
 libretro_snes9x_git_url="https://github.com/libretro/snes9x.git"
 libretro_snes9x_build_subdir="libretro"
 
+register_core "snes9x_next"
 libretro_snes9x_next_name="SNES9x Next"
 libretro_snes9x_next_git_url="https://github.com/libretro/snes9x-next.git"
 libretro_snes9x_next_build_makefile="Makefile.libretro"
 libretro_snes9x_next_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
+register_core "genesis_plus_gx"
 libretro_genesis_plus_gx_name="Genesis Plus GX"
 libretro_genesis_plus_gx_git_url="https://github.com/libretro/Genesis-Plus-GX.git"
 libretro_genesis_plus_gx_build_makefile="Makefile.libretro"
 
+register_core "fb_alpha"
 libretro_fb_alpha_name="Final Burn Alpha"
 libretro_fb_alpha_git_url="https://github.com/libretro/fba-libretro.git"
 libretro_fb_alpha_build_subdir="svn-current/trunk"
 libretro_fb_alpha_build_makefile="makefile.libretro"
 
+register_core "vba_next"
 libretro_vba_next_name="VBA Next"
 libretro_vba_next_git_url="https://github.com/libretro/vba-next.git"
 libretro_vba_next_build_makefile="Makefile.libretro"
 libretro_vba_next_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
+register_core "vbam"
 libretro_vbam_name="VBA-M"
 libretro_vbam_git_url="https://github.com/libretro/vbam-libretro.git"
 libretro_vbam_build_subdir="src/libretro"
 libretro_vbam_build_makefile="Makefile"
 libretro_vbam_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
+register_core "handy"
 libretro_handy_name="Handy"
 libretro_handy_git_url="https://github.com/libretro/libretro-handy.git"
-# IMPLICIT
 
+register_core "bnes"
 libretro_bnes_name="bnes/higan"
 libretro_bnes_git_url="https://github.com/libretro/bnes-libretro.git"
 libretro_bnes_build_rule=none
 # NEED CUSTOM RULE: bnes
 
+register_core "fceumm"
 libretro_fceumm_name="FCEUmm"
 libretro_fceumm_git_url="https://github.com/libretro/libretro-fceumm.git"
 libretro_fceumm_build_makefile="Makefile.libretro"
 
+register_core "gambatte"
 libretro_gambatte_name="Gambatte"
 libretro_gambatte_git_url="https://github.com/libretro/gambatte-libretro.git"
 libretro_gambatte_build_subdir="libgambatte"
 libretro_gambatte_build_makefile="Makefile.libretro"
 libretro_gambatte_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
+register_core "meteor"
 libretro_meteor_name="Meteor"
 libretro_meteor_git_url="https://github.com/libretro/meteor-libretro.git"
 libretro_meteor_build_subdir="libretro"
 
+register_core "nxengine"
 libretro_nxengine_name="NXEngine"
 libretro_nxengine_git_url="https://github.com/libretro/nxengine-libretro.git"
-# IMPLICIT
 
+register_core "prboom"
 libretro_prboom_name="PrBoom"
 libretro_prboom_git_url="https://github.com/libretro/libretro-prboom.git"
 libretro_prboom_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
+register_core "stella"
 libretro_stella_name="Stella"
 libretro_stella_git_url="https://github.com/libretro/stella-libretro.git"
-# IMPLICIT
 
+register_core "desmume"
 libretro_desmume_name="DeSmuME"
 libretro_desmume_git_url="https://github.com/libretro/desmume.git"
 libretro_desmume_build_subdir="desmume"
 libretro_desmume_build_makefile="Makefile.libretro"
 
+register_core "quicknes"
 libretro_quicknes_name="QuickNES"
 libretro_quicknes_git_url="https://github.com/libretro/QuickNES_Core.git"
 libretro_quicknes_build_subdir="libretro"
 
+register_core "nestopia"
 libretro_nestopia_name="Nestopia"
 libretro_nestopia_git_url="https://github.com/libretro/nestopia.git"
 libretro_nestopia_build_subdir="libretro"
 
+register_core "tyrquake"
 libretro_tyrquake_name="TyrQuake"
 libretro_tyrquake_git_url="https://github.com/libretro/tyrquake.git"
 libretro_tyrquake_build_makefile="Makefile.libretro"
 
+register_core "pcsx_rearmed"
 libretro_pcsx_rearmed_name="PCSX ReARMed"
 libretro_pcsx_rearmed_git_url="https://github.com/libretro/pcsx_rearmed.git"
 libretro_pcsx_rearmed_build_makefile="Makefile.libretro"
 
+register_core "mednafen_gba"
 libretro_mednafen_gba_name="Mednafen/Beetle GBA"
 libretro_mednafen_gba_git_url="https://github.com/libretro/beetle-gba-libretro.git"
-# IMPLICIT
 
+register_core "mednafen_lynx"
 libretro_mednafen_lynx_name="Mednafen/Beetle Lynx"
 libretro_mednafen_lynx_git_url="https://github.com/libretro/beetle-lynx-libretro.git"
-# IMPLICIT
 
+register_core "mednafen_ngp"
 libretro_mednafen_ngp_name="Mednafen/Beetle NeoPop"
 libretro_mednafen_ngp_git_url="https://github.com/libretro/beetle-ngp-libretro.git"
-# IMPLICIT
 
+register_core "mednafen_pce_fast"
 libretro_mednafen_pce_fast_name="Mednafen/Beetle PCE FAST"
 libretro_mednafen_pce_fast_git_url="https://github.com/libretro/beetle-pce-fast-libretro.git"
-# IMPLICIT
 
+register_core "mednafen_supergrafx"
 libretro_mednafen_supergrafx_name="Mednafen/Beetle SuperGrafx"
 libretro_mednafen_supergrafx_git_url="https://github.com/libretro/beetle-supergrafx-libretro.git"
-# IMPLICIT
 
+register_core "mednafen_psx"
 libretro_mednafen_psx_name="Mednafen PSX"
 libretro_mednafen_psx_git_url="https://github.com/libretro/mednafen-psx-libretro.git"
-# IMPLICIT
 
+register_core "mednafen_pcfx"
 libretro_mednafen_pcfx_name="Mednafen/Beetle PC-FX"
 libretro_mednafen_pcfx_git_url="https://github.com/libretro/beetle-pcfx-libretro.git"
-# IMPLICIT
 
+register_core "mednafen_snes"
 libretro_mednafen_snes_name="Mednafen/Beetle bsnes"
 libretro_mednafen_snes_git_url="https://github.com/libretro/beetle-bsnes-libretro.git"
-# IMPLICIT
 
+register_core "mednafen_vb"
 libretro_mednafen_vb_name="Mednafen/Beetle VB"
 libretro_mednafen_vb_git_url="https://github.com/libretro/beetle-vb-libretro.git"
-# IMPLICIT
 
+register_core "mednafen_wswan"
 libretro_mednafen_wswan_name="Mednafen/Beetle WonderSwan"
 libretro_mednafen_wswan_git_url="https://github.com/libretro/beetle-wswan-libretro.git"
-# IMPLICIT
 
+register_core "scummvm"
 libretro_scummvm_name="ScummVM"
 libretro_scummvm_git_url="https://github.com/libretro/scummvm.git"
 libretro_scummvm_build_subdir="backends/platform/libretro/build"
 
+register_core "yabause"
 libretro_yabause_name="Yabause"
 libretro_yabause_git_url="https://github.com/libretro/yabause.git"
 libretro_yabause_build_subdir="libretro"
 
+register_core "dosbox"
 libretro_dosbox_name="DOSBox"
 libretro_dosbox_git_url="https://github.com/libretro/dosbox-libretro.git"
 libretro_dosbox_makefile="Makefile.libretro"
 
+register_core "virtualjaguar"
 libretro_virtualjaguar_name="Virtual Jaguar"
 libretro_virtualjaguar_git_url="https://github.com/libretro/virtualjaguar-libretro.git"
-# IMPLICIT
 
+register_core "mame078"
 libretro_mame078_name="MAME 2003 (0.78)"
 libretro_mame078_git_url="https://github.com/libretro/mame2003-libretro.git"
-# IMPLICIT
 
+register_core "mame139"
 libretro_mame139_name="MAME 2010 (0.139)"
 libretro_mame139_git_url="https://github.com/libretro/mame2010-libretro.git"
 libretro_mame139_build_rule=none
 # NEED A BUILD RULE: mame139
 
+register_core "mame"
 libretro_mame_name="MAME (git)"
 libretro_mame_git_url="https://github.com/libretro/mame.git"
 libretro_mame_build_rule=none
 # NEED CUSTOM RULE: mame
 
+register_core "ffmpeg"
 libretro_ffmpeg_name="FFmpeg"
 libretro_ffmpeg_git_url="https://github.com/libretro/FFmpeg.git"
 libretro_ffmpeg_build_subdir="libretro"
 libretro_ffmpeg_build_opengl="optional"
 
+register_core "bsnes_cplusplus98"
 libretro_bsnes_cplusplus98_name="bsnes C++98 (v0.85)"
 libretro_bsnes_cplusplus98_git_url="https://github.com/libretro/bsnes-libretro-cplusplus98.git"
 libretro_bsnes_cplusplus98_build_rule=none
 # NEED CUSTOM RULE: bsnes_cplusplus98
 
+register_core "bsnes_mercury"
 libretro_bsnes_mercury_name="bsnes-mercury"
 libretro_bsnes_mercury_git_url="https://github.com/libretro/bsnes-mercury.git"
 libretro_bsnes_mercury_build_rule=none
 # NEED CUSTOM RULE: bsnes_mercury
 
+register_core "picodrive"
 libretro_picodrive_name="Picodrive"
 libretro_picodrive_git_url="https://github.com/libretro/picodrive.git"
 libretro_picodrive_git_submodules="yes"
 libretro_picodrive_build_makefile="Makefile.libretro"
 
+register_core "tgbdual"
 libretro_tgbdual_name="TGB Dual"
 libretro_tgbdual_git_url="https://github.com/libretro/tgbdual-libretro.git"
-# IMPLICIT
 
+register_core "mupen64plus"
 libretro_mupen64plus_name="Mupen64Plus"
 libretro_mupen64plus_git_url="https://github.com/libretro/mupen64plus-libretro.git"
 libretro_mupen64plus_build_rule=none
 # NEED CUSTOM RULE: mupen64plus
 
+register_core "dinothawr"
 libretro_dinothawr_name="Dinothawr"
 libretro_dinothawr_git_url="https://github.com/libretro/Dinothawr.git"
 libretro_dinothawr_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
+register_core "uae"
 libretro_uae_name="UAE"
 libretro_uae_git_url="https://github.com/libretro/libretro-uae.git"
 libretro_uae_build_rule=none
 # NEED A BUILD RULE: uae
 
+register_core "3dengine"
 libretro_3dengine_name="3DEngine"
 libretro_3dengine_git_url="https://github.com/libretro/libretro-3dengine.git"
 libretro_3dengine_build_opengl=yes
 
+register_core "remotejoy"
 libretro_remotejoy_name="RemoteJoy"
 libretro_remotejoy_git_url="https://github.com/libretro/libretro-remotejoy.git"
 libretro_remotejoy_build_rule=none
 # NEED A BUILD RULE: remotejoy
 
+register_core "bluemsx"
 libretro_bluemsx_name="blueMSX"
 libretro_bluemsx_git_url="https://github.com/libretro/blueMSX-libretro.git"
 libretro_bluemsx_build_makefile="Makefile.libretro"
 
+register_core "fmsx"
 libretro_fmsx_name="fMSX"
 libretro_fmsx_git_url="https://github.com/libretro/fmsx-libretro.git"
-# IMPLICIT
 
+register_module core "2048"
 libretro_2048_git_url="https://github.com/libretro/libretro-2048.git"
 libretro_2048_build_makefile="Makefile.libretro"
 
+register_module core "vecx"
 libretro_vecx_git_url="https://github.com/libretro/libretro-vecx.git"
 libretro_vecx_build_makefile="Makefile.libretro"
 
+register_core "ppsspp"
 libretro_ppsspp_name="PPSSPP"
 libretro_ppsspp_git_url="https://github.com/libretro/ppsspp.git"
 libretro_ppsspp_git_submodules="yes"
 libretro_ppsspp_build_subdir="libretro"
 libretro_ppsspp_build_opengl="yes"
 
+register_core "prosystem"
 libretro_prosystem_name="ProSystem"
 libretro_prosystem_git_url="https://github.com/libretro/prosystem-libretro.git"
-# IMPLICIT
 
+register_core "o2em"
 libretro_o2em_name="O2EM"
 libretro_o2em_git_url="https://github.com/libretro/libretro-o2em.git"
-# IMPLICIT
 
+register_core "4do"
 libretro_4do_name="4DO"
 libretro_4do_git_url="https://github.com/libretro/4do-libretro.git"
-# IMPLICIT
 
+register_core "catsfc"
 libretro_catsfc_name="CATSFC"
 libretro_catsfc_git_url="https://github.com/libretro/CATSFC-libretro.git"
-# IMPLICIT
 
+register_core "stonesoup"
 libretro_stonesoup_name="Dungeon Crawl Stone Soup"
 libretro_stonesoup_git_url="https://github.com/libretro/crawl-ref.git"
 libretro_stonesoup_git_submodules="clone"
 libretro_stonesoup_build_subdir="crawl-ref"
 libretro_stonesoup_build_makefile="Makefile.libretro"
 
+register_core "hatari"
 libretro_hatari_name="Hatari"
 libretro_hatari_git_url="https://github.com/libretro/hatari.git"
 libretro_hatari_build_makefile="Makefile.libretro"
 
+register_core "tempgba"
 libretro_tempgba_name="TempGBA"
 libretro_tempgba_git_url="https://github.com/libretro/TempGBA-libretro.git"
 libretro_tempgba_build_rule=none
 # NEED A BUILD RULE: tempgba
 
+register_core "gpsp"
 libretro_gpsp_name="gpSP"
 libretro_gpsp_git_url="https://github.com/libretro/gpsp.git"
-# IMPLICIT
 
+register_core "emux"
 libretro_emux_name="Emux"
 libretro_emux_git_url="https://github.com/libretro/emux.git"
 libretro_emux_build_rule=none
 # NEED CUSTOM RULE: emux
 
+register_core "fuse"
 libretro_fuse_name="Fuse"
 libretro_fuse_git_url="https://github.com/libretro/fuse-libretro.git"
 libretro_fuse_build_makefile="Makefile.libretro"
 libretro_fuse_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
+register_core "gw"
 libretro_gw_name="Game & Watch"
 libretro_gw_git_url="https://github.com/libretro/gw-libretro.git"
 libretro_gw_git_submodules="yes"
 libretro_gw_build_makefile="Makefile.libretro"
 
+register_core "lutro"
 libretro_lutro_name="Lutro"
 libretro_lutro_git_url="https://github.com/libretro/libretro-lutro.git"
 libretro_lutro_build_makefile="Makefile"

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -2,6 +2,7 @@
 
 libretro_bsnes_name="bsnes/higan"
 libretro_bsnes_git_url="https://github.com/libretro/bsnes-libretro.git"
+libretro_bsnes_build_rule=none
 # NEED CUSTOM RULE: bsnes
 
 libretro_snes9x_name="SNES9x"
@@ -39,6 +40,7 @@ libretro_handy_git_url="https://github.com/libretro/libretro-handy.git"
 
 libretro_bnes_name="bnes/higan"
 libretro_bnes_git_url="https://github.com/libretro/bnes-libretro.git"
+libretro_bnes_build_rule=none
 # NEED CUSTOM RULE: bnes
 
 libretro_fceumm_name="FCEUmm"
@@ -150,10 +152,12 @@ libretro_mame078_git_url="https://github.com/libretro/mame2003-libretro.git"
 
 libretro_mame139_name="MAME 2010 (0.139)"
 libretro_mame139_git_url="https://github.com/libretro/mame2010-libretro.git"
+libretro_mame139_build_rule=none
 # NEED A BUILD RULE: mame139
 
 libretro_mame_name="MAME (git)"
 libretro_mame_git_url="https://github.com/libretro/mame.git"
+libretro_mame_build_rule=none
 # NEED CUSTOM RULE: mame
 
 libretro_ffmpeg_name="FFmpeg"
@@ -163,10 +167,12 @@ libretro_ffmpeg_build_opengl="optional"
 
 libretro_bsnes_cplusplus98_name="bsnes C++98 (v0.85)"
 libretro_bsnes_cplusplus98_git_url="https://github.com/libretro/bsnes-libretro-cplusplus98.git"
+libretro_bsnes_cplusplus98_build_rule=none
 # NEED CUSTOM RULE: bsnes_cplusplus98
 
 libretro_bsnes_mercury_name="bsnes-mercury"
 libretro_bsnes_mercury_git_url="https://github.com/libretro/bsnes-mercury.git"
+libretro_bsnes_mercury_build_rule=none
 # NEED CUSTOM RULE: bsnes_mercury
 
 libretro_picodrive_name="Picodrive"
@@ -180,6 +186,7 @@ libretro_tgbdual_git_url="https://github.com/libretro/tgbdual-libretro.git"
 
 libretro_mupen64plus_name="Mupen64Plus"
 libretro_mupen64plus_git_url="https://github.com/libretro/mupen64plus-libretro.git"
+libretro_mupen64plus_build_rule=none
 # NEED CUSTOM RULE: mupen64plus
 
 libretro_dinothawr_name="Dinothawr"
@@ -188,6 +195,7 @@ libretro_dinothawr_build_platform="$FORMAT_COMPILER_TARGET_ALT"
 
 libretro_uae_name="UAE"
 libretro_uae_git_url="https://github.com/libretro/libretro-uae.git"
+libretro_uae_build_rule=none
 # NEED A BUILD RULE: uae
 
 libretro_3dengine_name="3DEngine"
@@ -196,6 +204,7 @@ libretro_3dengine_build_opengl=yes
 
 libretro_remotejoy_name="RemoteJoy"
 libretro_remotejoy_git_url="https://github.com/libretro/libretro-remotejoy.git"
+libretro_remotejoy_build_rule=none
 # NEED A BUILD RULE: remotejoy
 
 libretro_bluemsx_name="blueMSX"
@@ -246,6 +255,7 @@ libretro_hatari_build_makefile="Makefile.libretro"
 
 libretro_tempgba_name="TempGBA"
 libretro_tempgba_git_url="https://github.com/libretro/TempGBA-libretro.git"
+libretro_tempgba_build_rule=none
 # NEED A BUILD RULE: tempgba
 
 libretro_gpsp_name="gpSP"
@@ -254,6 +264,7 @@ libretro_gpsp_git_url="https://github.com/libretro/gpsp.git"
 
 libretro_emux_name="Emux"
 libretro_emux_git_url="https://github.com/libretro/emux.git"
+libretro_emux_build_rule=none
 # NEED CUSTOM RULE: emux
 
 libretro_fuse_name="Fuse"

--- a/script-modules/modules.sh
+++ b/script-modules/modules.sh
@@ -1,0 +1,23 @@
+# vim: set ts=3 sw=3 noet ft=sh : bash
+
+register_module() {
+	case "$1" in
+		core|devkit|player)
+			if [ -n "$2" ]; then
+				eval "libretro_${1}s=\"\$libretro_${1}s $2::\""
+				echo "Registering $1: $2"
+			else
+				echo "register_module:Trying to register a $1 without a name"
+				exit 1
+			fi
+			;;
+		*)
+			echo "register_module:Unknown module type \"$1\""
+			exit 1
+			;;
+	esac
+}
+
+register_core() {
+	register_module core $@
+}


### PR DESCRIPTION
Still have to edit libretro-build.sh though.  If you're looking at the new modules.sh and wondering what's the deal with the ::, it's for building and not implemented yet.

Also added a "none" build target.  Modules that are defined currently use that if they don't have a build rule at all, or if they need a custom rule I haven't written yet.
