### PR TITLE
Add glupen64 for android

### DIFF
--- a/libretro-build-android-mk.sh
+++ b/libretro-build-android-mk.sh
@@ -39,6 +39,22 @@ die()
 	#exit 1
 }
 
+build_libretro_standalone()
+{
+	cd $BASE_DIR
+	if [ -d "libretro-${1}" ]; then
+		echo "=== Building ${1} ==="
+		cd libretro-${1}
+		if [ -z "${NOCLEAN}" ]; then
+			platform=android make clean
+		fi
+		platform=android make -j4
+		cp ./${1}_libretro${FORMAT}.${FORMAT_EXT} $RARCH_DIST_DIR/armeabi-v7a/${1}_libretro${FORMAT}.${FORMAT_EXT}
+	else
+		echo "${1} not fetched, skipping ..."
+	fi
+}
+
 # $1 is core name
 # $2 is subdir (if there's no subdir, put "." here)
 # $3 is appendage to core name for output JNI file
@@ -112,7 +128,7 @@ if [ $1 ]; then
 else
 WANT_CORES=" \
 	2048 \
-   4do \
+	4do \
 	bluemsx \
 	fmsx \
 	mednafen_lynx \
@@ -143,8 +159,8 @@ WANT_CORES=" \
 	nestopia \
 	tgbdual \
 	quicknes \
-	handy \ 
-   gambatte \
+	handy \
+	gambatte \
 	prboom \
 	tyrquake \
 	vba_next \
@@ -158,7 +174,8 @@ WANT_CORES=" \
 	bsnes_performance \
 	mame2000 \
 	mame2003 \
-	pocketsnes"
+	pocketsnes \
+	glupen64"
 fi
 
 for core in $WANT_CORES; do
@@ -181,7 +198,11 @@ for core in $WANT_CORES; do
 		path="target-libretro/jni"
 		append="_$core"
 	fi
-	build_libretro_generic_makefile $core $path $append
-   build_libretro_generic_makefile_armv7neon $core $path $append
+	if [ $core = "glupen64" ]; then
+		build_libretro_standalone $core $path $append
+	else
+		build_libretro_generic_makefile $core $path $append
+		build_libretro_generic_makefile_armv7neon $core $path $append
+	fi
 done
 


### PR DESCRIPTION
This allows:
```
./libretro-build-android-mk.sh glupen64
```
to work. The result ends up at ```./dist/android/armeabi-v7a/glupen64_libretro_android.so```

I'm not sure if there is anything else that needs to be changed in order for the core to get zipped up or whatnot.

In order for this to work the buildbot needs a couple things: **flex** and **bison** need to be installed if they are not.

The buildbot needs the Android standalone toolchain installed.

Basically:
./android-ndk-path/build/tools/make_standalone_toolchain.py --arch arm --install-dir ~/mychain

PATH=$PATH:~/mychain/bin   (arm-linux-androideabi-gcc needs to be in the PATH somewhere)