### PR TITLE
SEE COMMENTS

### DIFF
--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -601,6 +601,30 @@ build_libretro_lutro() {
 ########## LEGACY RULES
 # TODO: Port these to modern rules
 
+build_libretro_bnes() {
+	build_dir="$WORKDIR/libretro-bnes"
+
+	if build_should_skip bnes "$build_dir"; then
+		echo "Core bnes is already built, skipping..."
+		return
+	fi
+
+	if [ -d "$build_dir" ]; then
+		echo '=== Building bNES ==='
+		echo_cmd "cd \"$build_dir\""
+
+		mkdir -p obj
+		if [ -z "$NOCLEAN" ]; then
+			echo_cmd "$MAKE -f Makefile \"-j$JOBS\" clean" || die 'Failed to clean bNES'
+		fi
+		echo_cmd "$MAKE -f Makefile $COMPILER \"-j$JOBS\" compiler=\"${CXX11}\"" || die 'Failed to build bNES'
+		copy_core_to_dist "bnes"
+		build_save_revision $? "bnes"
+	else
+		echo 'bNES not fetched, skipping ...'
+	fi
+}
+
 build_libretro_bsnes_modern() {
 	build_dir="$WORKDIR/libretro-$1"
 	if [ -d "$build_dir" ]; then
@@ -636,29 +660,6 @@ build_libretro_bsnes() {
 
 	build_libretro_bsnes_modern "bsnes"
 	build_save_revision $? bsnes
-}
-build_libretro_bnes() {
-	build_dir="$WORKDIR/libretro-bnes"
-
-	if build_should_skip bnes "$build_dir"; then
-		echo "Core bnes is already built, skipping..."
-		return
-	fi
-
-	if [ -d "$build_dir" ]; then
-		echo '=== Building bNES ==='
-		echo_cmd "cd \"$build_dir\""
-
-		mkdir -p obj
-		if [ -z "$NOCLEAN" ]; then
-			echo_cmd "$MAKE -f Makefile \"-j$JOBS\" clean" || die 'Failed to clean bNES'
-		fi
-		echo_cmd "$MAKE -f Makefile $COMPILER \"-j$JOBS\" compiler=\"${CXX11}\"" || die 'Failed to build bNES'
-		copy_core_to_dist "bnes"
-		build_save_revision $? "bnes"
-	else
-		echo 'bNES not fetched, skipping ...'
-	fi
 }
 
 build_libretro_bsnes_cplusplus98() {

--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -296,7 +296,15 @@ libretro_build_core() {
 
 			echo "Building ${1}..."
 			build_makefile $1
+			;;
 
+		legacy)
+			eval "core_build_legacy=\$libretro_${1}_build_legacy"
+			if [ -n "$core_build_legacy" ]; then
+				echo "Warning: $1 hasn't been ported to a modern build rule yet."
+				echo "         Will build it using legacy \"$core_build_legacy\"..."
+				$core_build_legacy
+			fi
 			;;
 		none)
 			echo "Don't have a build rule for $1, skipping..."

--- a/libretro-build-ngc.sh
+++ b/libretro-build-ngc.sh
@@ -29,27 +29,28 @@ MAKE=make
 if [ $1 ]; then
 	$1
 else
-	build_libretro_bluemsx
-	build_libretro_fmsx
-	build_libretro_beetle_lynx
-	build_libretro_beetle_gba
-	build_libretro_beetle_ngp
-	build_libretro_beetle_pce_fast
-	build_libretro_beetle_supergrafx
-	build_libretro_beetle_pcfx
-	build_libretro_beetle_vb
-	build_libretro_beetle_wswan
-	build_libretro_beetle_bsnes
-	build_libretro_snes9x_next
-	build_libretro_genesis_plus_gx
-	build_libretro_fba
-	build_libretro_vba_next
-	build_libretro_fceumm
-	build_libretro_gambatte
-	build_libretro_nx
-	build_libretro_prboom
-	build_libretro_quicknes
-	build_libretro_nestopia
-	build_libretro_tyrquake
-	#build_libretro_yabause
+	libretro_build_core bluemsx
+	libretro_build_core fceumm
+	libretro_build_core fmsx
+	libretro_build_core gambatte
+	libretro_build_core genesis_plus_gx
+	libretro_build_core mednafen_bsnes
+	libretro_build_core mednafen_gba
+	libretro_build_core mednafen_lynx
+	libretro_build_core mednafen_ngp
+	libretro_build_core mednafen_pce_fast
+	libretro_build_core mednafen_pcfx
+	libretro_build_core mednafen_supergrafx
+	libretro_build_core mednafen_vb
+	libretro_build_core mednafen_wswan
+	libretro_build_core nestopia
+	libretro_build_core nxengine
+	libretro_build_core prboom
+	libretro_build_core quicknes
+	libretro_build_core snes9x_next
+	libretro_build_core tyrquake
+	libretro_build_core vba_next
+	#libretro_build_core yabause
+
+	build_libretro_fba # not in libretro-build-common!
 fi

--- a/libretro-build-ps3.sh
+++ b/libretro-build-ps3.sh
@@ -18,28 +18,28 @@ MAKE=make
 if [ $1 ]; then
 	$1
 else
-	build_libretro_beetle_lynx
-	build_libretro_beetle_gba
-	build_libretro_beetle_ngp
-	build_libretro_beetle_pce_fast
-	build_libretro_beetle_supergrafx
-	build_libretro_beetle_pcfx
-	build_libretro_beetle_vb
-	build_libretro_beetle_wswan
-	build_libretro_mednafen_psx
-	build_libretro_beetle_bsnes
-	build_libretro_snes9x_next
-	build_libretro_genesis_plus_gx
-	build_libretro_fb_alpha
-	build_libretro_vba_next
-	build_libretro_fceumm
-	build_libretro_gambatte
-	build_libretro_nx
-	build_libretro_prboom
-	build_libretro_stella
-	build_libretro_quicknes
-	build_libretro_nestopia
-	build_libretro_tyrquake
-	build_libretro_mame078
-	build_libretro_handy
+	libretro_build_core fb_alpha
+	libretro_build_core fceumm
+	libretro_build_core gambatte
+	libretro_build_core genesis_plus_gx
+	libretro_build_core handy
+	libretro_build_core mame078
+	libretro_build_core mednafen_bsnes
+	libretro_build_core mednafen_gba
+	libretro_build_core mednafen_lynx
+	libretro_build_core mednafen_ngp
+	libretro_build_core mednafen_pce_fast
+	libretro_build_core mednafen_pcfx
+	libretro_build_core mednafen_psx
+	libretro_build_core mednafen_supergrafx
+	libretro_build_core mednafen_vb
+	libretro_build_core mednafen_wswan
+	libretro_build_core nestopia
+	libretro_build_core nxengine
+	libretro_build_core prboom
+	libretro_build_core quicknes
+	libretro_build_core snes9x_next
+	libretro_build_core stella
+	libretro_build_core tyrquake
+	libretro_build_core vba_next
 fi

--- a/libretro-build-psp1.sh
+++ b/libretro-build-psp1.sh
@@ -18,37 +18,37 @@ MAKE=make
 if [ $1 ]; then
 	$1
 else
-	build_libretro_2048
-	build_libretro_bluemsx
-	build_libretro_fmsx
-	build_libretro_beetle_lynx
-	build_libretro_beetle_gba
-	build_libretro_beetle_ngp
-	build_libretro_beetle_pce_fast
-	build_libretro_beetle_supergrafx
-	build_libretro_beetle_pcfx
-	build_libretro_beetle_vb
-	build_libretro_beetle_wswan
-	build_libretro_beetle_bsnes
-	build_libretro_mednafen
-	build_libretro_snes9x_next
-	build_libretro_genesis_plus_gx
-	#build_libretro_fba_full
+	libretro_build_core 2048
+	libretro_build_core bluemsx
+	libretro_build_core fceumm
+	libretro_build_core fmsx
+	libretro_build_core gambatte
+	libretro_build_core genesis_plus_gx
+	libretro_build_core handy
+	#libretro_build_core mame078
+	libretro_build_core mednafen
+	libretro_build_core mednafen_bsnes
+	libretro_build_core mednafen_gba
+	libretro_build_core mednafen_lynx
+	libretro_build_core mednafen_ngp
+	libretro_build_core mednafen_pce_fast
+	libretro_build_core mednafen_pcfx
+	libretro_build_core mednafen_supergrafx
+	libretro_build_core mednafen_vb
+	libretro_build_core mednafen_wswan
+	libretro_build_core nestopia
+	libretro_build_core nxengine
+	libretro_build_core o2em
+	libretro_build_core picodrive
+	libretro_build_core prboom
+	libretro_build_core prosystem
+	libretro_build_core quicknes
+	libretro_build_core snes9x_next
+	libretro_build_core stella
+	libretro_build_core tgbdual
+	libretro_build_core tyrquake
+	libretro_build_core vba_next
+	libretro_build_core vecx
+
 	build_libretro_fba_cps2
-	build_libretro_vba_next
-	build_libretro_fceumm
-	build_libretro_gambatte
-	build_libretro_nx
-	build_libretro_prboom
-	build_libretro_stella
-	build_libretro_quicknes
-	build_libretro_nestopia
-	build_libretro_tyrquake
-	#build_libretro_mame078
-	build_libretro_picodrive
-	build_libretro_handy
-	build_libretro_vecx
-	build_libretro_tgbdual
-	build_libretro_prosystem
-	build_libretro_o2em
 fi

--- a/libretro-build-qnx.sh
+++ b/libretro-build-qnx.sh
@@ -22,57 +22,57 @@ CXX11="QCC -Vgcc_ntoarmv7le"
 if [ $1 ]; then
 	$1
 else
-	build_libretro_2048
-	build_libretro_4do
-	build_libretro_bluemsx
-	build_libretro_fmsx
-	build_libretro_bsnes_cplusplus98
-	#build_libretro_bsnes
-	#build_libretro_bsnes_mercury
-	build_libretro_beetle_lynx
-	build_libretro_beetle_gba
-	build_libretro_beetle_pce_fast
-	build_libretro_beetle_supergrafx
-	build_libretro_beetle_pcfx
-	build_libretro_beetle_vb
-	build_libretro_beetle_wswan
-	build_libretro_mednafen_psx
-	build_libretro_beetle_snes
-	build_libretro_catsfc
-	build_libretro_snes9x
-	build_libretro_snes9x_next
-	build_libretro_genesis_plus_gx
-	build_libretro_fb_alpha
-	build_libretro_vbam
-	build_libretro_vba_next
-	build_libretro_fceumm
-	build_libretro_gambatte
-	#build_libretro_meteor
-	build_libretro_nx
-	build_libretro_prboom
-	build_libretro_stella
-	build_libretro_quicknes
-	build_libretro_nestopia
-	build_libretro_tyrquake
-	build_libretro_mame078
-	#build_libretro_mame
-	build_libretro_dosbox
-	build_libretro_scummvm
-	build_libretro_picodrive
-	build_libretro_handy
-	#build_libretro_desmume
-	#build_libretro_yabause
-	build_libretro_pcsx_rearmed
-	build_libretro_vecx
-	build_libretro_tgbdual
-	build_libretro_prosystem
-	#build_libretro_dinothawr
-	build_libretro_virtualjaguar
-	build_libretro_mupen64
-	build_libretro_3dengine
-	#build_libretro_bnes
-	#build_libretro_ffmpeg
-	#build_libretro_ppsspp
-	build_libretro_o2em
-	build_libretro_gpsp
+	libretro_build_core 2048
+	libretro_build_core 3dengine
+	libretro_build_core 4do
+	libretro_build_core bluemsx
+	#libretro_build_core bnes
+	#libretro_build_core bsnes
+	libretro_build_core bsnes_cplusplus98
+	#libretro_build_core bsnes_mercury
+	libretro_build_core catsfc
+	#libretro_build_core desmume
+	#libretro_build_core dinothawr
+	libretro_build_core dosbox
+	libretro_build_core fb_alpha
+	#libretro_build_core ffmpeg
+	libretro_build_core fceumm
+	libretro_build_core fmsx
+	libretro_build_core gambatte
+	libretro_build_core genesis_plus_gx
+	libretro_build_core gpsp
+	libretro_build_core handy
+	#libretro_build_core mame
+	libretro_build_core mame078
+	libretro_build_core mednafen_gba
+	libretro_build_core mednafen_lynx
+	libretro_build_core mednafen_pce_fast
+	libretro_build_core mednafen_pcfx
+	libretro_build_core mednafen_psx
+	libretro_build_core mednafen_snes
+	libretro_build_core mednafen_supergrafx
+	libretro_build_core mednafen_vb
+	libretro_build_core mednafen_wswan
+	#libretro_build_core meteor
+	libretro_build_core mupen64plus
+	libretro_build_core nestopia
+	libretro_build_core nxengine
+	libretro_build_core o2em
+	libretro_build_core pcsx_rearmed
+	libretro_build_core picodrive
+	#libretro_build_core ppsspp
+	libretro_build_core prboom
+	libretro_build_core prosystem
+	libretro_build_core quicknes
+	libretro_build_core scummvm
+	libretro_build_core snes9x
+	libretro_build_core snes9x_next
+	libretro_build_core stella
+	libretro_build_core tgbdual
+	libretro_build_core tyrquake
+	libretro_build_core vba_next
+	libretro_build_core vbam
+	libretro_build_core vecx
+	libretro_build_core virtualjaguar
+	#libretro_build_core yabause
 fi

--- a/libretro-build-wii.sh
+++ b/libretro-build-wii.sh
@@ -29,28 +29,29 @@ MAKE=make
 if [ $1 ]; then
 	$1
 else
-	build_libretro_bluemsx
-	build_libretro_fmsx
-	build_libretro_beetle_lynx
-	build_libretro_beetle_gba
-	build_libretro_beetle_ngp
-	build_libretro_beetle_pce_fast
-	build_libretro_beetle_supergrafx
-	build_libretro_beetle_pcfx
-	build_libretro_beetle_psx
-	build_libretro_beetle_vb
-	build_libretro_beetle_wswan
-	build_libretro_beetle_bsnes
-	build_libretro_snes9x_next
-	build_libretro_genesis_plus_gx
-	build_libretro_fba
-	build_libretro_vba_next
-	build_libretro_fceumm
-	build_libretro_gambatte
-	build_libretro_nx
-	build_libretro_prboom
-	build_libretro_quicknes
-	build_libretro_nestopia
-	build_libretro_tyrquake
-	#build_libretro_yabause
+	libretro_build_core bluemsx
+	libretro_build_core fceumm
+	libretro_build_core fmsx
+	libretro_build_core gambatte
+	libretro_build_core genesis_plus_gx
+	libretro_build_core mednafen_bsnes
+	libretro_build_core mednafen_gba
+	libretro_build_core mednafen_lynx
+	libretro_build_core mednafen_ngp
+	libretro_build_core mednafen_pce_fast
+	libretro_build_core mednafen_pcfx
+	libretro_build_core mednafen_psx
+	libretro_build_core mednafen_supergrafx
+	libretro_build_core mednafen_vb
+	libretro_build_core mednafen_wswan
+	libretro_build_core nestopia
+	libretro_build_core nxengine
+	libretro_build_core prboom
+	libretro_build_core quicknes
+	libretro_build_core snes9x_next
+	libretro_build_core tyrquake
+	libretro_build_core vba_next
+	#libretro_build_core yabause
+
+	build_libretro_fba # not in libretro-build-common!
 fi

--- a/libretro-build.sh
+++ b/libretro-build.sh
@@ -126,12 +126,17 @@ build_default_cores() {
 	# Nothing past here supports theos
 	[ "$platform" = "theos_ios" ] && return
 
+	libretro_build_core bsnes
+	libretro_build_core bsnes_cplusplus98
+	libretro_build_core bsnes_mercury
 	libretro_build_core dinothawr
+	libretro_build_core emux
 	libretro_build_core fuse
 	libretro_build_core genesis_plus_gx
 	libretro_build_core gw
 	libretro_build_core hatari
 	libretro_build_core lutro
+	libretro_build_core mame
 	libretro_build_core mame078
 	libretro_build_core mednafen_gba
 	libretro_build_core mednafen_lynx
@@ -143,17 +148,11 @@ build_default_cores() {
 	libretro_build_core mednafen_supergrafx
 	libretro_build_core mednafen_vb
 	libretro_build_core mednafen_wswan
+	libretro_build_core mupen64plus
 	libretro_build_core picodrive
 	libretro_build_core scummvm
 	libretro_build_core stonesoup
 	libretro_build_core yabause
-
-	build_libretro_bsnes
-	build_libretro_bsnes_cplusplus98
-	build_libretro_bsnes_mercury
-	build_libretro_emux
-	build_libretro_mame_prerule
-	build_libretro_mupen64
 
 	if [ $platform != "win" ]; then
 		libretro_build_core pcsx_rearmed
@@ -166,7 +165,7 @@ build_default_cores() {
 		libretro_build_core ffmpeg
 		libretro_build_core ppsspp
 
-		build_libretro_bnes
+		libretro_build_core bnes
 	fi
 
 	build_libretro_test

--- a/libretro-build.sh
+++ b/libretro-build.sh
@@ -157,9 +157,6 @@ build_default_cores() {
 	if [ $platform != "win" ]; then
 		libretro_build_core pcsx_rearmed
 	fi
-	if [ "$platform" = "ios" ]; then
-		build_libretro_pcsx_rearmed_interpreter # for non-jailbreak
-	fi
 
 	if [ $platform != "ios" ]; then
 		libretro_build_core ffmpeg

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -110,7 +110,10 @@ libretro_tyrquake_build_makefile="Makefile"
 register_core "pcsx_rearmed" -theos_ios -ngc -ps3 -psp1 -wii
 libretro_pcsx_rearmed_name="PCSX ReARMed"
 libretro_pcsx_rearmed_git_url="https://github.com/libretro/pcsx_rearmed.git"
-libretro_pcsx_rearmed_build_makefile="Makefile.libretro"
+# FIXME: Disabling modern rule so we can build dynarrec and interpreter on iOS
+#libretro_pcsx_rearmed_build_makefile="Makefile.libretro"
+libretro_pcsx_rearmed_build_rule=legacy
+libretro_pcsx_rearmed_build_legacy=build_libretro_pcsx_rearmed
 
 register_core "mednafen_gba" -theos_ios
 libretro_mednafen_gba_name="Mednafen/Beetle GBA"

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -3,7 +3,8 @@
 register_core "bsnes" -theos_ios -ngc -ps3 -psp1 -qnx -wii
 libretro_bsnes_name="bsnes/higan"
 libretro_bsnes_git_url="https://github.com/libretro/bsnes-libretro.git"
-libretro_bsnes_build_rule=none # NEED CUSTOM RULE
+libretro_bsnes_build_rule=legacy
+libretro_bsnes_build_legacy=build_libretro_bsnes
 
 register_core "snes9x" -ngc -ps3 -psp1 -wii
 libretro_snes9x_name="SNES9x"
@@ -183,7 +184,8 @@ libretro_mame139_build_rule=none # NEED A BUILD RULE
 register_core "mame" -theos_ios -ngc -ps3 -psp1 -qnx -wii
 libretro_mame_name="MAME (git)"
 libretro_mame_git_url="https://github.com/libretro/mame.git"
-libretro_mame_build_rule=none # NEED CUSTOM RULE
+libretro_mame_build_rule=legacy
+libretro_mame_build_legacy=build_libretro_mame_prerule
 
 register_core "ffmpeg" -ios -theos_ios -osx -ngc -ps3 -psp1 -qnx -wii
 libretro_ffmpeg_name="FFmpeg"
@@ -194,12 +196,14 @@ libretro_ffmpeg_build_opengl="optional"
 register_core "bsnes_cplusplus98" -theos_ios -ngc -ps3 -psp1 -wii
 libretro_bsnes_cplusplus98_name="bsnes C++98 (v0.85)"
 libretro_bsnes_cplusplus98_git_url="https://github.com/libretro/bsnes-libretro-cplusplus98.git"
-libretro_bsnes_cplusplus98_build_rule=none # NEED CUSTOM RULE
+libretro_bsnes_cplusplus98_build_rule=legacy
+libretro_bsnes_cplusplus98_build_legacy=build_libretro_bsnes_cplusplus98
 
 register_core "bsnes_mercury" -theos_ios -ngc -ps3 -psp1 -qnx -wii
 libretro_bsnes_mercury_name="bsnes-mercury"
 libretro_bsnes_mercury_git_url="https://github.com/libretro/bsnes-mercury.git"
-libretro_bsnes_mercury_build_rule=none # NEED CUSTOM RULE
+libretro_bsnes_mercury_build_rule=legacy
+libretro_bsnes_mercury_build_legacy=build_libretro_bsnes_mercury
 
 register_core "picodrive" -theos_ios -ngc -ps3 -wii
 libretro_picodrive_name="Picodrive"
@@ -214,7 +218,8 @@ libretro_tgbdual_git_url="https://github.com/libretro/tgbdual-libretro.git"
 register_core "mupen64plus" -theos_ios -ngc -ps3 -psp1 -wii
 libretro_mupen64plus_name="Mupen64Plus"
 libretro_mupen64plus_git_url="https://github.com/libretro/mupen64plus-libretro.git"
-libretro_mupen64plus_build_rule=none # NEED CUSTOM RULE
+libretro_mupen64plus_build_rule=legacy
+libretro_mupen64plus_build_legacy=build_libretro_mupen64
 
 register_core "dinothawr" -theos_ios -ngc -ps3 -psp1 -qnx -wii
 libretro_dinothawr_name="Dinothawr"
@@ -300,7 +305,8 @@ libretro_gpsp_git_url="https://github.com/libretro/gpsp.git"
 register_core "emux" -theos_ios -ngc -ps3 -psp1 -qnx -wii
 libretro_emux_name="Emux"
 libretro_emux_git_url="https://github.com/libretro/emux.git"
-libretro_emux_build_rule=none # NEED CUSTOM RULE
+libretro_emux_build_rule=legacy
+libretro_emux_build_legacy=build_libretro_emux
 
 register_core "fuse" -theos_ios -ngc -ps3 -psp1 -qnx -wii
 libretro_fuse_name="Fuse"

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -53,7 +53,8 @@ libretro_cap32_build_makefile="Makefile"
 register_core "bnes" -ios -theos_ios -ngc -ps3 -psp1 -qnx -wii
 libretro_bnes_name="bnes/higan"
 libretro_bnes_git_url="https://github.com/libretro/bnes-libretro.git"
-libretro_bnes_build_rule=none # NEED CUSTOM RULE
+libretro_bnes_build_rule=legacy
+libretro_bnes_build_legacy=build_libretro_bnes
 
 register_core "fceumm"
 libretro_fceumm_name="FCEUmm"


### PR DESCRIPTION
PR contains several things.  So far:

* New build rule "legacy" so that old legacy build functions not ported to the new rule model can pretend that they are (within limits)
* Replace most (not quite all) build_libretro_<foo> calls with modern rule calls using the above feature
* Alphabetize the cores in the build scripts (it will help when merging them)
* Remove legacy PCSX ReARMed Interpreter rule (sort of)
* REVERT dynarec-using PCSX ReARMed rule to use a legacy build rule
* Make new PCSX ReARMed rule install the interpreter as well (see http://git.io/pPfR for that change)

Porting the new PCSX ReARMed legacy rule requires that I first add support for:

* Modules that produce multiple cores (also needed for emux, bsnes, mame)
* Modules that need to specify custom makefile arguments (also needed for mupen64plus, mame)
* (To do it right) Modules that need to run make more than once (also needed for mame, especially when cross-compiling)
* Platform-specific rule overrides (also needed for fba)

Consequently, add all of those features and I can remove the legacy rule.  :)