### PR TITLE
libretro-buildbot-recipe.sh: Don't error if /vars does not exist.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -23,7 +23,7 @@ ENTRY_ID=""
 while read line; do
 	KEY=`echo $line | cut -f 1 -d " "`
 	VALUE=`echo $line | cut -f 2 -d " "`
-	rm $TMPDIR/vars
+	rm -f -- "$TMPDIR/vars"
 	if [ "${KEY}" = "PATH" ]; then
 		export PATH=${VALUE}:${ORIGPATH}
 		echo PATH=${VALUE}:${ORIGPATH} >> $TMPDIR/vars


### PR DESCRIPTION
Silences a inconsequential error if the script tries to remove `$TMPDIR/vars` and it does not exist.