### PR TITLE
Add .68k to Sega Genesis extensions

### DIFF
--- a/dist/info/genesis_plus_gx_libretro.info
+++ b/dist/info/genesis_plus_gx_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Sega MS/GG/MD/CD (Genesis Plus GX)"
 authors = "Charles McDonald|Eke-Eke"
-supported_extensions = "mdx|md|smd|gen|bin|cue|iso|sms|gg|sg"
+supported_extensions = "mdx|md|smd|gen|bin|cue|iso|sms|gg|sg|68k"
 corename = "Genesis Plus GX"
 manufacturer = "Sega"
 categories = "Emulator"

--- a/dist/info/picodrive_libretro.info
+++ b/dist/info/picodrive_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Sega MS/MD/CD/32X (PicoDrive)"
 authors = "notaz|fdave"
-supported_extensions = "bin|gen|smd|md|32x|cue|iso|sms"
+supported_extensions = "bin|gen|smd|md|32x|cue|iso|sms|68k"
 corename = "PicoDrive"
 manufacturer = "Sega"
 categories = "Emulator"


### PR DESCRIPTION
There are a few `.68K` in there:
https://github.com/libretro/libretro-database/blob/master/dat/Sega%20-%20Mega%20Drive%20-%20Genesis.dat