### PR TITLE
libretro-buildbot-recipe.sh: Remove seemingly unneeded and non-portable bash redirection.

### DIFF
--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -282,12 +282,7 @@ libretro_build_core() {
 		exec 6>&1
 		echo "Building ${1}..." >> $log_module
 
-		# TODO: Possibly a shell function for tee?
-		if [[ -n "$LIBRETRO_DEVELOPER" && -n "${cmd_tee:=$(find_tool "tee")}" ]]; then
-			exec > >($cmd_tee -a $log_module)
-		else
-			exec > $log_module
-		fi
+		exec > $log_module
 	fi
 
 	case "$core_build_rule" in


### PR DESCRIPTION
This should help the following issue reported by aaa801 in irc.
```
# Pastebin AyhdxPKp
Compiler: CC="ppu-lv2-gcc.exe" CXX="ppu-lv2-g++.exe"
ps3
ps3
=== 81
Building 81...
/g/retroarch/libretro-super/libretro-build-common.sh: cannot make pipe for process substitution: Function not implemented
/g/retroarch/libretro-super/libretro-build-common.sh: cannot make pipe for process substitution: Function not implemented
/g/retroarch/libretro-super/libretro-build-common.sh: line 287: >($cmd_tee -a $log_module): ambiguous redirect
```
@bparker06 I can't figure out what `exec > >$cmd_tee -a $log_module)` does that `exec > $logfile` doesn't already, but maybe you see something I am overlooking? Given the latter should be more portable I think that is preferable.