### PR TITLE
Add .cxi to Citra's list of file extensions

### DIFF
--- a/dist/info/citra_libretro.info
+++ b/dist/info/citra_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Nintendo 3DS (Citra)"
 authors = "Citra Emulation Project"
-supported_extensions = "3ds|3dsx|cia|elf"
+supported_extensions = "3ds|3dsx|cia|elf|cxi"
 corename = "Citra"
 manufacturer = "Nintendo"
 categories = "Emulator"


### PR DESCRIPTION
Citra can load .cxi files, as documentated here: https://citra-emu.org/wiki/dumping-installed-titles/

Fixes libretro/libretro-core-info#4