### PR TITLE
Add "ARCH = x86" to cores-linux-x86-generic.conf

### DIFF
--- a/recipes/linux/cores-linux-x86-generic.conf
+++ b/recipes/linux/cores-linux-x86-generic.conf
@@ -1,5 +1,6 @@
 platform unix
 PLATFORM unix
+ARCH x86
 MAKEPORTABLE YES
 CORE_JOB YES
 MAKE make


### PR DESCRIPTION
This PR adds one line to this .conf with the processor architecture. This ARCH parameter matches the way it it is already being capitalized and used all other x86 .confs within librero-super/recipes

This will also allow MIPS3 support to be built into x86 Linux MAME 2003 cores once we may sure that Makefile has been adjusted correctly: https://github.com/libretro/mame2003-libretro/pull/94

Until that PR is fully vetted, this should not have any particular effect.