### PR TITLE
recipes: Fix nSide recipes

### DIFF
--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -39,7 +39,7 @@ gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GE
 handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
 hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
 higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan target=libretro binary=library
-higan_sfc libretro-nside https://github.com/hex-usr/nSide.git libretro PROJECT YES HIGAN GNUmakefile higan target=libretro binary=library
+higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide target=libretro binary=library
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
 mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . PTR64=1
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -38,7 +38,7 @@ gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GE
 handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
 hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
 higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan target=libretro binary=library
-higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git libretro PROJECT YES HIGAN GNUmakefile nSide target=libretro binary=library
+higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide target=libretro binary=library
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
 mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . PTR64=1
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -37,7 +37,7 @@ gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GE
 handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
 hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
 higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan target=libretro binary=library
-higan_sfc libretro-nside https://github.com/hex-usr/nSide.git libretro PROJECT YES HIGAN GNUmakefile higan target=libretro binary=library
+higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide target=libretro binary=library
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
 mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . PTR64=0
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .


### PR DESCRIPTION
This should fix this for the buildbot.
```
BUILD CMD:  make.exe -f GNUmakefile compiler=g++ target=libretro binary=library -j6
make: GNUmakefile: No such file or directory
make: *** No rule to make target 'GNUmakefile'.  Stop.
COPY CMD cp -fv out/higan_sfc__libretro.dll /home/buildbot/buildbot/windows_x86/dist/win_x86/higan_sfc__libretro.dll
cp: cannot stat 'out/higan_sfc_libretro.dll': No such file or directory
```