### PR TITLE
libretro-buildbot-recipe.sh: Make sure $TMPDIR exists and is set.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -4,6 +4,9 @@
 
 # This will use an overridden value from the command-line if provided, otherwise just use the current date
 LOGDATE=${LOGDATE:-`date +%Y-%m-%d`}
+TMPDIR="${TMPDIR:-/tmp}"
+
+mkdir -p -- "$TMPDIR/log/${BOT}/${LOGDATE}"
 
 ORIGPATH=$PATH
 WORK=$PWD


### PR DESCRIPTION
If `$TMPDIR` is not set and/or it does not exist the script will fail to create logs and dump various files in `/` until it ultimately fails at the end when it has a return code of `1` from failing to create logs. This will set `$TMPDIR` to `/tmp/` if the variable is empty or unset and then create the tmp directories if it doesn't already exist.