### PR TITLE
Fix ppsspp build.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -1030,31 +1030,32 @@ compile_filters()
 	fi
 }
 
-echo "buildbot job: $jobid Building Retroarch-$PLATFORM"
-echo --------------------------------------------------
-echo
-cd $WORK
-BUILD=""
-
-echo WORKINGDIR=$PWD
-echo RELEASE=$RELEASE
-echo FORCE=$FORCE_RETROARCH_BUILD
-echo RADIR=$RADIR
-echo BRANCH=$BRANCH
-
-buildbot_pull
-
-if [ "${BUILD}" = "YES" ] || [ "${FORCE}" = "YES" ] || [ "${FORCE_RETROARCH_BUILD}" = "YES" ] || [ "${CORES_BUILT}" = "YES" ]; then
-	cd "$RADIR"
-	git clean -xdf
-	echo WORKINGDIR=$PWD
-	echo RADIR=$RADIR
-
-	echo "buildbot job: $jobid Building"
+if [ "${RA}" = "YES" ]; then
+	echo "buildbot job: $jobid Building Retroarch-$PLATFORM"
+	echo --------------------------------------------------
 	echo
+	BUILD=""
 
-	if [ -n "${LOGURL}" ]; then
-		ENTRY_ID="$(curl -X POST -d type="start" -d master_log="$MASTER_LOG_ID" -d platform="$jobid" -d name="retroarch" http://buildbot.fiveforty.net/build_entry/)"
+	echo WORKINGDIR=$PWD
+	echo RELEASE=$RELEASE
+	echo FORCE=$FORCE_RETROARCH_BUILD
+	echo RADIR=$RADIR
+	echo BRANCH=$BRANCH
+
+	buildbot_pull
+
+	if [ "${BUILD}" = "YES" ] || [ "${FORCE}" = "YES" ] || [ "${FORCE_RETROARCH_BUILD}" = "YES" ] || [ "${CORES_BUILT}" = "YES" ]; then
+		cd "$RADIR"
+		git clean -xdf
+		echo WORKINGDIR=$PWD
+		echo RADIR=$RADIR
+
+		echo "buildbot job: $jobid Building"
+		echo
+
+		if [ -n "${LOGURL}" ]; then
+			ENTRY_ID="$(curl -X POST -d type="start" -d master_log="$MASTER_LOG_ID" -d platform="$jobid" -d name="retroarch" http://buildbot.fiveforty.net/build_entry/)"
+		fi
 	fi
 fi
 
@@ -1637,7 +1638,7 @@ if [ "${PLATFORM}" = "emscripten" ] && [ "${RA}" = "YES" ]; then
 	fi
 fi
 
-if [ "${PLATFORM}" = "unix" ]; then
+if [ "${PLATFORM}" = "unix" ] && [ "${RA}" = "YES" ]; then
 
 	if [ "${BUILD}" = "YES" -o "${FORCE}" = "YES" -o "${FORCE_RETROARCH_BUILD}" == "YES" ]; then
 

--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -876,7 +876,7 @@ while read line; do
 					BUILD="YES"
 				fi
 			done
-		elif [ "${TYPE}" = "SUBMODULE"]; then
+		elif [ "${TYPE}" = "SUBMODULE" ]; then
 			git submodule update --init --recursive
 		fi
 

--- a/recipes/linux/retroarch-linux-x64.conf
+++ b/recipes/linux/retroarch-linux-x64.conf
@@ -5,3 +5,4 @@ CONFIGURE ./configure
 CORE_JOB YES
 MAKE make
 PATH /usr/lib/ccache
+RA YES


### PR DESCRIPTION
This accomplishes a few things.

1. Fixes the submodule path which I broke with a stupid typo...
2. Cleans up the `build_libretro_generic_makefile` function a little bit.
3. Fixes various issues with the cmake build path. Note that it now forces cleaning the cmake `build` directory as cmake seems incapable of cleaning up after itself...
4. Prevents the RetroArch build path from building the ppsspp static makefile.

This PR will also be needed to merge to fix another mistake on systems where glew is installed.
https://github.com/libretro/ppsspp/pull/22