### PR TITLE
[CHECK BEFORE MERGE] disable PTR64 on 32-bit builds

### DIFF
--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -1,94 +1,94 @@
-2048 libretro-2048  https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro . 
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile . 
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro . 
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . accuracy 
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . balanced 
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . performance 
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES BSNES Makefile . cpp98 
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . accuracy 
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . balanced 
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . performance 
-craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro . 
-crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile . 
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume 
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile . 
-dolphin libretro-dolphin https://github.com/libretro/dolphin.git master PROJECT YES GENERIC Makefile Source/Core/DolphinLibretro/ 
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro . 
-easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master PROJECT YES GENERIC Makefile.libretro builds/libretro 
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk 
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk 
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro . 
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro . 
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile . 
-fceumm libretro-fceuumm  https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro . 
-ffmpeg libretro-ffmpeg  https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro 
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile . 
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile.libretro .  
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile . 
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro . 
-mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64 
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile . 
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile . 
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile . 
-hatari libretro-hatari https://github.com/libretro/libretro-hatari.git master PROJECT YES GENERIC Makefile.libretro . 
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile . 
-mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . 
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile . 
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile . PTR64=1 
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft 
-mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_OPENGL=1 
-mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile . 
-melonds libretro-melonds  https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile . 
-meteor libretro-meteor  https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro 
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro . 
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile . 
-nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro 
-mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC_GL Makefile . 
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro 
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile . 
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile . 
-openlara libretro-openlara https://github.com/libretro/OpenLara.git master PROJECT YES GENERIC Makefile src/platform/libretro 
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=1 
-pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0 
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro . 
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master PROJECT YES GENERIC Makefile . 
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile . 
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES GENERIC_GL Makefile libretro 
-prboom libretro-prboom  https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile . 
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile . 
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile . 
+2048 libretro-2048  https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . accuracy
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . balanced
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . performance
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES BSNES Makefile . cpp98
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . accuracy
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . balanced
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . performance
+craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
+crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
+desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile .
+dolphin libretro-dolphin https://github.com/libretro/dolphin.git master PROJECT YES GENERIC Makefile Source/Core/DolphinLibretro/
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
+easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master PROJECT YES GENERIC Makefile.libretro builds/libretro
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
+fceumm libretro-fceuumm  https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
+ffmpeg libretro-ffmpeg  https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile.libretro .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
+mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
+gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/libretro-hatari.git master PROJECT YES GENERIC Makefile.libretro .
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
+mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro .
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile . PTR64=1
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft
+mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_OPENGL=1
+mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
+melonds libretro-melonds  https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile .
+meteor libretro-meteor  https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro
+mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile .
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro
+mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC_GL Makefile .
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
+openlara libretro-openlara https://github.com/libretro/OpenLara.git master PROJECT YES GENERIC Makefile src/platform/libretro
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=1
+pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master PROJECT YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
+ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES GENERIC_GL Makefile libretro
+prboom libretro-prboom  https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
 px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-quicknes libretro-quicknes  https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile . 
-reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master PROJECT YES GENERIC Makefile . 
-remotejoy libretro-remotejoy  https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile . 
-sameboy libretro-sameboy  https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile.libretro . 
-scummvm libretro-scummvm  https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build 
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile . 
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile . 
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro . 
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro 
-stella libretro-stella  https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile . 
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile . 
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile . 
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro . 
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro 
-vecx libretro-vecx  https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro . 
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile . 
-vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . 
-vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=x128 
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile . 
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro 
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame 
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess 
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume 
-uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC Makefile . 
+quicknes libretro-quicknes  https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
+reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master PROJECT YES GENERIC Makefile .
+remotejoy libretro-remotejoy  https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
+sameboy libretro-sameboy  https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile.libretro .
+scummvm libretro-scummvm  https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
+stella libretro-stella  https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
+vecx libretro-vecx  https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
+vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile .
+vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=x128
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame
+mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess
+ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume
+uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -1,79 +1,79 @@
-2048 libretro-2048  https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro . 
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile . 
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro . 
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . accuracy 
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . balanced 
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . performance 
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES BSNES Makefile . cpp98 
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES BSNES Makefile . cpp98 
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . accuracy 
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . balanced 
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . performance 
+2048 libretro-2048  https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . accuracy
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . balanced
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . performance
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES BSNES Makefile . cpp98
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES BSNES Makefile . cpp98
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . accuracy
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . balanced
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . performance
 cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume 
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile . 
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro . 
-emux_chip8 libretro-emux_chip8 https://github.com/sronsse/emux master PROJECT YES GENERIC Makefile libretro TARGETS=chip8 
-emux_gb libretro-emux_gb https://github.com/sronsse/emux master PROJECT YES GENERIC Makefile libretro TARGETS=gb 
-emux_nes libretro-emux_nes https://github.com/sronsse/emux master PROJECT YES GENERIC Makefile libretro TARGETS=nes 
-emux_sms libretro-emux_sms https://github.com/sronsse/emux master PROJECT YES GENERIC Makefile libretro TARGETS=sms 
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk 
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk 
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro . 
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro . 
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile . 
-fceumm libretro-fceuumm  https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro . 
-ffmpeg libretro-ffmpeg  https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro 
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile . 
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile . 
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro . 
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile . 
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile . 
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile . 
-hatari libretro-hatari https://github.com/libretro/libretro-hatari.git master PROJECT YES GENERIC Makefile.libretro . 
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile . 
-mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . 
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile . 
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile . 
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft 
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame 
-mednafen_gba libretro-mednafen_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_lynx libretro-mednafen_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_ngp libretro-mednafen_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_pce_fast libretro-mednafen_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_pcfx libretro-mednafen_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_psx libretro-mednafen_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_HW=1 
-mednafen_snes libretro-mednafen_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_supergrafx libretro-mednafen_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_vb libretro-mednafen_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_wswan libretro-mednafen_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile . 
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess 
-meteor libretro-meteor  https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro 
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro . 
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64 
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro 
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile . 
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile . 
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0 
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro . 
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile . 
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES GENERIC_GL Makefile libretro 
-prboom libretro-prboom  https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile . 
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile . 
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .  
-quicknes libretro-quicknes  https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile . 
-remotejoy libretro-remotejoy  https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile . 
-scummvm libretro-scummvm  https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build 
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile . 
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_ALT Makefile.libretro . 
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro 
-stella libretro-stella  https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile . 
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile . 
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile . 
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume PTR64=1 PARTIAL=1 
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro . 
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro 
-vecx libretro-vecx  https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro . 
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile . 
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro 
+desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile .
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
+emux_chip8 libretro-emux_chip8 https://github.com/sronsse/emux master PROJECT YES GENERIC Makefile libretro TARGETS=chip8
+emux_gb libretro-emux_gb https://github.com/sronsse/emux master PROJECT YES GENERIC Makefile libretro TARGETS=gb
+emux_nes libretro-emux_nes https://github.com/sronsse/emux master PROJECT YES GENERIC Makefile libretro TARGETS=nes
+emux_sms libretro-emux_sms https://github.com/sronsse/emux master PROJECT YES GENERIC Makefile libretro TARGETS=sms
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
+fceumm libretro-fceuumm  https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
+ffmpeg libretro-ffmpeg  https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
+gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/libretro-hatari.git master PROJECT YES GENERIC Makefile.libretro .
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
+mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro .
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame
+mednafen_gba libretro-mednafen_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_lynx libretro-mednafen_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_ngp libretro-mednafen_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_pce_fast libretro-mednafen_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_pcfx libretro-mednafen_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_psx libretro-mednafen_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_HW=1
+mednafen_snes libretro-mednafen_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_supergrafx libretro-mednafen_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_vb libretro-mednafen_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_wswan libretro-mednafen_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
+mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess
+meteor libretro-meteor  https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro
+mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
+ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES GENERIC_GL Makefile libretro
+prboom libretro-prboom  https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
+quicknes libretro-quicknes  https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
+remotejoy libretro-remotejoy  https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
+scummvm libretro-scummvm  https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_ALT Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
+stella libretro-stella  https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
+ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume PTR64=0 PARTIAL=1
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
+vecx libretro-vecx  https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -1,91 +1,91 @@
-2048 libretro-2048  https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro . 
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile . 
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro . 
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . accuracy 
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . balanced 
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . performance 
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES BSNES Makefile . cpp98 
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES BSNES Makefile . cpp98 
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . accuracy 
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . balanced 
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . performance 
-craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro . 
-crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile . 
+2048 libretro-2048  https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . accuracy
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . balanced
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . performance
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES BSNES Makefile . cpp98
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES BSNES Makefile . cpp98
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . accuracy
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . balanced
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . performance
+craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
+crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
 cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume 
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile . 
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro . 
-easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master PROJECT YES GENERIC Makefile.libretro builds/libretro 
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk 
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk 
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro . 
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro . 
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile . 
-fceumm libretro-fceuumm  https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro . 
-ffmpeg libretro-ffmpeg  https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro 
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile . 
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile . 
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro . 
+desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile .
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
+easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master PROJECT YES GENERIC Makefile.libretro builds/libretro
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
+fceumm libretro-fceuumm  https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
+ffmpeg libretro-ffmpeg  https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
 mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile . 
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile . 
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile . 
-hatari libretro-hatari https://github.com/libretro/libretro-hatari.git master PROJECT YES GENERIC Makefile.libretro . 
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile . 
-mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . 
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile . 
+gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/libretro-hatari.git master PROJECT YES GENERIC Makefile.libretro .
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
+mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro .
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft PTR64=1 
-mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_HW=1 
-mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile . 
-melonds libretro-melonds  https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile . 
-meteor libretro-meteor  https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro 
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro . 
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86 
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile . 
-nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro 
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro 
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile . 
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile . 
-openlara libretro-openlara https://github.com/libretro/OpenLara.git master PROJECT YES GENERIC Makefile src/platform/libretro 
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0 
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro . 
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master SUBMODULE YES GENERIC Makefile . 
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile . 
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES GENERIC_GL Makefile libretro 
-prboom libretro-prboom  https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile . 
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile . 
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .  
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft PTR64=0
+mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_HW=1
+mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
+melonds libretro-melonds  https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile .
+meteor libretro-meteor  https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro
+mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile .
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
+openlara libretro-openlara https://github.com/libretro/OpenLara.git master PROJECT YES GENERIC Makefile src/platform/libretro
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master SUBMODULE YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
+ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES GENERIC_GL Makefile libretro
+prboom libretro-prboom  https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
 px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-quicknes libretro-quicknes  https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile . 
-reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master PROJECT YES GENERIC Makefile . 
-remotejoy libretro-remotejoy  https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile . 
-sameboy libretro-sameboy  https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile.libretro . 
-scummvm libretro-scummvm  https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build 
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile . 
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_ALT Makefile.libretro . 
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro 
-stella libretro-stella  https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile . 
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile . 
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile . 
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro . 
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro 
-vecx libretro-vecx  https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro . 
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile . 
-vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . 
-vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile .  EMUTYPE=x128 
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile . 
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro 
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame PTR64=0 
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess PTR64=0 
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume PTR64=0 
-uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC Makefile . 
+quicknes libretro-quicknes  https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
+reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master PROJECT YES GENERIC Makefile .
+remotejoy libretro-remotejoy  https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
+sameboy libretro-sameboy  https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile.libretro .
+scummvm libretro-scummvm  https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_ALT Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
+stella libretro-stella  https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
+vecx libretro-vecx  https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
+vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile .
+vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile .  EMUTYPE=x128
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame PTR64=0
+mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess PTR64=0
+ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume PTR64=0
+uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -1,89 +1,89 @@
-2048 libretro-2048  https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro . 
-3dengine libretro-3dengine  https://github.com/libretro/libretro-3dengine.git master PROJECT YES GENERIC_GL Makefile . 
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile . 
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro . 
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . accuracy 
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . balanced 
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . performance 
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES BSNES Makefile . cpp98 
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . accuracy 
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . balanced 
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . performance 
-craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro . 
-crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile . 
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC_ALT Makefile . 
-easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master PROJECT YES GENERIC Makefile.libretro builds/libretro 
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk 
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk 
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro . 
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro . 
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile . 
-fceumm libretro-fceuumm  https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro . 
-ffmpeg libretro-ffmpeg  https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro 
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile . 
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile.libretro .  
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile . 
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro . 
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile . 
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile . 
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile . 
-hatari libretro-hatari https://github.com/libretro/libretro-hatari.git master PROJECT YES GENERIC Makefile.libretro . 
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile . 
-mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile . 
-melonds libretro-melonds  https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile . 
-meteor libretro-meteor  https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro 
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro . 
-mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86 
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86 
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile . 
-nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro 
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro 
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile . 
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile . 
-openlara libretro-openlara https://github.com/libretro/OpenLara.git master PROJECT YES GENERIC Makefile src/platform/libretro 
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0 
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro . 
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master PROJECT YES GENERIC Makefile . 
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile . 
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile . 
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile . 
+2048 libretro-2048  https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
+3dengine libretro-3dengine  https://github.com/libretro/libretro-3dengine.git master PROJECT YES GENERIC_GL Makefile .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . accuracy
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . balanced
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . performance
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES BSNES Makefile . cpp98
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . accuracy
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . balanced
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . performance
+craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
+crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC_ALT Makefile .
+easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master PROJECT YES GENERIC Makefile.libretro builds/libretro
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
+fceumm libretro-fceuumm  https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
+ffmpeg libretro-ffmpeg  https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile.libretro .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
+gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/libretro-hatari.git master PROJECT YES GENERIC Makefile.libretro .
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
+mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
+melonds libretro-melonds  https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile .
+meteor libretro-meteor  https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro
+mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
+mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile .
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
+openlara libretro-openlara https://github.com/libretro/OpenLara.git master PROJECT YES GENERIC Makefile src/platform/libretro
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master PROJECT YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
 px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-quicknes libretro-quicknes  https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile . 
-remotejoy libretro-remotejoy  https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile . 
-sameboy libretro-sameboy  https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile.libretro . 
-scummvm libretro-scummvm  https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build 
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile . 
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile . 
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_ALT Makefile.libretro . 
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro 
-stella libretro-stella  https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile . 
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile . 
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile . 
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC_ALT Makefile.libretro . 
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC_ALT Makefile src/libretro 
-vecx libretro-vecx  https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro . 
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile . 
-vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . 
-vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=x128 
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile . 
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro 
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume 
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro . 
-prboom libretro-prboom  https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile . 
-mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . PTR64=1 
+quicknes libretro-quicknes  https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
+remotejoy libretro-remotejoy  https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
+sameboy libretro-sameboy  https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile.libretro .
+scummvm libretro-scummvm  https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_ALT Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
+stella libretro-stella  https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC_ALT Makefile.libretro .
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC_ALT Makefile src/libretro
+vecx libretro-vecx  https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
+vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile .
+vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=x128
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro
+desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
+prboom libretro-prboom  https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
+mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . PTR64=0
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft PTR64=0 
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame PTR64=0 
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess PTR64=0 
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume PTR64=0 
-mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . 
-mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_HW=1 
-uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC Makefile . 
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft PTR64=0
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame PTR64=0
+mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess PTR64=0
+ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume PTR64=0
+mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
+mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_HW=1
+uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC Makefile .


### PR DESCRIPTION
My text editor strips out trailing spaces automatically, so if they were there for a reason, I'll need to redo the commit in a different editor.