### PR TITLE
added line for the zx spectrum database

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -221,6 +221,7 @@ build_libretro_databases() {
 	build_libretro_database "Sega - Mega Drive - Genesis" "rom.crc"
 	build_libretro_database "Sega - PICO" "rom.crc"
 	build_libretro_database "Sega - SG-1000" "rom.crc"
+	build_libretro_database "Sinclair - ZX Spectrum" "rom.crc"
 	build_libretro_database "Sinclair - ZX Spectrum +3" "rom.crc"
 	build_libretro_database "SNK - Neo Geo Pocket" "rom.crc"
 	build_libretro_database "SNK - Neo Geo Pocket Color" "rom.crc"


### PR DESCRIPTION
The shell script could automatically get the list of rdb databases to build from the list of dat files, but I don't know enough bash to do that.