### PR TITLE
Add building of Sega - Mega-CD - Sega CD.rdb

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -230,6 +230,7 @@ build_libretro_databases() {
 	build_libretro_database "Sega - 32X" "rom.crc"
 	build_libretro_database "Sega - Game Gear" "rom.crc"
 	build_libretro_database "Sega - Master System - Mark III" "rom.crc"
+	build_libretro_database "Sega - Mega-CD - Sega CD" "rom.crc"
 	build_libretro_database "Sega - Mega Drive - Genesis" "rom.crc"
 	build_libretro_database "Sega - PICO" "rom.crc"
 	build_libretro_database "Sega - Saturn" "rom.crc"


### PR DESCRIPTION
Once the .DAT is added in https://github.com/libretro/libretro-database/pull/233 , we can then build the .rdb for it.