### PR TITLE
retrolink.sh: Silent shellcheck warnings.

### DIFF
--- a/retrolink.sh
+++ b/retrolink.sh
@@ -3,8 +3,8 @@
 #Usage: ./retrolink foobar_libretro.so
 #http://www.lightofdawn.org/wiki/wiki.cgi/NewAppsOnOldGlibc
 
-start=$(readelf -V $1 | grep -A1 .gnu.version_r | tail -n1 | cut -d' ' -f6)
-pos=$(readelf -V $1 | grep 'Flags: none' | cut -d' ' -f3 | sed 's/://')
+start=$(readelf -V "$1" | grep -A1 .gnu.version_r | tail -n1 | cut -d' ' -f6)
+pos=$(readelf -V "$1" | grep 'Flags: none' | cut -d' ' -f3 | sed 's/://')
 for pos in $pos; do
-printf '\x02' | dd if=/dev/stdin of=$1 seek=$(($start+$pos+4)) count=1 bs=1 conv=notrunc 2> /dev/null
+printf '\x02' | dd if=/dev/stdin of="$1" seek=$((start+pos+4)) count=1 bs=1 conv=notrunc 2> /dev/null
 done


### PR DESCRIPTION
Silences these warnings in the `retrolink,sh` script.
```
Line 6:
start=$(readelf -V $1 | grep -A1 .gnu.version_r | tail -n1 | cut -d' ' -f6)
                             ^-- SC2086: Double quote to prevent globbing and word splitting.

Line 7:
pos=$(readelf -V $1 | grep 'Flags: none' | cut -d' ' -f3 | sed 's/://')
                           ^-- SC2086: Double quote to prevent globbing and word splitting.

Line 9:
printf '\x02' | dd if=/dev/stdin of=$1 seek=$(($start+$pos+4)) count=1 bs=1 conv=notrunc 2> /dev/null
                                                  ^-- SC2086: Double quote to prevent globbing and word splitting.
                                                                      ^-- SC2004: $/${} is unnecessary on arithmetic variables.
                                                                                 ^-- SC2004: $/${} is unnecessary on arithmetic variables.
```
Also see.
https://github.com/koalaman/shellcheck/wiki/SC2086
https://github.com/koalaman/shellcheck/wiki/SC2004