### PR TITLE
libretro-buildbot-recipe.sh: Build higan and nSide in the generic make function.

### DIFF
--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -33,7 +33,8 @@ gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE Y
 gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
 handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
 hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan target=libretro binary=library
+higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan compiler=clang++ target=libretro binary=library
+higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide compiler=clang++ target=libretro binary=library
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
 mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro .
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -38,8 +38,8 @@ gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENER
 gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
 handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
 hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan target=libretro binary=library
-higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide target=libretro binary=library
+higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan compiler=g++ target=libretro binary=library
+higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide compiler=g++ target=libretro binary=library
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
 mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . PTR64=1
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -37,8 +37,8 @@ gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENER
 gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
 handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
 hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan target=libretro binary=library
-higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide target=libretro binary=library
+higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan compiler=g++ target=libretro binary=library
+higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide compiler=g++ target=libretro binary=library
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
 mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . PTR64=1
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -36,8 +36,8 @@ gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENER
 gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
 handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
 hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan target=libretro binary=library
-higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide target=libretro binary=library
+higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan compiler=g++ target=libretro binary=library
+higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide compiler=g++ target=libretro binary=library
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
 mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . PTR64=0
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .


### PR DESCRIPTION
This will remove the `build_libretro_higan` function and move the build logic for `higan` and `nside` into the `build_libretro_generic_makefile` function. The goal behind this is generally more clean up.

Another thing to note is that it will no longer install the same core two times in a row...