### PR TITLE
Revert "Revert "recipes: Fix Redream recipes.""

### DIFF
--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -74,7 +74,7 @@ puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YE
 px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
 quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
 reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master PROJECT YES GENERIC Makefile .
-redream libretro-redream https://github.com/inolen/redream.git master PROJECT YES GENERIC deps/libretro/Makefile .
+redream libretro-redream https://github.com/inolen/redream.git master PROJECT YES GENERIC Makefile deps/libretro
 remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
 sameboy libretro-sameboy https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile . libretro
 scummvm libretro-scummvm https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -80,7 +80,7 @@ prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git 
 puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
 px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
 quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-redream libretro-redream https://github.com/inolen/redream.git master PROJECT YES GENERIC deps/libretro/Makefile .
+redream libretro-redream https://github.com/inolen/redream.git master PROJECT YES GENERIC Makefile deps/libretro
 reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master PROJECT YES GENERIC Makefile .
 remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
 sameboy libretro-sameboy https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile . libretro

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -79,7 +79,7 @@ prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git 
 puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
 px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
 quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-redream libretro-redream https://github.com/inolen/redream.git master PROJECT YES GENERIC deps/libretro/Makefile .
+redream libretro-redream https://github.com/inolen/redream.git master PROJECT YES GENERIC Makefile deps/libretro
 reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master PROJECT YES GENERIC Makefile .
 remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
 sameboy libretro-sameboy https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile . libretro


### PR DESCRIPTION
This reverts commit daddfab6b5c724c42f3bbb0d782fd2f120b033af.

Please do not merge until if/when this is merged. https://github.com/inolen/redream/pull/231

This fixes the Makefile paths in the redream recipe files which are wrong to accommodate for a path issue in the redream Makefile.