### PR TITLE
Fix Sony - PlayStation Vita naming to No-Intro

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -266,7 +266,7 @@ build_libretro_databases() {
 	build_libretro_database "Sony - PlayStation Portable (PSX2PSP)" "rom.crc"
 	build_libretro_database "Sony - PlayStation Portable (UMD Music)" "rom.crc"
 	build_libretro_database "Sony - PlayStation Portable (UMD Video)" "rom.crc"
-	build_libretro_database "Sony - PlayStation Portable Vita" "rom.serial"
+	build_libretro_database "Sony - PlayStation Vita" "rom.serial"
 	build_libretro_database "Tiger - Game.com" "rom.crc"
 	build_libretro_database "Uzebox" "rom.crc"
 	build_libretro_database "VTech - CreatiVision" "rom.crc"


### PR DESCRIPTION
It was renamed in No-Intro. We're not currently using it in an info file.