### PR TITLE
Add building of the Cave Story database

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -253,6 +253,7 @@ build_libretro_databases() {
 	build_libretro_database "MAME2003" "rom.name"
 	build_libretro_database "FB Alpha - Arcade Games" "rom.name"
 	build_libretro_database "DOOM" "rom.crc"
+	build_libretro_database "Cave Story" "rom.crc"
 	build_libretro_database "Quake1" "rom.crc"
 }
 


### PR DESCRIPTION
This will allow launching Cave Story through the RetroArch menu...

![cavestr](https://cloud.githubusercontent.com/assets/25086/15988457/aa063ea2-301f-11e6-98ba-2f757c0243c6.jpg)

## Other PRs
- https://github.com/libretro/libretro-super/pull/291
- https://github.com/libretro/libretro-thumbnails/pull/62

You can download Cave Story from http://www.cavestory.org/download/cave-story.php . Once downloaded, scan the directory, and then you can launch Cave Story from the menu.