### PR TITLE
libretro-buildbot-recipe.sh: Use the RECIPE name for the log files.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -892,7 +892,7 @@ if [ "${RA}" = "YES" ]; then
 			ENTRY_ID="$(curl -X POST -d type="start" -d master_log="$MASTER_LOG_ID" -d platform="$jobid" -d name="retroarch" http://buildbot.fiveforty.net/build_entry/)"
 		fi
 
-		LOGFILE="$TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_RetroArch_${PLATFORM}.log"
+		LOGFILE="$TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_RetroArch_${RECIPE##*/}.log"
 	fi
 fi
 


### PR DESCRIPTION
Should fix an issue where more than one log was being added to the same file.

http://p.0bl.net/105721