### PR TITLE
libretro-buildbot-recipe.sh: return 0 if $RECIPE.ra does not exist.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -916,6 +916,8 @@ while read line; do
 done < $1
 
 buildbot_pull(){
+	[ ! -f "$RECIPE.ra" ] && return 0
+
 	while read line; do
 		NAME=`echo $line | cut -f 1 -d " "`
 		DIR=`echo $line | cut -f 2 -d " "`


### PR DESCRIPTION
As I understand it the `.ra` files are only used for RetroArch and not the cores, but this while loop will still be executed for both. This can be easily avoided by returning early in the function if the `.ra` file does not exist.

Silences the following error.
```
./libretro-buildbot-recipe.sh: line 918: recipes/linux/cores-linux-x64-generic.ra: No such file or directory
```