### PR TITLE
Fetch basilisk2, dolphin and pokemini cores.

### DIFF
--- a/build-config.sh
+++ b/build-config.sh
@@ -116,7 +116,8 @@ include_core_mednafen_vb
 # --- Atari Jaguar emulator cores ---
 include_core_virtualjaguar
 
-# --- DOS/PC emulator cores ---
+# --- DOS/PC/MAC emulator cores ---
+include_core_basilisk2
 include_core_dosbox
 include_core_pcem
 
@@ -131,6 +132,12 @@ include_core_mame
 # --- N64 emulator cores ---
 include_core_mupen64plus
 include_core_parallel_n64
+
+# --- Nintendo Gamecube/Wii cores ---
+include_core_dolphin
+
+# --- Nintendo Pokemon Mini cores ---
+include_core_pokemini
 
 # --- Game & Watch cores ---
 include_core_gw

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -481,6 +481,14 @@ libretro_dosbox_name="DOSBox"
 libretro_dosbox_git_url="https://github.com/libretro/dosbox-libretro.git"
 libretro_dosbox_makefile="Makefile.libretro"
 
+include_core_basilisk2() {
+	register_module core "basilisk2" -ngc -ps3 -psp1 -wii
+}
+libretro_basilisk2_name="Basilisk II"
+libretro_basilisk2_git_url="https://github.com/libretro/Basilisk2.git"
+libretro_basilisk2_build_subdir="BasiliskII/src/libretro"
+libretro_basilisk2_makefile="Makefile.libretro"
+
 include_core_virtualjaguar() {
 	register_module core "virtualjaguar" -ngc -ps3 -psp1 -wii
 }


### PR DESCRIPTION
Should fix these two issues. https://github.com/libretro/libretro-super/issues/258 & https://github.com/libretro/libretro-super/issues/414

I am also not sure on the correct flags for the `register_module` line in `rules.d/core-rules.sh`.