### PR TITLE
Add GLES3 version of GLupeN64

### DIFF
--- a/dist/info/glupen64_gles3_libretro.info
+++ b/dist/info/glupen64_gles3_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Nintendo 64 (GLupeN64)"
+display_name = "Nintendo 64 (GLupeN64 GLES3)"
 authors = "Hacktarux|Mupen64Plus Team|loganmc10"
 supported_extensions = "n64|v64|z64|bin|u1|ndd"
 corename = "GLupeN64"


### PR DESCRIPTION
On Android there is now a GLES2 and GLES3 version being built by the buildbot, so this will help users see the difference.