### PR TITLE
libretro-buildbot-recipe.sh: Remove extra cd commands.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -312,8 +312,6 @@ build_libretro_generic_makefile() {
 		mkdir -p $DIR/$SUBDIR
 	fi
 
-	cd $DIR
-	cd $SUBDIR
 	JOBS_ORIG=$JOBS
 
 	if [ "${NAME}" == "mame2003" ]; then


### PR DESCRIPTION
Silences the following error from trying to `cd` to a directory that is already the `$PWD`.
```
./libretro-buildbot-recipe.sh: line 329: cd: libretro-fceumm/.: No such file or directory
```