### PR TITLE
[Travis] Missing .ra file for Linux

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -1251,7 +1251,11 @@ buildbot_pull(){
 
 		echo
 		echo RADIR=$RADIR
-	done < $RECIPE.ra
+	if [ -e {$RECIPE}.ra ]; then
+		done < {$RECIPE}.ra
+	else
+		done < $RECIPE
+	fi
 	cd $WORK
 }
 


### PR DESCRIPTION
Getting some failures on Linux when building:
https://travis-ci.org/libretro/vice-libretro/jobs/296038702

Tries to find a .ra file, but it doesn't list.