### PR TITLE
Add Sega - Saturn Database Building

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -232,6 +232,7 @@ build_libretro_databases() {
 	build_libretro_database "Sega - Master System - Mark III" "rom.crc"
 	build_libretro_database "Sega - Mega Drive - Genesis" "rom.crc"
 	build_libretro_database "Sega - PICO" "rom.crc"
+	build_libretro_database "Sega - Saturn" "rom.crc"
 	build_libretro_database "Sega - SG-1000" "rom.crc"
 	build_libretro_database "Sinclair - ZX Spectrum" "rom.crc"
 	build_libretro_database "Sinclair - ZX Spectrum +3" "rom.crc"


### PR DESCRIPTION
Pending https://github.com/libretro/libretro-database/pull/224 , this will build the Sega - Saturn database to allow browsing and playing Sega - Saturn games.