### PR TITLE
Update Lutro database to scan with rom.name

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -179,7 +179,7 @@ build_libretro_database() {
 
 build_libretro_databases() {
 	build_libretro_database "ScummVM" "rom.crc"
-	build_libretro_database "Lutro" "rom.crc"
+	build_libretro_database "Lutro" "rom.name"
 	build_libretro_database "Nintendo - Super Nintendo Entertainment System" "rom.crc"
 	build_libretro_database "Sony - PlayStation" "rom.serial"
 	build_libretro_database "Atari - Jaguar" "rom.crc"


### PR DESCRIPTION
The CRCs are inconsistent because `.lutro` files are `.zip` files, whose compression can change from system to system. Selecting by `rom.name` will make the rom detection a bit more consistent.