### PR TITLE
Add scanning "no-intro" folder when building database

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -65,6 +65,11 @@ build_libretro_database() {
 			COMMAND+=' "${LIBRETRODATABASE_META_DAT_DIR}/${1}.dat"'
 		fi
 
+		#Check if meta no-intro is there
+		if [ -f "${LIBRETRODATABASE_META_DAT_DIR}/no-intro/${1}.dat" ]; then
+			COMMAND+=' "${LIBRETRODATABASE_META_DAT_DIR}/no-intro/${1}.dat"'
+		fi
+
 		#Check if meta goodtools is there
 		if [ -f "${LIBRETRODATABASE_META_DAT_DIR}/goodtools/${1}.dat" ]; then
 			COMMAND+=' "${LIBRETRODATABASE_META_DAT_DIR}/goodtools/${1}.dat"'

--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -65,11 +65,6 @@ build_libretro_database() {
 			COMMAND+=' "${LIBRETRODATABASE_META_DAT_DIR}/${1}.dat"'
 		fi
 
-		#Check if meta no-intro is there
-		if [ -f "${LIBRETRODATABASE_META_DAT_DIR}/no-intro/${1}.dat" ]; then
-			COMMAND+=' "${LIBRETRODATABASE_META_DAT_DIR}/no-intro/${1}.dat"'
-		fi
-
 		#Check if meta goodtools is there
 		if [ -f "${LIBRETRODATABASE_META_DAT_DIR}/goodtools/${1}.dat" ]; then
 			COMMAND+=' "${LIBRETRODATABASE_META_DAT_DIR}/goodtools/${1}.dat"'
@@ -168,6 +163,11 @@ build_libretro_database() {
 		#Check if meta TGDB DAT is there
 		if [ -f "${LIBRETRODATABASE_META_DAT_DIR}/tgdb/${1}.dat" ]; then
 			COMMAND+=' "${LIBRETRODATABASE_META_DAT_DIR}/tgdb/${1}.dat"'
+		fi
+
+		#Check if meta no-intro is there
+		if [ -f "${LIBRETRODATABASE_META_DAT_DIR}/no-intro/${1}.dat" ]; then
+			COMMAND+=' "${LIBRETRODATABASE_META_DAT_DIR}/no-intro/${1}.dat"'
 		fi
 
 		#Check if main DAT is there


### PR DESCRIPTION
Introduce a specific `no-intro` directory that can house the No-Intro DATs. Having them mixed in the main directory can be confusing, having them split off will make updating a lot easier.