### PR TITLE
libretro-buildbot-recipe.sh: Remove dead submodule code for RetroArch.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -957,18 +957,6 @@ buildbot_pull(){
 						git clean -xdf
 						BUILD="YES"
 					fi
-				elif [ "${TYPE}" = "SUBMODULE" ]; then
-					RADIR=$DIR
-					if [[ $OUT == *"Already up-to-date"* ]] && [ ! "${BUILD}" = "YES" ]; then
-						BUILD="NO"
-					else
-						echo "resetting repo state $URL... "
-						git reset --hard FETCH_HEAD
-						git clean -xdf
-						BUILD="YES"
-						git submodule update --init --recursive
-						#git submodule foreach git pull origin master
-					fi
 				fi
 				cd $WORK
 			else
@@ -987,14 +975,6 @@ buildbot_pull(){
 				if [ "${TYPE}" = "PROJECT" ]; then
 					BUILD="YES"
 					RADIR=$DIR
-				elif [ "${TYPE}" == "SUBMODULE" ]; then
-					cd $PARENTDIR
-					cd $DIR
-					RADIR=$DIR
-					echo "updating submodules..."
-					git submodule update --init --recursive
-					#git submodule foreach git pull origin master
-					BUILD="YES"
 				fi
 				cd $WORK
 			fi

--- a/recipes/android/retroarch-android-aarch64.ra
+++ b/recipes/android/retroarch-android-aarch64.ra
@@ -1,4 +1,4 @@
-retroarch retroarch-aarch64 https://github.com/libretro/Retroarch.git SUBMODULE YES .
+retroarch retroarch-aarch64 https://github.com/libretro/Retroarch.git PROJECT YES .
 overlays overlays https://github.com/libretro/common-overlays.git ASSETS YES retroarch-aarch64/media
 shaders shaders_glsl https://github.com/libretro/glsl-shaders.git ASSETS YES retroarch-aarch64/media
 autoconfig autoconfig https://github.com/libretro/retroarch-joypad-autoconfig.git ASSETS YES retroarch-aarch64/media

--- a/recipes/android/retroarch-android-dev.ra
+++ b/recipes/android/retroarch-android-dev.ra
@@ -1,4 +1,4 @@
-retroarch retroarch-dev git@github.com:libretro/RetroArchPro.git SUBMODULE YES .
+retroarch retroarch-dev git@github.com:libretro/RetroArchPro.git PROJECT YES .
 overlays overlays https://github.com/libretro/common-overlays.git ASSETS YES retroarch-dev/media
 shaders shaders_cg https://github.com/libretro/common-shaders.git ASSETS YES retroarch-dev/media
 autoconfig autoconfig https://github.com/libretro/retroarch-joypad-autoconfig.git ASSETS YES retroarch-dev/media

--- a/recipes/android/retroarch-android-staging.ra
+++ b/recipes/android/retroarch-android-staging.ra
@@ -1,4 +1,4 @@
-retroarch retroarch-staging https://github.com/fr500/Retroarch.git SUBMODULE YES .
+retroarch retroarch-staging https://github.com/fr500/Retroarch.git PROJECT YES .
 overlays overlays https://github.com/libretro/common-overlays.git ASSETS YES retroarch-staging/media
 shaders shaders_glsl https://github.com/libretro/glsl-shaders.git ASSETS YES retroarch-staging/media
 autoconfig autoconfig https://github.com/libretro/retroarch-joypad-autoconfig.git ASSETS YES retroarch-staging/media

--- a/recipes/android/retroarch-android.ra
+++ b/recipes/android/retroarch-android.ra
@@ -1,4 +1,4 @@
-retroarch retroarch https://github.com/libretro/Retroarch.git SUBMODULE YES .
+retroarch retroarch https://github.com/libretro/Retroarch.git PROJECT YES .
 overlays overlays https://github.com/libretro/common-overlays.git ASSETS YES retroarch/media
 shaders shaders_glsl https://github.com/libretro/glsl-shaders.git ASSETS YES retroarch/media
 autoconfig autoconfig https://github.com/libretro/retroarch-joypad-autoconfig.git ASSETS YES retroarch/media

--- a/recipes/linux/retroarch-linux-x64.ra
+++ b/recipes/linux/retroarch-linux-x64.ra
@@ -1,4 +1,4 @@
-retroarch retroarch https://github.com/libretro/Retroarch.git SUBMODULE YES .
+retroarch retroarch https://github.com/libretro/Retroarch.git PROJECT YES .
 overlays overlays https://github.com/libretro/common-overlays.git ASSETS YES retroarch/media
 shaders shaders_cg https://github.com/libretro/common-shaders.git ASSETS YES retroarch/media
 shaders shaders_glsl https://github.com/libretro/glsl-shaders.git ASSETS YES retroarch/media

--- a/recipes/windows/retroarch-windows-msvc2005-x86_dw2.ra
+++ b/recipes/windows/retroarch-windows-msvc2005-x86_dw2.ra
@@ -1,1 +1,1 @@
-retroarch retroarch https://github.com/libretro/Retroarch.git SUBMODULE YES .
+retroarch retroarch https://github.com/libretro/Retroarch.git PROJECT YES .

--- a/recipes/windows/retroarch-windows-msvc2010-x64_seh.ra
+++ b/recipes/windows/retroarch-windows-msvc2010-x64_seh.ra
@@ -1,1 +1,1 @@
-retroarch retroarch https://github.com/libretro/Retroarch.git SUBMODULE YES .
+retroarch retroarch https://github.com/libretro/Retroarch.git PROJECT YES .

--- a/recipes/windows/retroarch-windows-msvc2010-x86_dw2.ra
+++ b/recipes/windows/retroarch-windows-msvc2010-x86_dw2.ra
@@ -1,1 +1,1 @@
-retroarch retroarch https://github.com/libretro/Retroarch.git SUBMODULE YES .
+retroarch retroarch https://github.com/libretro/Retroarch.git PROJECT YES .

--- a/recipes/windows/retroarch-windows-x64_seh.ra
+++ b/recipes/windows/retroarch-windows-x64_seh.ra
@@ -1,1 +1,1 @@
-retroarch retroarch https://github.com/libretro/Retroarch.git SUBMODULE YES .
+retroarch retroarch https://github.com/libretro/Retroarch.git PROJECT YES .

--- a/recipes/windows/retroarch-windows-x86_dw2.ra
+++ b/recipes/windows/retroarch-windows-x86_dw2.ra
@@ -1,1 +1,1 @@
-retroarch retroarch https://github.com/libretro/Retroarch.git SUBMODULE YES .
+retroarch retroarch https://github.com/libretro/Retroarch.git PROJECT YES .


### PR DESCRIPTION
RetroArch no longer has any submodules and there are very good reasons to not use them for RetroArch again so I think it should be safe to remove this old submodule code specific to RetroArch. The core submodule code is of course left intact. 