### PR TITLE
Lutro should scan with CRC

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -179,7 +179,7 @@ build_libretro_database() {
 
 build_libretro_databases() {
 	build_libretro_database "ScummVM" "rom.crc"
-	build_libretro_database "Lutro" "rom.name"
+	build_libretro_database "Lutro" "rom.crc"
 	build_libretro_database "Nintendo - Super Nintendo Entertainment System" "rom.crc"
 	build_libretro_database "Sony - PlayStation" "rom.serial"
 	build_libretro_database "Atari - Jaguar" "rom.crc"


### PR DESCRIPTION
Reverts libretro/libretro-super#295

We actually do want to scan the CRCs. I'll update the DAT to read main.lua files. We could add the CRCs for the compiled .lutro files too later on.