### PR TITLE
Renamed CORENAME of fba_libretro to fba

### DIFF
--- a/recipes/android/cores-android-jni
+++ b/recipes/android/cores-android-jni
@@ -14,7 +14,7 @@ desmume libretro-desmume https://github.com/libretro/desmume.git PROJECT YES GEN
 dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git PROJECT YES GENERIC_JNI Makefile jni
 dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git PROJECT YES GENERIC_JNI Makefile.libretro jni 
 fb_alpha libretro-fba https://github.com/libretro/fba-libretro.git PROJECT YES GENERIC_JNI makefile.libretro svn-current/trunk/projectfiles/libretro-android/jni 
-fba_libretro libretro-fba_new https://github.com/libretro/libretro-fba.git PROJECT YES GENERIC_JNI makefile.libretro jni 
+fba libretro-fba_new https://github.com/libretro/libretro-fba.git PROJECT YES GENERIC_JNI makefile.libretro jni 
 fceumm libretro-fceuumm  https://github.com/libretro/libretro-fceumm.git PROJECT YES GENERIC_JNI Makefile.libretro jni 
 fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git PROJECT YES GENERIC_JNI Makefile jni 
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git PROJECT YES GENERIC_JNI Makefile.libretro libgambatte/libretro/jni 


### PR DESCRIPTION
From looking at the name of the compiled core, I see that the CORE_NAME should have be "fba" and not "fba_libretro". On the buildbot site the core is now called "fba_libretro_libretro_android.so.zip".

This is corrected in this pull request.

Can you remove the core that was generated with wrong name?
