### PR TITLE
Disable Web Services in Citra-Libretro by default

### DIFF
--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -13,7 +13,7 @@ bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.g
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . performance 
 cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .
 chaigame libretro-chaigame https://github.com/RobLoach/ChaiGame.git master PROJECT YES GENERIC Makefile .
-citra libretro-citra https://github.com/libretro/citra.git master SUBMODULE YES CMAKE Makefile build -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DDISABLE_LIBPNG=1 -DCMAKE_BUILD_TYPE="Release" --target citra_libretro .. 
+citra libretro-citra https://github.com/libretro/citra.git master SUBMODULE YES CMAKE Makefile build -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DDISABLE_LIBPNG=1 -DCMAKE_BUILD_TYPE="Release" -DENABLE_WEB_SERVICE=0 -DUSE_SYSTEM_CURL=1 --target citra_libretro .. 
 craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro . 
 crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile . 
 desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume 


### PR DESCRIPTION
Right now, web services are only used for telemetry in Citra, and as such, are not used at all. This configures the core correctly so that these are disabled.

This will be enabled in the future when other features using this mechanism are implemented, but this doesn't do anything except increase build complexity at this time.