### PR TITLE
MANE is now the only legacy rule

### DIFF
--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -478,31 +478,3 @@ build_libretro_mame_prerule() {
 
 	build_save_revision $ret mame
 }
-
-build_libretro_pcsx_rearmed() {
-	build_dir="$WORKDIR/libretro-pcsx_rearmed"
-
-	if build_should_skip "pcsx_rearmed" "$build_dir"; then
-		echo "Core pcsx_rearmed is already built, skipping..."
-		return
-	fi
-
-	if [ -d "$build_dir" ]; then
-		echo '=== Building PCSX ReARMed ==='
-		echo_cmd "cd \"$build_dir\""
-
-		if [ -z "$NOCLEAN" ]; then
-			echo_cmd "$MAKE -f Makefile.libretro platform=\"$FORMAT_COMPILER_TARGET\" \"-j$JOBS\" clean" || die 'Failed to clean PCSX ReARMed'
-		fi
-		echo_cmd "$MAKE -f Makefile.libretro platform=\"$FORMAT_COMPILER_TARGET\" $COMPILER \"-j$JOBS\"" || die 'Failed to build PCSX ReARMed'
-		copy_core_to_dist "pcsx_rearmed"
-		ret=$?
-		if [ "$platform" = "ios" ]; then
-			copy_core_to_dist "pcsx_rearmed_interpreter"
-			ret=$?
-		fi
-		build_save_revision $ret "pcsx_rearmed"
-	else
-		echo 'PCSX ReARMed not fetched, skipping ...'
-	fi
-}

--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -273,7 +273,7 @@ libretro_build_core() {
 	case "$core_build_rule" in
 		generic_makefile)
 			for a in configure preclean prebuild prepkg; do
-				if [ "$(type -f libretro_${1}_build_$a)" = "function" ]; then
+				if [ "$(type -t libretro_${1}_build_$a 2> /dev/null)" = "function" ]; then
 					eval "core_build_$a=libretro_${1}_build_$a"
 				else
 					eval "core_build_$a="

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -110,10 +110,12 @@ libretro_tyrquake_build_makefile="Makefile"
 register_core "pcsx_rearmed" -theos_ios -ngc -ps3 -psp1 -wii
 libretro_pcsx_rearmed_name="PCSX ReARMed"
 libretro_pcsx_rearmed_git_url="https://github.com/libretro/pcsx_rearmed.git"
-# FIXME: Disabling modern rule so we can build dynarrec and interpreter on iOS
-#libretro_pcsx_rearmed_build_makefile="Makefile.libretro"
-libretro_pcsx_rearmed_build_rule=legacy
-libretro_pcsx_rearmed_build_legacy=build_libretro_pcsx_rearmed
+libretro_pcsx_rearmed_build_makefile="Makefile.libretro"
+libretro_pcsx_rearmed_build_configure() {
+	if [ "$platform" = "ios" ]; then
+		core_build_cores="pcsx_rearmed_interpreter pcsx_rearmed"
+	fi
+}
 
 register_core "mednafen_gba" -theos_ios
 libretro_mednafen_gba_name="Mednafen/Beetle GBA"


### PR DESCRIPTION
I'm still not happy about how I did pcsx_rearmed, but it works until I can go in and improve the process.

That mane doesn't build on iOS is a problem now because it is the last legacy rule. When it works, I can safely obliterate legacy rule support, implement a clean-only command, get rid of the dozen build scripts, come up with a dependency checker (so cores that require perl or Python or whatever don't even try to build unless those tools are installed), and generally make the whole thing much simpler overall.

The home stretch!