### PR TITLE
libretro-buildbot-recipe.sh: Build all three profiles for the bsnes cores.

### DIFF
--- a/recipes/android/cores-android-jni
+++ b/recipes/android/cores-android-jni
@@ -2,12 +2,8 @@
 3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master PROJECT YES GENERIC_JNI Makefile jni
 4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC_JNI Makefile jni
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES_JNI Makefile target-libretro/jni profile=accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES_JNI Makefile target-libretro/jni profile=balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES_JNI Makefile target-libretro/jni profile=performance
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES_JNI Makefile target-libretro/jni profile=accuracy
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES_JNI Makefile target-libretro/jni profile=balanced
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES_JNI Makefile target-libretro/jni profile=performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES_JNI Makefile target-libretro/jni
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES_JNI Makefile target-libretro/jni
 craft libretro-craft https://github.com/libretro/Craft.git master PROJECT YES GENERIC_JNI Makefile.libretro jni
 crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master PROJECT YES GENERIC_JNI Makefile jni
 desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC_JNI Makefile.libretro desmume/src/libretro/jni

--- a/recipes/android/cores-android-jni-aarch64
+++ b/recipes/android/cores-android-jni-aarch64
@@ -2,12 +2,8 @@
 3dengine libretro64-3dengine https://github.com/libretro/libretro-3dengine.git master PROJECT YES GENERIC_JNI Makefile jni
 4do libretro64-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
 bluemsx libretro64-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-bsnes libretro64-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES_JNI Makefile target-libretro/jni profile=performance
-bsnes libretro64-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES_JNI Makefile target-libretro/jni profile=balanced
-bsnes libretro64-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES_JNI Makefile target-libretro/jni profile=accuracy
-bsnes_mercury libretro64-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES_JNI Makefile target-libretro/jni profile=performance
-bsnes_mercury libretro64-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES_JNI Makefile target-libretro/jni profile=balanced
-bsnes_mercury libretro64-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES_JNI Makefile target-libretro/jni profile=accuracy
+bsnes libretro64-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES_JNI Makefile target-libretro/jni
+bsnes_mercury libretro64-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES_JNI Makefile target-libretro/jni
 snes9x2002 libretro64-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC_JNI Makefile jni
 snes9x2005 libretro64-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC_JNI Makefile jni
 snes9x2010 libretro64-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_JNI Makefile jni

--- a/recipes/apple/cores-ios-generic
+++ b/recipes/apple/cores-ios-generic
@@ -2,13 +2,9 @@
 4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=accuracy
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=balanced
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=performance
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
 craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
 crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
 desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume

--- a/recipes/apple/cores-ios9-generic
+++ b/recipes/apple/cores-ios9-generic
@@ -2,13 +2,9 @@
 4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=accuracy
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=balanced
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=performance
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
 craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
 crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
 desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume

--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -2,13 +2,9 @@
 4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=accuracy
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=balanced
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=performance
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
 chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master SUBMODULE YES GENERIC Makefile .
 citra libretro-citra https://github.com/libretro/citra.git master SUBMODULE YES CMAKE Makefile build -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DDISABLE_LIBPNG=1 -DCMAKE_BUILD_TYPE="Release" --target citra_libretro
 craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -3,13 +3,9 @@
 4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=accuracy
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=balanced
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=performance
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
 cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .
 chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master SUBMODULE YES GENERIC Makefile .
 desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume platform=armv7-neon-hardfloat

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -5,13 +5,9 @@
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
 bnes libretro-bnes https://github.com/libretro/bnes-libretro.git master PROJECT YES GENERIC Makefile .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=accuracy
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=balanced
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=performance
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
 cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .
 chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master SUBMODULE YES GENERIC Makefile .
 citra libretro-citra https://github.com/libretro/citra.git master SUBMODULE YES CMAKE Makefile build -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DDISABLE_LIBPNG=1 -DCMAKE_BUILD_TYPE="Release" -DENABLE_WEB_SERVICE=0 -DUSE_SYSTEM_CURL=1 --target citra_libretro

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -4,13 +4,9 @@
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
 bnes libretro-bnes https://github.com/libretro/bnes-libretro.git master PROJECT YES GENERIC Makefile .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=accuracy
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=balanced
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=performance
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
 craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
 crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
 cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -5,13 +5,9 @@
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
 bnes libretro-bnes https://github.com/libretro/bnes-libretro.git master PROJECT YES GENERIC Makefile .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=accuracy
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=balanced
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=performance
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
 cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .
 chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master SUBMODULE YES GENERIC Makefile .
 craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -5,13 +5,9 @@
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
 bnes libretro-bnes https://github.com/libretro/bnes-libretro.git master PROJECT YES GENERIC Makefile .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=accuracy
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=balanced
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile . profile=performance
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=accuracy
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=balanced
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile . profile=performance
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
 cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .
 chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master SUBMODULE YES GENERIC Makefile .
 craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .


### PR DESCRIPTION
If the command is `BSNES` or `BSNES_JNI` which are now only used for `bsnes-libretro` and `bsnes-mercury` it will build all three profiles. This is especially important because at some point the buildbot only started to update the `accuracy` profile and this should fix that.

Additionally the recipe files no longer require multiple lines for these cores.

Warning! I am not currently capable of testing this on android, but it probably works and I can troubleshoot it with the help of the buildbot.

Fixes https://github.com/libretro/libretro-super/issues/241