### PR TITLE
Use rom.crc for the ScummVM database

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -178,7 +178,7 @@ build_libretro_database() {
 }
 
 build_libretro_databases() {
-	build_libretro_database "ScummVM" "rom.sha1"
+	build_libretro_database "ScummVM" "rom.crc"
 	build_libretro_database "Nintendo - Super Nintendo Entertainment System" "rom.crc"
 	build_libretro_database "Sony - PlayStation" "rom.serial"
 	build_libretro_database "Atari - Jaguar" "rom.crc"


### PR DESCRIPTION
The ScummVM DAT doesn't currently provide SHA1 information, use the `rom.crc` instead.