### PR TITLE
Revert "libretro-buildbot-recipe.sh: Remove seemingly unneeded and non-portable bash redirection."

### DIFF
--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -282,7 +282,12 @@ libretro_build_core() {
 		exec 6>&1
 		echo "Building ${1}..." >> $log_module
 
-		exec > $log_module
+		# TODO: Possibly a shell function for tee?
+		if [[ -n "$LIBRETRO_DEVELOPER" && -n "${cmd_tee:=$(find_tool "tee")}" ]]; then
+			exec > >($cmd_tee -a $log_module)
+		else
+			exec > $log_module
+		fi
 	fi
 
 	case "$core_build_rule" in


### PR DESCRIPTION
Reverts libretro/libretro-super#635

It turns out this causes problems with loss of verbosity. I tried to come up with a more portable method, but all of the possibilities seem less than ideal so lets revert this for now. The caveat is that this won't work on some older bash versions. I'm not sure what the exact cut off is. If I can find a better way I will come back later to improve this.

Meanwhile here is some documentation on this feature.
https://unix.stackexchange.com/questions/145651/using-exec-and-tee-to-redirect-logs-to-stdout-and-a-log-file-in-the-same-time