### PR TITLE
libretro-buildbot-recipe.sh: Set $BOT to . by default.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -3,7 +3,8 @@
 # ----- setup -----
 
 # This will use an overridden value from the command-line if provided, otherwise just use the current date
-LOGDATE=${LOGDATE:-`date +%Y-%m-%d`}
+BOT="${BOT:-.}"
+LOGDATE="${LOGDATE:-$(date +%Y-%m-%d)}"
 TMPDIR="${TMPDIR:-/tmp}"
 
 if [ -z "${1}" ]; then


### PR DESCRIPTION
Its better practice to not rely on unset variables. The default value of `.` is taken from the travis scripts.

Also took the liberty of setting `$LOGDATE` in a more canonical way.