### PR TITLE
Fix mismatched info against core

### DIFF
--- a/dist/info/nestopia_libretro.info
+++ b/dist/info/nestopia_libretro.info
@@ -1,7 +1,7 @@
 display_name = "NES / Famicom (Nestopia UE)"
 authors = "Martin Freij|R. Belmont|R. Danbrook"
 supported_extensions = "nes|fds"
-corename = "Nestopia UE"
+corename = "Nestopia"
 manufacturer = "Nintendo"
 categories = "Emulator"
 systemname = "Nintendo Entertainment System"


### PR DESCRIPTION
Fixes https://github.com/libretro/nestopia/pull/34. Mismatched info between "Nestopia" and "Nestopia UE" 