### PR TITLE
Fix to libretro-fetch.sh

### DIFF
--- a/libretro-build.sh
+++ b/libretro-build.sh
@@ -169,8 +169,8 @@ else
 	if [ $FORMAT_COMPILER_TARGET != "ios" ]; then
 		# These don't currently build on iOS
 		build_libretro_bnes
-		build_libretro_core ffmpeg
-		build_libretro_core ppsspp
+		libretro_build_core ffmpeg
+		libretro_build_core ppsspp
 	fi
 	libretro_build_core o2em
 	libretro_build_core hatari

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -328,23 +328,23 @@ libretro_lutro_name="Lutro"
 libretro_lutro_git_url="https://github.com/libretro/libretro-lutro.git"
 libretro_lutro_build_makefile="Makefile"
 
-register_core "lutro-platformer"
+register_core "lutro_platformer"
 libretro_lutro_platformer_name="Lutro-Platformer"
 libretro_lutro_platformer_git_url="https://github.com/libretro/lutro-platformer.git"
 
-register_core "lutro-tetris"
+register_core "lutro_tetris"
 libretro_lutro_tetris_name="Lutro-tetris"
 libretro_lutro_tetris_git_url="https://github.com/libretro/lutro-tetris.git"
 
-register_core "lutro-snake"
+register_core "lutro_snake"
 libretro_lutro_snake_name="Lutro-snake"
 libretro_lutro_snake_git_url="https://github.com/libretro/lutro-snake.git"
 
-register_core "lutro-iyfct"
+register_core "lutro_iyfct"
 libretro_lutro_iyfct_name="Lutro-iyfct"
 libretro_lutro_iyfct_git_url="https://github.com/libretro/lutro-iyfct.git"
 
-register_core "lutro-game-of-life"
+register_core "lutro_game_of_life"
 libretro_lutro_game_of_life_name="Lutro-Game-of-Life"
 libretro_lutro_game_of_life_git_url="https://github.com/libretro/lutro-game-of-life.git"
 


### PR DESCRIPTION
@twinaphex this fixes libretro-fetch.sh the register_core line needs to use _ instead of - in the names.

@iKarith something is wrong with libretro-build.sh. I think it has to do with https://github.com/libretro/libretro-super/commit/c5dba10034050048d166947e2b813fb11e68c84d but to complicated for me to figure out.