### PR TITLE
libretro-buildbot-recipe.sh: Check if the HEAD commit is new or not.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -812,10 +812,10 @@ while read line; do
 			fi
 
 			echo "pulling changes from repo $URL..."
-			OUT="$(git pull)"
-			echo "$OUT"
+			HEAD="$(git rev-parse HEAD)"
+			git pull
 
-			if [[ $OUT == *"Already up-to-date"* ]] && [ "${BUILD}" != "YES" ]; then
+			if [ "$HEAD" = "$(git rev-parse HEAD)" ] && [ "${BUILD}" != "YES" ]; then
 				BUILD="NO"
 			else
 				echo "resetting repo state $URL..."
@@ -944,12 +944,12 @@ buildbot_pull(){
 				fi
 
 				echo "pulling changes from repo $URL... "
-				OUT=`git pull`
-				echo $OUT
+				HEAD="$(git rev-parse HEAD)"
+				git pull
 
 				if [ "${TYPE}" = "PROJECT" ]; then
 					RADIR=$DIR
-					if [[ $OUT == *"Already up-to-date"* ]] && [ ! "${BUILD}" = "YES" ]; then
+					if [ "$HEAD" = "$(git rev-parse HEAD)" ] && [ "${BUILD}" != "YES" ]; then
 						BUILD="NO"
 					else
 						echo "resetting repo state $URL... "


### PR DESCRIPTION
Newer git versions now report `Already up to date.` instead of `Already up-to-date` so we need a more robust solution.