### PR TITLE
libretro-buildbot-recipe.sh: Exit early if there is no recipe target

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -6,6 +6,11 @@
 LOGDATE=${LOGDATE:-`date +%Y-%m-%d`}
 TMPDIR="${TMPDIR:-/tmp}"
 
+if [ -z "${1}" ]; then
+	echo 'No recipe target, exiting.' >&2
+	exit 1
+fi
+
 mkdir -p -- "$TMPDIR/log/${BOT}/${LOGDATE}"
 
 ORIGPATH=$PATH


### PR DESCRIPTION
This adds a sanity check if `$1` is empty or unset the script will exit early and print an error that there was no recipe target instead of failing later without an explicit error.