### PR TITLE
"Faster" for loop is only "faster" because it was broken

### DIFF
--- a/libretro-fetch.sh
+++ b/libretro-fetch.sh
@@ -76,7 +76,7 @@ libretro_fetch() {
 			fi
 
 			[ "$module_dir" != "." ] && echo_cmd "mkdir -p \"$WORKDIR/$module_dir\""
-			for i in seq 0 $num_git_urls; do
+			for (( i=0; i < $num_git_urls; ++i )); do
 				eval "git_url=\$libretro_${1}_mgit_url_$i"
 				eval "git_subdir=\$libretro_${1}_mgit_dir_$i"
 				eval "git_submodules=\$libretro_${1}_mgit_submodules_$i"

--- a/libretro-fetch.sh
+++ b/libretro-fetch.sh
@@ -69,7 +69,7 @@ libretro_fetch() {
 			local git_submodules
 			local i
 
-			eval "num_git_urls=\$libretro_${1}_mgit_urls"
+			eval "num_git_urls=\${libretro_${1}_mgit_urls:-0}"
 			if [ "$num_git_urls" -lt 1 ]; then
 				echo "Cannot fetch \"$num_git_urls\" multiple git URLs"
 				return 1

--- a/script-modules/modules.sh
+++ b/script-modules/modules.sh
@@ -5,7 +5,6 @@ register_module() {
 		core|devkit|player)
 			if [ -n "$2" ]; then
 				eval "libretro_${1}s=\"\$libretro_${1}s $2::\""
-				echo "Registering $1: $2"
 			else
 				echo "register_module:Trying to register a $1 without a name"
 				exit 1


### PR DESCRIPTION
```bash
for i in seq 0 $num_git_urls; do		
```

fails because:

1. We need i to expand to "0", "1", "2", and "3".
2. Instead, i is expanded to "seq", "0", and "4".
3. Even ``$(seq 0 $num_git_urls)`` doesn't expand to what we want.  It would seem that you could rewrite it so that mgit URLs are numbered 1 to 4, however this illustrates why I didn't do that in the first place:

```
tjcarter@amaya:~$ seq 4
1
2
3
4
tjcarter@amaya:~$ seq ""
1
0
```

In costrast:

```
tjcarter@amaya:~$ for ((i=0; i < 4; ++i)); do echo $i; done
0
1
2
3
tjcarter@amaya:~$ for ((i=0; i < ""; ++i)); do echo $i; done
-bash: ((: i < : syntax error: operand expected (error token is " ")
```

Which is at least an error rather than running git with something bogus.  Actually better still than what's in this PR would be for the expansion to default to -1 which would simply do nothing.  That is what I think I will do.