### PR TITLE
recipes: Update recipe.info

### DIFF
--- a/recipes/recipes.info
+++ b/recipes/recipes.info
@@ -4,6 +4,4 @@ RECIPE FORMAT:
 Ex:
 2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
 
-The trailing space is really important for now, if no args are specified there needs to be a trailing space after SUBDIR
 Command should usually be GENERIC and REPOTYPE should usually be project. Notable exceptions are PPSSPP and PICODRIVE. Those are submodule repos.
-


### PR DESCRIPTION
Given that this PR is working this is no longer needed in the recipe.info file.
https://github.com/libretro/libretro-super/pull/602