### PR TITLE
[ScummVM] Add .scummvm as a supported extension

### DIFF
--- a/dist/info/scummvm_libretro.info
+++ b/dist/info/scummvm_libretro.info
@@ -1,6 +1,6 @@
 display_name = "ScummVM"
 authors = "SCUMMVMdev"
-supported_extensions = "exe|scum"
+supported_extensions = "exe|scum|scummvm"
 corename = "ScummVM"
 manufacturer = "LucasArts"
 categories = "Game"


### PR DESCRIPTION
This follows `.scummvm` being added as a valid extension at https://github.com/libretro/scummvm/pull/41 .