### PR TITLE
libretro-buildbot-recipe.sh: Don't export empty variables.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -21,6 +21,7 @@ ENTRY_ID=""
 
 # ----- read variables from recipe config -----
 while read line; do
+	[ -z "${line}" ] && continue
 	KEY=`echo $line | cut -f 1 -d " "`
 	VALUE=`echo $line | cut -f 2 -d " "`
 	rm -f -- "$TMPDIR/vars"

--- a/recipes/linux/cores-linux-x64-generic.conf
+++ b/recipes/linux/cores-linux-x64-generic.conf
@@ -5,4 +5,3 @@ CORE_JOB YES
 MAKE make
 CMAKE cmake
 PATH /usr/lib/ccache
-


### PR DESCRIPTION
Silences the following error if the read file contains a blank line.
```
./libretro-buildbot-recipe.sh: line 31: export: `=': not a valid identifier
```