### PR TITLE
Add rom, abs, cof, bin, prg formats to virtualJag info file.

### DIFF
--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Atari Jaguar (Virtual Jaguar)"
 authors = "David Raingeard|Shamus"
-supported_extensions = "j64|jag"
+supported_extensions = "j64|jag|rom|abs|cof|bin|prg"
 corename = "Virtual Jaguar"
 manufacturer = "Atari"
 categories = "Emulator"


### PR DESCRIPTION
Virtual jaguar supports these so i thought I'd add them. I have tested a few for each format and i can get a few to work. I suspect many don't work because they are header-less or just bad files, as I got them from a dat called "nongood". None the less i can get a few to work so i feel this should be added.