### PR TITLE
Fix windows RA builds

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -1390,7 +1390,9 @@ if [ "${PLATFORM}" = "MINGW64" ] || [ "${PLATFORM}" = "MINGW32" ] || [ "${PLATFO
 		echo
 		
 		compile_audio_filters ${HELPER} ${MAKE}
+		cd $RADIR
 		compile_video_filters ${HELPER} ${MAKE}
+		cd $RADIR
 
 		echo "configuring..."
 		echo "configure command: $CONFIGURE $ARGS"
@@ -1889,7 +1891,9 @@ if [ "${PLATFORM}" = "unix" ]; then
 		echo
 
 		compile_audio_filters ${HELPER} ${MAKE}
+		cd $RADIR
 		compile_video_filters ${HELPER} ${MAKE}
+		cd $RADIR
 
 		echo "configuring..."
 		echo "configure command: $CONFIGURE $ARGS"


### PR DESCRIPTION
RA windows builds are failing since 
https://github.com/libretro/libretro-super/commit/7a709eab0878c48752209ddb9b51c68b220ae791

Not sure what's wrong on the commit but this should make it end up in the proper directory instead of inside libretro-super