### PR TITLE
libretro-buildbot-recipe.sh: Always use the branch in the recipe file.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -748,7 +748,7 @@ while read line; do
 			UPDATE="NO"
 		fi
 
-		cd "$DIR"
+		cd "$DIR" || { echo "Failed to cd to ${DIR}, skipping ${NAME}"; continue; }
 
 		CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 

--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -752,7 +752,7 @@ while read line; do
 
 		CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 
-		if [ "${GIT_BRANCH}" != "${CURRENT_BRANCH}" ]; then
+		if [ "${GIT_BRANCH}" != "${CURRENT_BRANCH}" ] && [ "${TRAVIS:-0}" = "0" ]; then
 			echo "Changing to the branch ${GIT_BRANCH} from ${CURRENT_BRANCH}"
 			git remote set-branches origin "${GIT_BRANCH}"
 			git fetch --depth 1 origin "${GIT_BRANCH}"

--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -750,6 +750,18 @@ while read line; do
 
 		cd "$DIR"
 
+		CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+		if [ "${GIT_BRANCH}" != "${CURRENT_BRANCH}" ]; then
+			echo "Changing to the branch ${GIT_BRANCH} from ${CURRENT_BRANCH}"
+			git remote set-branches origin "${GIT_BRANCH}"
+			git fetch --depth 1 origin "${GIT_BRANCH}"
+			git checkout "${GIT_BRANCH}"
+			git branch -D "${CURRENT_BRANCH}"
+			BUILD="YES"
+			UPDATE="NO"
+		fi
+
 		if [ "${UPDATE}" != "NO" ]; then
 			if [ -f .forcebuild ]; then
 				echo "found .forcebuild file, building $NAME"

--- a/recipes/apple/cores-ios-generic
+++ b/recipes/apple/cores-ios-generic
@@ -2,9 +2,9 @@
 4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . accuracy
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . balanced
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . accuracy
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . balanced

--- a/recipes/apple/cores-ios9-generic
+++ b/recipes/apple/cores-ios9-generic
@@ -2,9 +2,9 @@
 4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . accuracy
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . balanced
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . accuracy
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . balanced

--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -2,9 +2,9 @@
 4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . accuracy
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . balanced
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . accuracy
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . balanced

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -3,9 +3,9 @@
 4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . accuracy
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . balanced
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . accuracy
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . balanced

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -4,9 +4,9 @@
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
 bnes libretro-bnes https://github.com/libretro/bnes-libretro.git master PROJECT YES GENERIC Makefile .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master PROJECT YES BSNES Makefile . performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . accuracy
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . balanced
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . accuracy
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . balanced

--- a/travis/build-long.sh
+++ b/travis/build-long.sh
@@ -4,6 +4,7 @@ export LOGDATE=`date +%Y-%m-%d`
 mkdir -p /tmp/log/${LOGDATE}
 export BOT=.
 export TMPDIR=/tmp
+export TRAVIS=1
 export EXIT_ON_ERROR=1
 
 # taken from https://stackoverflow.com/questions/26082444/how-to-work-around-travis-cis-4mb-output-limit

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -4,6 +4,7 @@ export LOGDATE=`date +%Y-%m-%d`
 mkdir -p /tmp/log/${LOGDATE}
 export BOT=.
 export TMPDIR=/tmp
+export TRAVIS=1
 export EXIT_ON_ERROR=1
 
 ./build-${PLATFORM}.sh


### PR DESCRIPTION
If the checked out branch does not match the branch name in the recipe file the script will now make a shallow fetch of the correct branch, checkout the new branch and then remove the old one. If this is done it will also build a core with the new branch.

The motivation behind this is that I noticed that some of the `bsnes-libretro` recipes are using the incorrect and outdated branch `master` instead of the default `libretro`. While fixing this is easy, before this commit it would of also have meant changing each clone on the buildbot server manually and this now should be an automatic process. Additionally I wonder if this will uncover any repos which have been on the wrong branch for a while?