### PR TITLE
move mame2014/2016 cores from ndk13b to  ndk10e

### DIFF
--- a/recipes/android/cores-android-armv7-ndk-mame
+++ b/recipes/android/cores-android-armv7-ndk-mame
@@ -1,5 +1,1 @@
 mame libretro-mame https://github.com/libretro/mame.git PROJECT YES GENERIC makefile . OSD=retro verbose=1 RETRO=1 NOWERROR=1 NOASM=1 gcc=android-arm OS=linux TARGETOS=android-arm CONFIG=libretro NO_USE_MIDI=1 TARGET=mame 
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git PROJECT YES GENERIC Makefile . TARGET=mame 
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git PROJECT YES GENERIC Makefile . TARGET=mess 
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git PROJECT YES GENERIC Makefile . TARGET=ume 
-mame2016  libretro-mame2016 https://github.com/libretro/mame2016-libretro PROJECT YES GENERIC makefile . OSD=retro RETRO=1 NOWERROR=1 NOASM=1 gcc=android-arm gcc_version=4.9 TARGETOS=android-arm CONFIG=libretro NO_USE_MIDI=1 OS=linux VERBOSE=1 verbose=1 TARGET=mame

--- a/recipes/android/cores-android-armv7-ndk-old-mame
+++ b/recipes/android/cores-android-armv7-ndk-old-mame
@@ -1,0 +1,4 @@
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git PROJECT YES GENERIC Makefile . TARGET=mame 
+mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git PROJECT YES GENERIC Makefile . TARGET=mess 
+ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git PROJECT YES GENERIC Makefile . TARGET=ume 
+mame2016 libretro-mame2016 https://github.com/libretro/mame2016-libretro PROJECT YES GENERIC makefile . OSD=retro RETRO=1 NOWERROR=1 NOASM=1 gcc=android-arm gcc_version=4.9 TARGETOS=android-arm CONFIG=libretro NO_USE_MIDI=1 OS=linux VERBOSE=1 verbose=1 TARGET=mame

--- a/recipes/android/cores-android-armv7-ndk-old-mame.conf
+++ b/recipes/android/cores-android-armv7-ndk-old-mame.conf
@@ -1,0 +1,10 @@
+PATH home/buildbot/tools/android/android-ndk-r10e/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/
+ANDROID_NDK_ARM /home/buildbot/tools/android/android-ndk-r10e/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/
+ANDROID_NDK_ROOT /home/buildbot/tools/android/android-ndk-r10e/
+ANDROID_NDK_LLVM /home/buildbot/tools/android/android-ndk-r10e/toolchains/llvm-3.5/prebuilt/linux-x86_64/
+PLATFORM android
+platform android
+LIBSUFFIX _android
+MAKE make
+DIST armeabi-v7a
+CORE_JOB YES


### PR DESCRIPTION
I hope the format is correct  and that it will fine with 10e (works for me with 10d).
this should solve the dipswitch menu crash.
