### PR TITLE
These lines are redundant

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -1316,8 +1316,6 @@ key.alias.password=buildbot
 
 EOF
 
-		$NDK clean | tee $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_RetroArch_${PLATFORM}.log
-		$NDK -j${JOBS} | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_RetroArch_${PLATFORM}.log
 		if [ "${RELEASE}" == "NO" ]; then
 			python ./version_increment.py
 		else


### PR DESCRIPTION
ant clean performs "ndk-build clean" and ant release peforms "ndk-build =j4".

See these lines:

https://github.com/libretro/RetroArch/blob/master/pkg/android/phoenix/build.xml#L102-L109

Therefore these lines are redundant.