### PR TITLE
libretro-buildbot-recipe.sh: Clean cores after building them.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -885,6 +885,8 @@ while read line; do
 				HIGAN )         build_libretro_higan $NAME $DIR $SUBDIR $MAKEFILE $PLATFORM ${FORMAT_COMPILER_TARGET} ${CXX11} "${ARGS}" ;;
 				* )             :                                                                                                        ;;
 			esac
+			echo "Cleaning repo state after build $URL..."
+			git clean -xdf
 		else
 			echo "buildbot job: building $NAME up-to-date"
 		fi


### PR DESCRIPTION
If a core builds it will not reset and clean the git repo to save space on the buildbot server. If it does not build it will do nothing as before.