### PR TITLE
Fix typo in log.sh that leads to incompatibility with some shells.

### DIFF
--- a/script-modules/log.sh
+++ b/script-modules/log.sh
@@ -56,7 +56,7 @@ log_module_start() {
 
 		# Output to screen and logfile in developer mode (if possible)
 		if [[ -n "$LIBRETRO_DEVELOPER" && -n "${log_tee:=$(find_tool "tee")}" ]]; then
-			exec > >($log_tee -a $log_module) 2>&1
+			exec >> $($log_tee -a $log_module) 2>&1
 		else
 			exec >> $log_module 2>&1
 			log_file_only=1


### PR DESCRIPTION
On my machine this was causing `sh libretro-fetch.sh` to fail.  `bash libretro-fetch.sh` was not failing.