### PR TITLE
Fix ini syntax for notes in PSP1 (PPSSPP)

### DIFF
--- a/dist/info/psp1_libretro.info
+++ b/dist/info/psp1_libretro.info
@@ -14,4 +14,4 @@ firmware_count = 1
 firmware0_desc = "ppge_atlas.zim (PPSSPP Data ROM)"
 firmware0_path = "ppge_atlas.zim"
 firmware0_opt = "false"
-notes = "(!) ppge_atlas.zim (md5): a93fc411c1ce7d001a2a812643c70085|(!) PPSSPP requires the asset files, lang folder, and flash0 folder inside the 'system\PPSSPP' directory.
+notes = "(!) ppge_atlas.zim (md5): a93fc411c1ce7d001a2a812643c70085|(!) PPSSPP requires the asset files, lang folder, and flash0 folder inside the 'system\PPSSPP' directory."


### PR DESCRIPTION
This was causing https://github.com/libretro/RetroArch/issues/5175