### PR TITLE
Submodule

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -552,14 +552,13 @@ while read line; do
 	DIR="$2"
 	URL="$3"
 	GIT_BRANCH="$4"
-	TYPE="$5"
-	ENABLED="$6"
-	COMMAND="$7"
-	MAKEFILE="$8"
-	SUBDIR="$9"
+	ENABLED="$5"
+	COMMAND="$6"
+	MAKEFILE="$7"
+	SUBDIR="$8"
 	ARGS=""
 
-	shift 9
+	shift 8
 	while [ $# -gt 0 ]; do
 		ARGS="${ARGS} ${1}"
 		shift
@@ -580,7 +579,6 @@ while read line; do
 		echo --------------------------------------------------
 		echo Variables:
 		echo URL		  $URL
-		echo REPO TYPE  $TYPE
 		echo ENABLED	 $ENABLED
 		echo COMMAND	 $COMMAND
 		echo MAKEFILE	$MAKEFILE

--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -634,32 +634,32 @@ while read line; do
 			fi
 		fi
 
-		if [ "${TYPE}" = "PROJECT" ]; then
-			FORCE_ORIG=$FORCE
-			OLDBUILD=$BUILD
+		FORCE_ORIG=$FORCE
+		OLDBUILD=$BUILD
 
-			if [ "${PREVCORE}" = "mame2014" ] && [ "${PREVBUILD}" = "YES" ] && [ "${NAME}" = "mess2014" ]; then
+		if [ "${PREVCORE}" = "mame2014" ] && [ "${PREVBUILD}" = "YES" ] && [ "${NAME}" = "mess2014" ]; then
+			FORCE="YES"
+			BUILD="YES"
+		fi
+
+		if [ "${PREVCORE}" = "mess2014" ] && [ "${PREVBUILD}" = "YES" ] && [ "${NAME}" = "ume2014" ]; then
+			FORCE="YES"
+			BUILD="YES"
+		fi
+
+		if [[ "${PREVCORE}" == *fbalpha2012* ]] && [[ "${PREVBUILD}" = "YES" ]] && [[ "${NAME}" == *fbalpha2012* ]]; then
+			FORCE="YES"
+			BUILD="YES"
+		fi
+
+		for core in 81 emux_nes emux_sms fuse gw mame2010 mgba snes9x_next snes9x-next vba_next; do
+			if [ "${PREVCORE}" = "$core" ] && [ "${PREVBUILD}" = "YES" ] && [ "${NAME}" = "$core" ]; then
 				FORCE="YES"
 				BUILD="YES"
 			fi
+		done
 
-			if [ "${PREVCORE}" = "mess2014" ] && [ "${PREVBUILD}" = "YES" ] && [ "${NAME}" = "ume2014" ]; then
-				FORCE="YES"
-				BUILD="YES"
-			fi
-
-			if [[ "${PREVCORE}" == *fbalpha2012* ]] && [[ "${PREVBUILD}" = "YES" ]] && [[ "${NAME}" == *fbalpha2012* ]]; then
-				FORCE="YES"
-				BUILD="YES"
-			fi
-
-			for core in 81 emux_nes emux_sms fuse gw mame2010 mgba snes9x_next snes9x-next vba_next; do
-				if [ "${PREVCORE}" = "$core" ] && [ "${PREVBUILD}" = "YES" ] && [ "${NAME}" = "$core" ]; then
-					FORCE="YES"
-					BUILD="YES"
-				fi
-			done
-		elif [ "${TYPE}" = "SUBMODULE" ]; then
+		if git config --file .gitmodules --name-only --get-regexp path 2>&1 >/dev/null; then
 			git submodule update --init --recursive
 		fi
 

--- a/recipes/android/cores-android-armv7-ndk
+++ b/recipes/android/cores-android-armv7-ndk
@@ -1,4 +1,4 @@
-mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC Makefile .
-mupen64plus_gles3 libretro-mupen64plus-gles3 https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC Makefile . platform=android-armv7-gles3
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft PTR64=0 CC=arm-linux-androideabi-gcc CXX=arm-linux-androideabi-g++ LD=arm-linux-androideabi-g++ platform=android emulator
-scummvm libretro-scummvm https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
+mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC Makefile .
+mupen64plus_gles3 libretro-mupen64plus-gles3 https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC Makefile . platform=android-armv7-gles3
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft PTR64=0 CC=arm-linux-androideabi-gcc CXX=arm-linux-androideabi-g++ LD=arm-linux-androideabi-g++ platform=android emulator
+scummvm libretro-scummvm https://github.com/libretro/scummvm.git master YES GENERIC Makefile backends/platform/libretro/build

--- a/recipes/android/cores-android-armv7-ndk-mame
+++ b/recipes/android/cores-android-armv7-ndk-mame
@@ -1,1 +1,1 @@
-mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC makefile . OSD=retro verbose=1 RETRO=1 NOWERROR=1 NOASM=1 gcc=android-arm OS=linux TARGETOS=android-arm CONFIG=libretro NO_USE_MIDI=1 TARGET=mame
+mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC makefile . OSD=retro verbose=1 RETRO=1 NOWERROR=1 NOASM=1 gcc=android-arm OS=linux TARGETOS=android-arm CONFIG=libretro NO_USE_MIDI=1 TARGET=mame

--- a/recipes/android/cores-android-armv7-ndk-old-mame
+++ b/recipes/android/cores-android-armv7-ndk-old-mame
@@ -1,4 +1,4 @@
-mame2014 libretro-mame2014o https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame
-mess2014 libretro-mame2014o https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess
-ume2014 libretro-mame2014o https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume
-mame2016 libretro-mame2016o https://github.com/libretro/mame2016-libretro master PROJECT YES GENERIC makefile . OSD=retro RETRO=1 NOWERROR=1 NOASM=1 gcc=android-arm gcc_version=4.9 TARGETOS=android-arm CONFIG=libretro NO_USE_MIDI=1 OS=linux VERBOSE=1 verbose=1 OVERRIDE_CC=/home/buildbot/tools/android/android-ndk-r10e/toolchains/llvm-3.5/prebuilt/linux-x86_64/bin/clang OVERRIDE_CXX=/home/buildbot/tools/android/android-ndk-r10e/toolchains/llvm-3.5/prebuilt/linux-x86_64/bin/clang++ TARGET=mame
+mame2014 libretro-mame2014o https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame
+mess2014 libretro-mame2014o https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess
+ume2014 libretro-mame2014o https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume
+mame2016 libretro-mame2016o https://github.com/libretro/mame2016-libretro master YES GENERIC makefile . OSD=retro RETRO=1 NOWERROR=1 NOASM=1 gcc=android-arm gcc_version=4.9 TARGETOS=android-arm CONFIG=libretro NO_USE_MIDI=1 OS=linux VERBOSE=1 verbose=1 OVERRIDE_CC=/home/buildbot/tools/android/android-ndk-r10e/toolchains/llvm-3.5/prebuilt/linux-x86_64/bin/clang OVERRIDE_CXX=/home/buildbot/tools/android/android-ndk-r10e/toolchains/llvm-3.5/prebuilt/linux-x86_64/bin/clang++ TARGET=mame

--- a/recipes/android/cores-android-cmake-aarch64
+++ b/recipes/android/cores-android-cmake-aarch64
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-aarch64 https://github.com/libretro/ppsspp.git master SUBMODULE YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-aarch64 https://github.com/libretro/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-armv7
+++ b/recipes/android/cores-android-cmake-armv7
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-armv7 https://github.com/libretro/ppsspp.git master SUBMODULE YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-armv7 https://github.com/libretro/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-x86
+++ b/recipes/android/cores-android-cmake-x86
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-x86 https://github.com/libretro/ppsspp.git master SUBMODULE YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-x86 https://github.com/libretro/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cross
+++ b/recipes/android/cores-android-cross
@@ -1,32 +1,32 @@
-81 libretro64-81 https://github.com/libretro/81-libretro.git master PROJECT YES LEIRADEL Makefile build armeabi
-81 libretro64-81 https://github.com/libretro/81-libretro.git master PROJECT YES LEIRADEL Makefile build armeabi-v7a
-81 libretro64-81 https://github.com/libretro/81-libretro.git master PROJECT YES LEIRADEL Makefile build arm64-v8a
-81 libretro64-81 https://github.com/libretro/81-libretro.git master PROJECT YES LEIRADEL Makefile build x86
-emux_chip8 libretro64-emux_chip8 https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro armeabi MACHINE=chip8
-emux_chip8 libretro64-emux_chip8 https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro armeabi-v7a MACHINE=chip8
-emux_chip8 libretro64-emux_chip8 https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro arm64-v8a MACHINE=chip8
-emux_chip8 libretro64-emux_chip8 https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86 MACHINE=chip8
-emux_gb libretro64-emux_gb https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro armeabi MACHINE=gb
-emux_gb libretro64-emux_gb https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro armeabi-v7a MACHINE=gb
-emux_gb libretro64-emux_gb https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro arm64-v8a MACHINE=gb
-emux_gb libretro64-emux_gb https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86 MACHINE=gb
-emux_nes libretro64-emux_nes https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro armeabi MACHINE=nes
-emux_nes libretro64-emux_nes https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro armeabi-v7a MACHINE=nes
-emux_nes libretro64-emux_nes https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro arm64-v8a MACHINE=nes
-emux_nes libretro64-emux_nes https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86 MACHINE=nes
-emux_sms libretro64-emux_sms https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro armeabi MACHINE=sms
-emux_sms libretro64-emux_sms https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro armeabi-v7a MACHINE=sms
-emux_sms libretro64-emux_sms https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro arm64-v8a MACHINE=sms
-emux_sms libretro64-emux_sms https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86 MACHINE=sms
-fuse libretro64-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES LEIRADEL Makefile build armeabi
-fuse libretro64-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES LEIRADEL Makefile build armeabi-v7a
-fuse libretro64-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES LEIRADEL Makefile build arm64-v8a
-fuse libretro64-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES LEIRADEL Makefile build x86
-gw libretro64-gw https://github.com/libretro/gw-libretro.git master PROJECT YES LEIRADEL Makefile build armeabi
-gw libretro64-gw https://github.com/libretro/gw-libretro.git master PROJECT YES LEIRADEL Makefile build armeabi-v7a
-gw libretro64-gw https://github.com/libretro/gw-libretro.git master PROJECT YES LEIRADEL Makefile build arm64-v8a
-gw libretro64-gw https://github.com/libretro/gw-libretro.git master PROJECT YES LEIRADEL Makefile build x86
-mgba libretro64-mgba https://github.com/libretro/mgba.git master PROJECT YES LEIRADEL Makefile libretro-build armeabi
-mgba libretro64-mgba https://github.com/libretro/mgba.git master PROJECT YES LEIRADEL Makefile libretro-build armeabi-v7a
-mgba libretro64-mgba https://github.com/libretro/mgba.git master PROJECT YES LEIRADEL Makefile libretro-build arm64-v8a
-mgba libretro64-mgba https://github.com/libretro/mgba.git master PROJECT YES LEIRADEL Makefile libretro-build x86
+81 libretro64-81 https://github.com/libretro/81-libretro.git master YES LEIRADEL Makefile build armeabi
+81 libretro64-81 https://github.com/libretro/81-libretro.git master YES LEIRADEL Makefile build armeabi-v7a
+81 libretro64-81 https://github.com/libretro/81-libretro.git master YES LEIRADEL Makefile build arm64-v8a
+81 libretro64-81 https://github.com/libretro/81-libretro.git master YES LEIRADEL Makefile build x86
+emux_chip8 libretro64-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi MACHINE=chip8
+emux_chip8 libretro64-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi-v7a MACHINE=chip8
+emux_chip8 libretro64-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro arm64-v8a MACHINE=chip8
+emux_chip8 libretro64-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=chip8
+emux_gb libretro64-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi MACHINE=gb
+emux_gb libretro64-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi-v7a MACHINE=gb
+emux_gb libretro64-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro arm64-v8a MACHINE=gb
+emux_gb libretro64-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=gb
+emux_nes libretro64-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi MACHINE=nes
+emux_nes libretro64-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi-v7a MACHINE=nes
+emux_nes libretro64-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro arm64-v8a MACHINE=nes
+emux_nes libretro64-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=nes
+emux_sms libretro64-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi MACHINE=sms
+emux_sms libretro64-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi-v7a MACHINE=sms
+emux_sms libretro64-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro arm64-v8a MACHINE=sms
+emux_sms libretro64-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=sms
+fuse libretro64-fuse https://github.com/libretro/fuse-libretro.git master YES LEIRADEL Makefile build armeabi
+fuse libretro64-fuse https://github.com/libretro/fuse-libretro.git master YES LEIRADEL Makefile build armeabi-v7a
+fuse libretro64-fuse https://github.com/libretro/fuse-libretro.git master YES LEIRADEL Makefile build arm64-v8a
+fuse libretro64-fuse https://github.com/libretro/fuse-libretro.git master YES LEIRADEL Makefile build x86
+gw libretro64-gw https://github.com/libretro/gw-libretro.git master YES LEIRADEL Makefile build armeabi
+gw libretro64-gw https://github.com/libretro/gw-libretro.git master YES LEIRADEL Makefile build armeabi-v7a
+gw libretro64-gw https://github.com/libretro/gw-libretro.git master YES LEIRADEL Makefile build arm64-v8a
+gw libretro64-gw https://github.com/libretro/gw-libretro.git master YES LEIRADEL Makefile build x86
+mgba libretro64-mgba https://github.com/libretro/mgba.git master YES LEIRADEL Makefile libretro-build armeabi
+mgba libretro64-mgba https://github.com/libretro/mgba.git master YES LEIRADEL Makefile libretro-build armeabi-v7a
+mgba libretro64-mgba https://github.com/libretro/mgba.git master YES LEIRADEL Makefile libretro-build arm64-v8a
+mgba libretro64-mgba https://github.com/libretro/mgba.git master YES LEIRADEL Makefile libretro-build x86

--- a/recipes/android/cores-android-jni
+++ b/recipes/android/cores-android-jni
@@ -1,70 +1,70 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC_JNI Makefile jni
-3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master PROJECT YES GENERIC_JNI Makefile jni
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC_JNI Makefile jni
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES_JNI Makefile target-libretro/jni
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES_JNI Makefile target-libretro/jni
-craft libretro-craft https://github.com/libretro/Craft.git master PROJECT YES GENERIC_JNI Makefile.libretro jni
-crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master PROJECT YES GENERIC_JNI Makefile jni
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC_JNI Makefile.libretro desmume/src/libretro/jni
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC_JNI Makefile jni
-dolphin libretro-dolphin https://github.com/libretro/dolphin.git master PROJECT YES GENERIC_JNI Makefile.libretro Source/Core/DolphinLibretro/jni
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC_JNI Makefile.libretro jni
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC_JNI makefile.libretro jni
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC_JNI makefile.libretro svn-current/trunk/projectfiles/libretro-android/jni
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC_JNI Makefile.libretro jni
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC_JNI Makefile libgambatte/libretro/jni
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC_JNI Makefile.libretro libretro/jni
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC_JNI Makefile jni
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC_JNI Makefile jni
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC_JNI Makefile jni
-lutro libretro-lutro https://github.com/libretro/libretro-lutro.git master PROJECT YES GENERIC_JNI Makefile jni
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC_JNI Makefile parallel-psx/jni
-mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-melonds libretro-melonds https://github.com/libretro/melonDS.git master PROJECT YES GENERIC_JNI Makefile jni
-meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC_JNI Makefile libretro/jni
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC_JNI Makefile.libretro libretro/jni
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC_JNI Makefile.libretro jni
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC_JNI Makefile jni
-openlara libretro-openlara https://github.com/libretro/OpenLara.git master PROJECT YES GENERIC_JNI Makefile src/platform/libretro/jni
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_JNI Makefile jni
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC_JNI Makefile.libretro jni
-pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC_JNI Makefile.libretro . USE_DYNAREC=0
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC_JNI Makefile.libretro jni
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master PROJECT YES GENERIC_JNI Makefile jni
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC_JNI Makefile jni
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_JNI Makefile jni
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-puae libretro-puae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC_JNI Makefile jni
-px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC_JNI Makefile.libretro libretro/jni
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC_JNI Makefile libretro/jni
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC_JNI Makefile jni
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC_JNI Makefile jni
-snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC_JNI Makefile . USE_BLARGG_APU=1
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_JNI Makefile jni
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC_JNI Makefile jni
-uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC_JNI Makefile jni
-vba_next libretro-vba-next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC_JNI Makefile libretro/jni
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC_JNI Makefile src/libretro/jni
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC_JNI Makefile.libretro jni
-vice_x64 libretro-vice https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC_JNI Makefile libretro/jni
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC_JNI Makefile jni
+3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master YES GENERIC_JNI Makefile jni
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC_JNI Makefile jni
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC_JNI Makefile jni
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro YES BSNES_JNI Makefile target-libretro/jni
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES BSNES_JNI Makefile target-libretro/jni
+craft libretro-craft https://github.com/libretro/Craft.git master YES GENERIC_JNI Makefile.libretro jni
+crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master YES GENERIC_JNI Makefile jni
+desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC_JNI Makefile.libretro desmume/src/libretro/jni
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC_JNI Makefile jni
+dolphin libretro-dolphin https://github.com/libretro/dolphin.git master YES GENERIC_JNI Makefile.libretro Source/Core/DolphinLibretro/jni
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC_JNI Makefile.libretro jni
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC_JNI makefile.libretro jni
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC_JNI makefile.libretro svn-current/trunk/projectfiles/libretro-android/jni
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC_JNI Makefile.libretro jni
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC_JNI Makefile jni
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC_JNI Makefile libgambatte/libretro/jni
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC_JNI Makefile.libretro libretro/jni
+gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC_JNI Makefile jni
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master YES GENERIC_JNI Makefile jni
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC_JNI Makefile jni
+lutro libretro-lutro https://github.com/libretro/libretro-lutro.git master YES GENERIC_JNI Makefile jni
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC_JNI Makefile jni
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC_JNI Makefile parallel-psx/jni
+mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC_JNI Makefile jni
+melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC_JNI Makefile jni
+meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC_JNI Makefile libretro/jni
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC_JNI Makefile jni
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC_JNI Makefile.libretro libretro/jni
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC_JNI Makefile.libretro jni
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC_JNI Makefile jni
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC_JNI Makefile jni
+openlara libretro-openlara https://github.com/libretro/OpenLara.git master YES GENERIC_JNI Makefile src/platform/libretro/jni
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_JNI Makefile jni
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC_JNI Makefile.libretro jni
+pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/libretro/pcsx_rearmed.git master YES GENERIC_JNI Makefile.libretro . USE_DYNAREC=0
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC_JNI Makefile.libretro jni
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC_JNI Makefile jni
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC_JNI Makefile jni
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_JNI Makefile jni
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC_JNI Makefile jni
+puae libretro-puae https://github.com/libretro/libretro-uae.git master YES GENERIC_JNI Makefile jni
+px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES GENERIC_JNI Makefile.libretro libretro/jni
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC_JNI Makefile libretro/jni
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC_JNI Makefile jni
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC_JNI Makefile jni
+snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master YES GENERIC_JNI Makefile . USE_BLARGG_APU=1
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC_JNI Makefile jni
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC_JNI Makefile jni
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC_JNI Makefile jni
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC_JNI Makefile jni
+uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC_JNI Makefile jni
+vba_next libretro-vba-next https://github.com/libretro/vba-next.git master YES GENERIC_JNI Makefile libretro/jni
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC_JNI Makefile src/libretro/jni
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC_JNI Makefile.libretro jni
+vice_x64 libretro-vice https://github.com/libretro/vice-libretro.git master YES GENERIC_JNI Makefile jni
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC_JNI Makefile jni
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC_JNI Makefile jni
+yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC_JNI Makefile libretro/jni

--- a/recipes/android/cores-android-jni-aarch64
+++ b/recipes/android/cores-android-jni-aarch64
@@ -1,72 +1,72 @@
-2048 libretro64-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC_JNI Makefile jni
-3dengine libretro64-3dengine https://github.com/libretro/libretro-3dengine.git master PROJECT YES GENERIC_JNI Makefile jni
-4do libretro64-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-bluemsx libretro64-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-bsnes libretro64-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES_JNI Makefile target-libretro/jni
-bsnes_mercury libretro64-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES_JNI Makefile target-libretro/jni
-snes9x2002 libretro64-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC_JNI Makefile jni
-snes9x2005 libretro64-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC_JNI Makefile jni
-snes9x2010 libretro64-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_JNI Makefile jni
-snes9x libretro64-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC_JNI Makefile libretro/jni
-snes9x2010 libretro64-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_JNI Makefile jni
-craft libretro64-craft https://github.com/libretro/Craft.git master PROJECT YES GENERIC_JNI Makefile.libretro jni
-crocods libretro64-crocods https://github.com/libretro/libretro-crocods.git master PROJECT YES GENERIC_JNI Makefile jni
-desmume libretro64-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC_JNI Makefile.libretro desmume/src/libretro/jni
-dolphin libretro64-dolphin https://github.com/libretro/dolphin.git master PROJECT YES GENERIC_JNI Makefile.libretro Source/Core/DolphinLibretro/jni
-dinothawr libretro64-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC_JNI Makefile jni
-dosbox libretro64-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC_JNI Makefile.libretro jni
-fbalpha libretro64-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC_JNI makefile.libretro jni
-fbalpha2012 libretro64-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC_JNI makefile.libretro svn-current/trunk/projectfiles/libretro-android/jni
-fceumm libretro64-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC_JNI Makefile.libretro jni
-fmsx libretro64-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-gambatte libretro64-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC_JNI Makefile libgambatte/libretro/jni
-genesis_plus_gx libretro64-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC_JNI Makefile.libretro libretro/jni
-gme libretro64-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC_JNI Makefile jni
-gpsp libretro64-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC_JNI Makefile jni
-handy libretro64-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC_JNI Makefile jni
-lutro libretro64-lutro https://github.com/libretro/libretro-lutro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_gba libretro64-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_lynx libretro64-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_ngp libretro64-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_pce_fast libretro64-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_pcfx libretro64-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_psx libretro64-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_psx_hw libretro64-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC_JNI Makefile parallel-psx/jni
-mednafen_saturn libretro64-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_snes libretro64-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_supergrafx libretro64-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_vb libretro64-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mednafen_wswan libretro64-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-melonds libretro64-melonds https://github.com/libretro/melonDS.git master PROJECT YES GENERIC_JNI Makefile jni
-meteor libretro64-meteor https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC_JNI Makefile libretro/jni
-mame2003 libretro64-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mame2000 libretro64-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-mrboom libretro64-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-nekop2 libretro64-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC_JNI Makefile.libretro libretro/jni
-np2kai libretro64-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC_JNI Makefile.libretro jni
-parallel_n64 libretro64-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_JNI Makefile jni
-nxengine libretro64-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-o2em libretro64-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC_JNI Makefile jni
-openlara libretro64-openlara https://github.com/libretro/OpenLara.git master PROJECT YES GENERIC_JNI Makefile src/platform/libretro/jni
-pcsx_rearmed libretro64-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC_JNI Makefile.libretro jni
-pcsx_rearmed_interpreter libretro64-pcsx_rearmed_interpreter https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC_JNI Makefile.libretro . USE_DYNAREC=0
-pocketcdg libretro64-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master PROJECT YES GENERIC_JNI Makefile jni
-picodrive libretro64-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC_JNI Makefile.libretro jni
-pokemini libretro64-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC_JNI Makefile jni
-prboom libretro64-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_JNI Makefile jni
-prosystem libretro64-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-px68k libretro64-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC_JNI Makefile.libretro libretro/jni
-stella libretro64-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-tgbdual libretro64-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-tyrquake libretro64-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC_JNI Makefile jni
-vba_next libretro64-vba-next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC_JNI Makefile libretro/jni
-vbam libretro64-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC_JNI Makefile src/libretro/jni
-vecx libretro64-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC_JNI Makefile.libretro jni
-virtualjaguar libretro64-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-vice_x64 libretro64-vice https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-xrick libretro64-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
-yabause libretro64-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC_JNI Makefile libretro/jni
-uzem libretro64-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC_JNI Makefile jni
-nestopia libretro64-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC_JNI Makefile libretro/jni
-quicknes libretro64-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC_JNI Makefile jni
-puae libretro-puae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC_JNI Makefile jni
+2048 libretro64-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC_JNI Makefile jni
+3dengine libretro64-3dengine https://github.com/libretro/libretro-3dengine.git master YES GENERIC_JNI Makefile jni
+4do libretro64-4do https://github.com/libretro/4do-libretro.git master YES GENERIC_JNI Makefile jni
+bluemsx libretro64-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC_JNI Makefile jni
+bsnes libretro64-bsnes https://github.com/libretro/bsnes-libretro.git libretro YES BSNES_JNI Makefile target-libretro/jni
+bsnes_mercury libretro64-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES BSNES_JNI Makefile target-libretro/jni
+snes9x2002 libretro64-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC_JNI Makefile jni
+snes9x2005 libretro64-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC_JNI Makefile jni
+snes9x2010 libretro64-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC_JNI Makefile jni
+snes9x libretro64-snes9x https://github.com/libretro/snes9x.git master YES GENERIC_JNI Makefile libretro/jni
+snes9x2010 libretro64-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC_JNI Makefile jni
+craft libretro64-craft https://github.com/libretro/Craft.git master YES GENERIC_JNI Makefile.libretro jni
+crocods libretro64-crocods https://github.com/libretro/libretro-crocods.git master YES GENERIC_JNI Makefile jni
+desmume libretro64-desmume https://github.com/libretro/desmume.git master YES GENERIC_JNI Makefile.libretro desmume/src/libretro/jni
+dolphin libretro64-dolphin https://github.com/libretro/dolphin.git master YES GENERIC_JNI Makefile.libretro Source/Core/DolphinLibretro/jni
+dinothawr libretro64-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC_JNI Makefile jni
+dosbox libretro64-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC_JNI Makefile.libretro jni
+fbalpha libretro64-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC_JNI makefile.libretro jni
+fbalpha2012 libretro64-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC_JNI makefile.libretro svn-current/trunk/projectfiles/libretro-android/jni
+fceumm libretro64-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC_JNI Makefile.libretro jni
+fmsx libretro64-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC_JNI Makefile jni
+gambatte libretro64-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC_JNI Makefile libgambatte/libretro/jni
+genesis_plus_gx libretro64-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC_JNI Makefile.libretro libretro/jni
+gme libretro64-gme https://github.com/libretro/libretro-gme.git master YES GENERIC_JNI Makefile jni
+gpsp libretro64-gpsp https://github.com/libretro/gpsp.git master YES GENERIC_JNI Makefile jni
+handy libretro64-handy https://github.com/libretro/libretro-handy.git master YES GENERIC_JNI Makefile jni
+lutro libretro64-lutro https://github.com/libretro/libretro-lutro.git master YES GENERIC_JNI Makefile jni
+mednafen_gba libretro64-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_lynx libretro64-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_ngp libretro64-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_pce_fast libretro64-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_pcfx libretro64-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_psx libretro64-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_psx_hw libretro64-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC_JNI Makefile parallel-psx/jni
+mednafen_saturn libretro64-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_snes libretro64-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_supergrafx libretro64-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_vb libretro64-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC_JNI Makefile jni
+mednafen_wswan libretro64-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC_JNI Makefile jni
+melonds libretro64-melonds https://github.com/libretro/melonDS.git master YES GENERIC_JNI Makefile jni
+meteor libretro64-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC_JNI Makefile libretro/jni
+mame2003 libretro64-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC_JNI Makefile jni
+mame2000 libretro64-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC_JNI Makefile jni
+mrboom libretro64-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC_JNI Makefile jni
+nekop2 libretro64-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC_JNI Makefile.libretro libretro/jni
+np2kai libretro64-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC_JNI Makefile.libretro jni
+parallel_n64 libretro64-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_JNI Makefile jni
+nxengine libretro64-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC_JNI Makefile jni
+o2em libretro64-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC_JNI Makefile jni
+openlara libretro64-openlara https://github.com/libretro/OpenLara.git master YES GENERIC_JNI Makefile src/platform/libretro/jni
+pcsx_rearmed libretro64-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC_JNI Makefile.libretro jni
+pcsx_rearmed_interpreter libretro64-pcsx_rearmed_interpreter https://github.com/libretro/pcsx_rearmed.git master YES GENERIC_JNI Makefile.libretro . USE_DYNAREC=0
+pocketcdg libretro64-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC_JNI Makefile jni
+picodrive libretro64-picodrive https://github.com/libretro/picodrive.git master YES GENERIC_JNI Makefile.libretro jni
+pokemini libretro64-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC_JNI Makefile jni
+prboom libretro64-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_JNI Makefile jni
+prosystem libretro64-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC_JNI Makefile jni
+px68k libretro64-px68k https://github.com/libretro/px68k-libretro.git master YES GENERIC_JNI Makefile.libretro libretro/jni
+stella libretro64-stella https://github.com/libretro/stella-libretro.git master YES GENERIC_JNI Makefile jni
+tgbdual libretro64-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC_JNI Makefile jni
+tyrquake libretro64-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC_JNI Makefile jni
+vba_next libretro64-vba-next https://github.com/libretro/vba-next.git master YES GENERIC_JNI Makefile libretro/jni
+vbam libretro64-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC_JNI Makefile src/libretro/jni
+vecx libretro64-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC_JNI Makefile.libretro jni
+virtualjaguar libretro64-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC_JNI Makefile jni
+vice_x64 libretro64-vice https://github.com/libretro/vice-libretro.git master YES GENERIC_JNI Makefile jni
+xrick libretro64-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC_JNI Makefile jni
+yabause libretro64-yabause https://github.com/libretro/yabause.git master YES GENERIC_JNI Makefile libretro/jni
+uzem libretro64-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC_JNI Makefile jni
+nestopia libretro64-nestopia https://github.com/libretro/nestopia.git master YES GENERIC_JNI Makefile libretro/jni
+quicknes libretro64-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC_JNI Makefile jni
+puae libretro-puae https://github.com/libretro/libretro-uae.git master YES GENERIC_JNI Makefile jni

--- a/recipes/android/cores-android-jni-old
+++ b/recipes/android/cores-android-jni-old
@@ -1,3 +1,3 @@
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC_JNI Makefile libretro/jni
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC_JNI Makefile jni
-bluemsx libretro-bluemsx-old https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC_JNI Makefile jni
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC_JNI Makefile libretro/jni
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC_JNI Makefile jni
+bluemsx libretro-bluemsx-old https://github.com/libretro/blueMSX-libretro.git master YES GENERIC_JNI Makefile jni

--- a/recipes/apple/cores-ios-generic
+++ b/recipes/apple/cores-ios-generic
@@ -1,89 +1,89 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
-craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
-crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile .
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master PROJECT YES GENERIC Makefile.libretro builds/libretro
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC makefile . OSD=retro RETRO=1 NOWERROR=1 NOASM=1 TARGETOS=ios-arm CONFIG=libretro USE_BGFX=0 NO_USE_MIDI=1 VERBOSE=1 verbose=1
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame
-mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess
-melonds libretro-melonds https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile .
-meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=arm
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile .
-nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=1
-pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master PROJECT YES GENERIC Makefile .
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES GENERIC_GL Makefile libretro
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
-px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
-scummvm libretro-scummvm https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_ALT Makefile.libretro .
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
-vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile .
-vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=x128
-vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xvic
-vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xplus4
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro
-uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC Makefile .
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro YES BSNES Makefile .
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES BSNES Makefile .
+craft libretro-craft https://github.com/libretro/craft master YES GENERIC Makefile.libretro .
+crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master YES GENERIC Makefile .
+desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC Makefile.libretro desmume
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
+easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
+mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC makefile . OSD=retro RETRO=1 NOWERROR=1 NOASM=1 TARGETOS=ios-arm CONFIG=libretro USE_BGFX=0 NO_USE_MIDI=1 VERBOSE=1 verbose=1
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame
+mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC Makefile .
+mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile .
+mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess
+melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
+meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
+mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=arm
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=1
+pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=0
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
+ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_GL Makefile libretro
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .
+px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES GENERIC Makefile.libretro .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master YES GENERIC Makefile .
+scummvm libretro-scummvm https://github.com/libretro/scummvm.git master YES GENERIC Makefile backends/platform/libretro/build
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC_ALT Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC Makefile .
+vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
+vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
+vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xvic
+vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xplus4
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC Makefile libretro
+uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-ios9-generic
+++ b/recipes/apple/cores-ios9-generic
@@ -1,89 +1,89 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
-craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
-crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile .
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master PROJECT YES GENERIC Makefile.libretro builds/libretro
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC makefile . OSD=retro RETRO=1 NOWERROR=1 NOASM=1 TARGETOS=ios-arm CONFIG=libretro USE_BGFX=0 NO_USE_MIDI=1 VERBOSE=1 verbose=1
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame
-mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess
-melonds libretro-melonds https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile .
-meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile .
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile .
-nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=1
-pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master PROJECT YES GENERIC Makefile .
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES GENERIC_GL Makefile libretro
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
-px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
-scummvm libretro-scummvm https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro .
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
-vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile .
-vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=x128
-vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xvic
-vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xplus4
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro
-uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC Makefile .
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro YES BSNES Makefile .
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES BSNES Makefile .
+craft libretro-craft https://github.com/libretro/craft master YES GENERIC Makefile.libretro .
+crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master YES GENERIC Makefile .
+desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC Makefile.libretro desmume
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
+easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
+mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC makefile . OSD=retro RETRO=1 NOWERROR=1 NOASM=1 TARGETOS=ios-arm CONFIG=libretro USE_BGFX=0 NO_USE_MIDI=1 VERBOSE=1 verbose=1
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame
+mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC Makefile .
+mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile .
+mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess
+melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
+meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
+mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile .
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=1
+pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=0
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
+ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_GL Makefile libretro
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .
+px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES GENERIC Makefile.libretro .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master YES GENERIC Makefile .
+scummvm libretro-scummvm https://github.com/libretro/scummvm.git master YES GENERIC Makefile backends/platform/libretro/build
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC Makefile .
+vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
+vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
+vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xvic
+vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xplus4
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC Makefile libretro
+uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -1,101 +1,101 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
-chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master SUBMODULE YES GENERIC Makefile .
-citra libretro-citra https://github.com/libretro/citra.git master SUBMODULE YES CMAKE Makefile build -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DDISABLE_LIBPNG=1 -DCMAKE_BUILD_TYPE="Release" --target citra_libretro
-craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
-crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile .
-dolphin libretro-dolphin https://github.com/libretro/dolphin.git master PROJECT YES GENERIC Makefile Source/Core/DolphinLibretro/
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master PROJECT YES GENERIC Makefile.libretro builds/libretro
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan compiler=clang++ target=libretro binary=library
-higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide compiler=clang++ target=libretro binary=library
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro .
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile . PTR64=1
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft
-mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_OPENGL=1
-mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-melonds libretro-melonds https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile .
-meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile .
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile .
-nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
-openlara libretro-openlara https://github.com/libretro/OpenLara.git master PROJECT YES GENERIC Makefile src/platform/libretro
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=1
-pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master PROJECT YES GENERIC Makefile .
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES GENERIC_GL Makefile libretro
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
-px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master PROJECT YES GENERIC Makefile .
-redream libretro-redream https://github.com/inolen/redream.git master PROJECT YES GENERIC Makefile deps/libretro
-remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
-sameboy libretro-sameboy https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile . libretro
-scummvm libretro-scummvm https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro .
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
-vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile .
-vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=x128
-vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xvic
-vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xplus4
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume
-uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC Makefile .
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro YES BSNES Makefile .
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES BSNES Makefile .
+chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master YES GENERIC Makefile .
+citra libretro-citra https://github.com/libretro/citra.git master YES CMAKE Makefile build -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DDISABLE_LIBPNG=1 -DCMAKE_BUILD_TYPE="Release" --target citra_libretro
+craft libretro-craft https://github.com/libretro/craft master YES GENERIC Makefile.libretro .
+crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master YES GENERIC Makefile .
+desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC Makefile.libretro desmume
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
+dolphin libretro-dolphin https://github.com/libretro/dolphin.git master YES GENERIC Makefile Source/Core/DolphinLibretro/
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
+easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
+gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
+higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro YES HIGAN GNUmakefile higan compiler=clang++ target=libretro binary=library
+higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master YES HIGAN GNUmakefile nSide compiler=clang++ target=libretro binary=library
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
+mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro .
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile . PTR64=1
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft
+mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC Makefile .
+mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile .
+mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile . HAVE_OPENGL=1
+mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master YES GENERIC Makefile .
+mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
+meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
+mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile .
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
+openlara libretro-openlara https://github.com/libretro/OpenLara.git master YES GENERIC Makefile src/platform/libretro
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=1
+pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=0
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
+ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_GL Makefile libretro
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .
+px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES GENERIC Makefile.libretro .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master YES GENERIC Makefile .
+redream libretro-redream https://github.com/inolen/redream.git master YES GENERIC Makefile deps/libretro
+remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master YES GENERIC Makefile .
+sameboy libretro-sameboy https://github.com/libretro/SameBoy.git master YES GENERIC Makefile . libretro
+scummvm libretro-scummvm https://github.com/libretro/scummvm.git master YES GENERIC Makefile backends/platform/libretro/build
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC Makefile .
+vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
+vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
+vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xvic
+vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xplus4
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC Makefile libretro
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame
+mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess
+ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume
+uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .

--- a/recipes/blackberry/cores-qnx-generic
+++ b/recipes/blackberry/cores-qnx-generic
@@ -1,65 +1,65 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile .
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro MACHINE=chip8
-emux_gb libretro-emux_gb https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro MACHINE=gb
-emux_nes libretro-emux_nes https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro MACHINE=nes
-emux_sms libretro-emux_sms https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro MACHINE=sms
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame
-mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master PROJECT YES GENERIC Makefile .
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-scummvm libretro-scummvm https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_ALT Makefile.libretro .
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master YES GENERIC Makefile .
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
+emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=chip8
+emux_gb libretro-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=gb
+emux_nes libretro-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=nes
+emux_sms libretro-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=sms
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile.libretro .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame
+mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC Makefile .
+mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile .
+mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
+mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=0
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+scummvm libretro-scummvm https://github.com/libretro/scummvm.git master YES GENERIC Makefile backends/platform/libretro/build
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC_ALT Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC Makefile .
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC Makefile libretro

--- a/recipes/emscripten/emscripten
+++ b/recipes/emscripten/emscripten
@@ -1,56 +1,56 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master PROJECT NO GENERIC_GL Makefile libretro
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT NO GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC_GL Makefile .
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT NO GENERIC Makefile .
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master PROJECT NO GENERIC Makefile .
-mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master PROJECT YES GENERIC Makefile .
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro .
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC_ALT Makefile.libretro .
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT NO GENERIC Makefile libretro
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+craft libretro-craft https://github.com/libretro/craft master YES GENERIC Makefile.libretro .
+desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC Makefile.libretro desmume
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master NO GENERIC_GL Makefile libretro
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master NO GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC_GL Makefile .
+gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master NO GENERIC Makefile .
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC Makefile .
+mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile .
+mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master NO GENERIC Makefile .
+mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile .
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master YES GENERIC Makefile .
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC_ALT Makefile.libretro .
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master NO GENERIC Makefile libretro
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -1,79 +1,79 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master PROJECT YES GENERIC Makefile .
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
-cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .
-chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master SUBMODULE YES GENERIC Makefile .
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume platform=armv7-neon-hardfloat
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile .
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro MACHINE=chip8
-emux_gb libretro-emux_gb https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro MACHINE=gb
-emux_nes libretro-emux_nes https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro MACHINE=nes
-emux_sms libretro-emux_sms https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro MACHINE=sms
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-gearboy libretro-gearboy https://github.com/libretro/Gearboy.git master PROJECT YES GENERIC Makefile platforms/libretro
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . ARCH=arm PTR64=0 LIBRETRO_CPU=arm platform=arm CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ LD=arm-linux-gnueabihf-g++ platform=armv7-neon-hardfloat PTR64=0
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame
-mednafen_gba libretro-mednafen_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_lynx libretro-mednafen_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-mednafen_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-mednafen_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pcfx libretro-mednafen_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx libretro-mednafen_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_HW=1
-mednafen_snes libretro-mednafen_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-mednafen_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-mednafen_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-mednafen_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess
-meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . ARCH=arm
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES GENERIC_GL Makefile libretro platform=armv7-neon-hardfloat ARCH=arm
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
-scummvm libretro-scummvm https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_ALT Makefile.libretro .
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume PTR64=0 PARTIAL=1
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master YES GENERIC Makefile .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro YES BSNES Makefile .
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES BSNES Makefile .
+cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master YES GENERIC Makefile .
+chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master YES GENERIC Makefile .
+desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC Makefile.libretro desmume platform=armv7-neon-hardfloat
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
+emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=chip8
+emux_gb libretro-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=gb
+emux_nes libretro-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=nes
+emux_sms libretro-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=sms
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+gearboy libretro-gearboy https://github.com/libretro/Gearboy.git master YES GENERIC Makefile platforms/libretro
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
+mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . ARCH=arm PTR64=0 LIBRETRO_CPU=arm platform=arm CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ LD=arm-linux-gnueabihf-g++ platform=armv7-neon-hardfloat PTR64=0
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame
+mednafen_gba libretro-mednafen_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
+mednafen_lynx libretro-mednafen_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-mednafen_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-mednafen_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_pcfx libretro-mednafen_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC Makefile .
+mednafen_psx libretro-mednafen_psx https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile .
+mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile . HAVE_HW=1
+mednafen_snes libretro-mednafen_snes https://github.com/libretro/beetle-bsnes-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-mednafen_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-mednafen_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-mednafen_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess
+meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
+mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . ARCH=arm
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=0
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
+ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_GL Makefile libretro platform=armv7-neon-hardfloat ARCH=arm
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master YES GENERIC Makefile .
+scummvm libretro-scummvm https://github.com/libretro/scummvm.git master YES GENERIC Makefile backends/platform/libretro/build
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC_ALT Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume PTR64=0 PARTIAL=1
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC Makefile libretro

--- a/recipes/linux/cores-linux-x64-cross
+++ b/recipes/linux/cores-linux-x64-cross
@@ -1,4 +1,4 @@
-emux_nes libretro-emux_nes https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86_64 MACHINE=nes
-emux_sms libretro-emux_sms https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86_64 MACHINE=sms
-emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86_64 MACHINE=chip8
-emux_gb libretro-emux_gb https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86_64 MACHINE=gb
+emux_nes libretro-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=nes
+emux_sms libretro-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=sms
+emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=chip8
+emux_gb libretro-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=gb

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -1,106 +1,106 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master PROJECT YES GENERIC_GL Makefile .
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bnes libretro-bnes https://github.com/libretro/bnes-libretro.git master PROJECT YES GENERIC Makefile .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
-cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .
-chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master SUBMODULE YES GENERIC Makefile .
-citra libretro-citra https://github.com/libretro/citra.git master SUBMODULE YES CMAKE Makefile build -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DDISABLE_LIBPNG=1 -DCMAKE_BUILD_TYPE="Release" -DENABLE_WEB_SERVICE=0 -DUSE_SYSTEM_CURL=1 --target citra_libretro
-craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
-crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile .
-dolphin libretro-dolphin https://github.com/libretro/dolphin.git master PROJECT YES GENERIC Makefile Source/Core/DolphinLibretro/
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master PROJECT YES GENERIC Makefile.libretro builds/libretro
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-gearboy libretro-gearboy https://github.com/libretro/Gearboy.git master PROJECT YES GENERIC Makefile platforms/libretro
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan compiler=g++ target=libretro binary=library
-higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide compiler=g++ target=libretro binary=library
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . PTR64=1
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft PTR64=1
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame PTR64=1
-mame2016 libretro-mame2016 https://github.com/libretro/mame2016-libretro.git master PROJECT YES GENERIC Makefile.libretro . PTR64=1
-mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_HW=1
-mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-melonds libretro-melonds https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile .
-mess2014 libretro-mess2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess PTR64=1
-meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile .
-mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
-nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
-openlara libretro-openlara https://github.com/libretro/OpenLara.git master PROJECT YES GENERIC Makefile src/platform/libretro
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master PROJECT YES GENERIC Makefile .
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
-px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-redream libretro-redream https://github.com/inolen/redream.git master PROJECT YES GENERIC Makefile deps/libretro
-reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master PROJECT YES GENERIC Makefile .
-remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
-sameboy libretro-sameboy https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile . libretro
-scummvm libretro-scummvm https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile . USE_BLARGG_APU=1
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro .
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-ume2014 libretro-ume2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume PTR64=1
-uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC Makefile .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=x128
-vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile .
-vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xplus4
-vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xvic
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master YES GENERIC_GL Makefile .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+bnes libretro-bnes https://github.com/libretro/bnes-libretro.git master YES GENERIC Makefile .
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro YES BSNES Makefile .
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES BSNES Makefile .
+cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master YES GENERIC Makefile .
+chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master YES GENERIC Makefile .
+citra libretro-citra https://github.com/libretro/citra.git master YES CMAKE Makefile build -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DDISABLE_LIBPNG=1 -DCMAKE_BUILD_TYPE="Release" -DENABLE_WEB_SERVICE=0 -DUSE_SYSTEM_CURL=1 --target citra_libretro
+craft libretro-craft https://github.com/libretro/craft master YES GENERIC Makefile.libretro .
+crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master YES GENERIC Makefile .
+desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC Makefile.libretro desmume
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
+dolphin libretro-dolphin https://github.com/libretro/dolphin.git master YES GENERIC Makefile Source/Core/DolphinLibretro/
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
+easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+gearboy libretro-gearboy https://github.com/libretro/Gearboy.git master YES GENERIC Makefile platforms/libretro
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master YES GENERIC Makefile .
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
+higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro YES HIGAN GNUmakefile higan compiler=g++ target=libretro binary=library
+higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master YES HIGAN GNUmakefile nSide compiler=g++ target=libretro binary=library
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
+mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . PTR64=1
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft PTR64=1
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame PTR64=1
+mame2016 libretro-mame2016 https://github.com/libretro/mame2016-libretro.git master YES GENERIC Makefile.libretro . PTR64=1
+mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC Makefile .
+mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile .
+mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile . HAVE_HW=1
+mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master YES GENERIC Makefile .
+mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
+mess2014 libretro-mess2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess PTR64=1
+meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
+mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
+mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
+openlara libretro-openlara https://github.com/libretro/OpenLara.git master YES GENERIC Makefile src/platform/libretro
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=0
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
+ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .
+px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES GENERIC Makefile.libretro .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+redream libretro-redream https://github.com/inolen/redream.git master YES GENERIC Makefile deps/libretro
+reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master YES GENERIC Makefile .
+remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master YES GENERIC Makefile .
+sameboy libretro-sameboy https://github.com/libretro/SameBoy.git master YES GENERIC Makefile . libretro
+scummvm libretro-scummvm https://github.com/libretro/scummvm.git master YES GENERIC Makefile backends/platform/libretro/build
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile . USE_BLARGG_APU=1
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC Makefile.libretro .
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+ume2014 libretro-ume2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume PTR64=1
+uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
+vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
+vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xplus4
+vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xvic
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC Makefile .
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC Makefile libretro

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -1,97 +1,97 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master PROJECT YES GENERIC Makefile .
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bnes libretro-bnes https://github.com/libretro/bnes-libretro.git master PROJECT YES GENERIC Makefile .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
-craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
-crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
-cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .
-chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master SUBMODULE YES GENERIC Makefile .
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile .
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master PROJECT YES GENERIC Makefile.libretro builds/libretro
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro .
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft PTR64=0
-mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_HW=1
-mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-melonds libretro-melonds https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile .
-meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile .
-nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
-openlara libretro-openlara https://github.com/libretro/OpenLara.git master PROJECT YES GENERIC Makefile src/platform/libretro
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master SUBMODULE YES GENERIC Makefile .
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
-px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master PROJECT YES GENERIC Makefile .
-remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
-sameboy libretro-sameboy https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile.libretro .
-scummvm libretro-scummvm https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_ALT Makefile.libretro .
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
-vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile .
-vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=x128
-vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xvic
-vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xplus4
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame PTR64=0
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess PTR64=0
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume PTR64=0
-uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC Makefile .
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master YES GENERIC Makefile .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+bnes libretro-bnes https://github.com/libretro/bnes-libretro.git master YES GENERIC Makefile .
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro YES BSNES Makefile .
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES BSNES Makefile .
+craft libretro-craft https://github.com/libretro/craft master YES GENERIC Makefile.libretro .
+crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master YES GENERIC Makefile .
+cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master YES GENERIC Makefile .
+chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master YES GENERIC Makefile .
+desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC Makefile.libretro desmume
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
+easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86
+gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
+mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro .
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft PTR64=0
+mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC Makefile .
+mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile .
+mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile . HAVE_HW=1
+mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master YES GENERIC Makefile .
+mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
+meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
+mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
+openlara libretro-openlara https://github.com/libretro/OpenLara.git master YES GENERIC Makefile src/platform/libretro
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=0
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
+ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .
+px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES GENERIC Makefile.libretro .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master YES GENERIC Makefile .
+remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master YES GENERIC Makefile .
+sameboy libretro-sameboy https://github.com/libretro/SameBoy.git master YES GENERIC Makefile.libretro .
+scummvm libretro-scummvm https://github.com/libretro/scummvm.git master YES GENERIC Makefile backends/platform/libretro/build
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC_ALT Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC Makefile .
+vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
+vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
+vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xvic
+vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xplus4
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC Makefile libretro
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame PTR64=0
+mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess PTR64=0
+ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume PTR64=0
+uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .

--- a/recipes/nintendo/3ds
+++ b/recipes/nintendo/3ds
@@ -1,35 +1,35 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/aliaspider/beetle-pce-fast-libretro.git psp_hw_render PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT NO GENERIC Makefile.libretro .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro .
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT NO GENERIC Makefile .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile . USE_BLARGG_APU=1
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT NO GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT NO GENERIC Makefile .
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master YES GENERIC Makefile .
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/aliaspider/beetle-pce-fast-libretro.git psp_hw_render YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+mgba libretro-mgba https://github.com/libretro/mgba.git master NO GENERIC Makefile.libretro .
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro .
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master NO GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile . USE_BLARGG_APU=1
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC Makefile.libretro .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master NO GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master NO GENERIC Makefile .
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .

--- a/recipes/nintendo/gamecube
+++ b/recipes/nintendo/gamecube
@@ -1,31 +1,31 @@
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC Makefile .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile . USE_BLARGG_APU=1
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro .
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile . USE_BLARGG_APU=1
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .

--- a/recipes/nintendo/wii
+++ b/recipes/nintendo/wii
@@ -1,34 +1,34 @@
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC Makefile .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile . USE_BLARGG_APU=1
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro .
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile . USE_BLARGG_APU=1
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .

--- a/recipes/nintendo/wiiu
+++ b/recipes/nintendo/wiiu
@@ -1,46 +1,46 @@
-cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .
-hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile .
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps3 libretro-fbalpha2012_cps3 https://github.com/libretro/fbalpha2012_cps3.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mame2009 libretro-mame2009 https://github.com/r-type/mame2009-libretro.git master PROJECT YES GENERIC Makefile . PTR64=0 TINY=0
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile . USE_BLARGG_APU=1
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro .
-mame2003_midway libretro-mame2003_midway https://github.com/libretro/mame2003_midway.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC Makefile .
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
-vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile .
-vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xvic
-vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xplus4
+cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile .
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps3 libretro-fbalpha2012_cps3 https://github.com/libretro/fbalpha2012_cps3.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mame2009 libretro-mame2009 https://github.com/r-type/mame2009-libretro.git master YES GENERIC Makefile . PTR64=0 TINY=0
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
+mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile . USE_BLARGG_APU=1
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC Makefile.libretro .
+mame2003_midway libretro-mame2003_midway https://github.com/libretro/mame2003_midway.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .
+vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
+vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xvic
+vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xplus4

--- a/recipes/playstation/ps3
+++ b/recipes/playstation/ps3
@@ -1,40 +1,40 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT NO GENERIC Makefile.libretro .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT NO GENERIC Makefile.libretro .
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT NO GENERIC Makefile.libretro desmume
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT NO GENERIC Makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT NO GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT NO GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT NO GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT NO GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT NO GENERIC Makefile .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT NO GENERIC Makefile .
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT NO GENERIC Makefile.libretro .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT NO GENERIC Makefile.libretro . USE_DYNAREC=1
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE NO GENERIC Makefile.libretro .
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT NO GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT NO GENERIC Makefile .
-snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master PROJECT NO GENERIC Makefile . USE_BLARGG_APU=1
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro .
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT NO GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT NO GENERIC Makefile.libretro .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master NO GENERIC Makefile.libretro .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master NO GENERIC Makefile.libretro .
+desmume libretro-desmume https://github.com/libretro/desmume.git master NO GENERIC Makefile.libretro desmume
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master NO GENERIC Makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master NO GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master NO GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master NO GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master NO GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master NO GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master NO GENERIC Makefile .
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+mgba libretro-mgba https://github.com/libretro/mgba.git master NO GENERIC Makefile.libretro .
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master NO GENERIC Makefile.libretro . USE_DYNAREC=1
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master NO GENERIC Makefile.libretro .
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master NO GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master NO GENERIC Makefile .
+snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master NO GENERIC Makefile . USE_BLARGG_APU=1
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC Makefile.libretro .
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master NO GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master NO GENERIC Makefile.libretro .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .

--- a/recipes/playstation/psp
+++ b/recipes/playstation/psp
@@ -1,19 +1,19 @@
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile . USE_BLARGG_APU=1
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/aliaspider/beetle-pce-fast-libretro.git psp_hw_render PROJECT YES GENERIC Makefile .
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
-njemu_cps2 libretro-njemu https://github.com/aliaspider/NJEMU-libretro.git master PROJECT YES GENERIC Makefile .
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master PROJECT YES GENERIC Makefile.libretro .
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC Makefile .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-tempgba libretro-tempgba https://github.com/libretro/TempGBA-libretro.git master PROJECT YES GENERIC Makefile .
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile . USE_BLARGG_APU=1
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/aliaspider/beetle-pce-fast-libretro.git psp_hw_render YES GENERIC Makefile .
+mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
+njemu_cps2 libretro-njemu https://github.com/aliaspider/NJEMU-libretro.git master YES GENERIC Makefile .
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+tempgba libretro-tempgba https://github.com/libretro/TempGBA-libretro.git master YES GENERIC Makefile .
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .

--- a/recipes/playstation/vita
+++ b/recipes/playstation/vita
@@ -1,46 +1,46 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT NO GENERIC Makefile.libretro .
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT NO GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT NO GENERIC Makefile .
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT NO GENERIC Makefile.libretro .
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES Makefile . WITH_DYNAREC=arm
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=1
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile . USE_BLARGG_APU=1
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro .
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master NO GENERIC Makefile.libretro .
+desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC Makefile.libretro desmume
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master NO GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master NO GENERIC Makefile .
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+mgba libretro-mgba https://github.com/libretro/mgba.git master NO GENERIC Makefile.libretro .
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES Makefile . WITH_DYNAREC=arm
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=1
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile . USE_BLARGG_APU=1
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC Makefile.libretro .
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
+yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC Makefile libretro
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .

--- a/recipes/recipes.info
+++ b/recipes/recipes.info
@@ -1,7 +1,7 @@
 RECIPE FORMAT:
-{CORENAME} {COREDIR} {URL} {BRANCH} {REPOTYPE} {ENABLED} {COMMAND} {MAKEFILE} {SUBDIR} {ARGS} TRAILINGSPACE
+{CORENAME} {COREDIR} {URL} {BRANCH} {ENABLED} {COMMAND} {MAKEFILE} {SUBDIR} {ARGS}
 
 Ex:
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
 
 Command should usually be GENERIC and REPOTYPE should usually be project. Notable exceptions are PPSSPP and PICODRIVE. Those are submodule repos.

--- a/recipes/windows/cores-windows-msvc2003-x86_dw2-generic
+++ b/recipes/windows/cores-windows-msvc2003-x86_dw2-generic
@@ -1,1 +1,1 @@
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .

--- a/recipes/windows/cores-windows-msvc2005-x86_dw2-generic
+++ b/recipes/windows/cores-windows-msvc2005-x86_dw2-generic
@@ -1,30 +1,30 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master SUBMODULE YES GENERIC Makefile .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_ALT Makefile.libretro .
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC_ALT Makefile.libretro .
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC_ALT Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC_ALT Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC Makefile .
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-msvc2010-x64_seh-generic
+++ b/recipes/windows/cores-windows-msvc2010-x64_seh-generic
@@ -1,35 +1,35 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master PROJECT YES GENERIC Makefile .
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-melonds libretro-melonds https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile .
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master SUBMODULE YES GENERIC Makefile .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_ALT Makefile.libretro .
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC_ALT Makefile.libretro .
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master YES GENERIC Makefile .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+craft libretro-craft https://github.com/libretro/craft master YES GENERIC Makefile.libretro .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC_ALT Makefile.libretro .
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC_ALT Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC Makefile .
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-msvc2010-x86_dw2-generic
+++ b/recipes/windows/cores-windows-msvc2010-x86_dw2-generic
@@ -1,36 +1,36 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master PROJECT YES GENERIC Makefile .
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-melonds libretro-melonds https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile .
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC_ALT Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master SUBMODULE YES GENERIC Makefile .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC_ALT Makefile.libretro .
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC_ALT Makefile.libretro .
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master YES GENERIC Makefile .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+craft libretro-craft https://github.com/libretro/craft master YES GENERIC Makefile.libretro .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC_ALT Makefile.libretro .
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC_ALT Makefile.libretro .
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC Makefile .
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-msvc2017-desktop-x64_seh-generic
+++ b/recipes/windows/cores-windows-msvc2017-desktop-x64_seh-generic
@@ -1,5 +1,5 @@
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro

--- a/recipes/windows/cores-windows-msvc2017-desktop-x86_dw2-generic
+++ b/recipes/windows/cores-windows-msvc2017-desktop-x86_dw2-generic
@@ -1,5 +1,5 @@
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro

--- a/recipes/windows/cores-windows-msvc2017-uwp-arm-generic
+++ b/recipes/windows/cores-windows-msvc2017-uwp-arm-generic
@@ -1,5 +1,5 @@
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro

--- a/recipes/windows/cores-windows-msvc2017-uwp-x64_seh-generic
+++ b/recipes/windows/cores-windows-msvc2017-uwp-x64_seh-generic
@@ -1,5 +1,5 @@
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro

--- a/recipes/windows/cores-windows-msvc2017-uwp-x86_dw2-generic
+++ b/recipes/windows/cores-windows-msvc2017-uwp-x86_dw2-generic
@@ -1,5 +1,5 @@
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro

--- a/recipes/windows/cores-windows-x64_seh-cross
+++ b/recipes/windows/cores-windows-x64_seh-cross
@@ -1,4 +1,4 @@
-emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86_64 MACHINE=chip8
-emux_gb libretro-emux_gb https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86_64 MACHINE=gb
-emux_nes libretro-emux_nes https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86_64 MACHINE=nes
-emux_sms libretro-emux_sms https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86_64 MACHINE=sms
+emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=chip8
+emux_gb libretro-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=gb
+emux_nes libretro-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=nes
+emux_sms libretro-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=sms

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -1,105 +1,105 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master PROJECT YES GENERIC_GL Makefile .
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bnes libretro-bnes https://github.com/libretro/bnes-libretro.git master PROJECT YES GENERIC Makefile .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
-cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .
-chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master SUBMODULE YES GENERIC Makefile .
-craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
-crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile .
-dolphin libretro-dolphin https://github.com/libretro/dolphin.git master PROJECT YES GENERIC Makefile Source/Core/DolphinLibretro/
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master PROJECT YES GENERIC Makefile.libretro builds/libretro
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-gearboy libretro-gearboy https://github.com/libretro/Gearboy.git master PROJECT YES GENERIC Makefile platforms/libretro
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan compiler=g++ target=libretro binary=library
-higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide compiler=g++ target=libretro binary=library
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . PTR64=1
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft PTR64=1
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame PTR64=1
-mame2016 libretro-mame2016 https://github.com/libretro/mame2016-libretro.git master PROJECT YES GENERIC Makefile.libretro . PTR64=1
-mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_HW=1
-mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-melonds libretro-melonds https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile .
-mess2014 libretro-mess2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess PTR64=1
-meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile .
-mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
-nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
-openlara libretro-openlara https://github.com/libretro/OpenLara.git master PROJECT YES GENERIC Makefile src/platform/libretro
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64 HAVE_THR_AL=1 platform=windows_msvc2017_desktop_x64
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master PROJECT YES GENERIC Makefile .
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES GENERIC_GL Makefile libretro platform=windows_msvc2017_desktop_x64
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
-px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-redream libretro-redream https://github.com/inolen/redream.git master PROJECT YES GENERIC Makefile deps/libretro
-reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master PROJECT YES GENERIC Makefile .
-remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
-sameboy libretro-sameboy https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile . libretro
-scummvm libretro-scummvm https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile . USE_BLARGG_APU=1
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro .
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-ume2014 libretro-ume2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume PTR64=1
-uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC Makefile .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=x128
-vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile .
-vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xplus4
-vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xvic
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master YES GENERIC_GL Makefile .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+bnes libretro-bnes https://github.com/libretro/bnes-libretro.git master YES GENERIC Makefile .
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro YES BSNES Makefile .
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES BSNES Makefile .
+cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master YES GENERIC Makefile .
+chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master YES GENERIC Makefile .
+craft libretro-craft https://github.com/libretro/craft master YES GENERIC Makefile.libretro .
+crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master YES GENERIC Makefile .
+desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC Makefile.libretro desmume
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
+dolphin libretro-dolphin https://github.com/libretro/dolphin.git master YES GENERIC Makefile Source/Core/DolphinLibretro/
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
+easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+gearboy libretro-gearboy https://github.com/libretro/Gearboy.git master YES GENERIC Makefile platforms/libretro
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master YES GENERIC Makefile .
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
+higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro YES HIGAN GNUmakefile higan compiler=g++ target=libretro binary=library
+higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master YES HIGAN GNUmakefile nSide compiler=g++ target=libretro binary=library
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
+mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . PTR64=1
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft PTR64=1
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame PTR64=1
+mame2016 libretro-mame2016 https://github.com/libretro/mame2016-libretro.git master YES GENERIC Makefile.libretro . PTR64=1
+mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC Makefile .
+mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile .
+mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile . HAVE_HW=1
+mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master YES GENERIC Makefile .
+mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
+mess2014 libretro-mess2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess PTR64=1
+meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
+mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
+mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
+openlara libretro-openlara https://github.com/libretro/OpenLara.git master YES GENERIC Makefile src/platform/libretro
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64 HAVE_THR_AL=1 platform=windows_msvc2017_desktop_x64
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=0
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
+ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_GL Makefile libretro platform=windows_msvc2017_desktop_x64
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .
+px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES GENERIC Makefile.libretro .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+redream libretro-redream https://github.com/inolen/redream.git master YES GENERIC Makefile deps/libretro
+reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master YES GENERIC Makefile .
+remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master YES GENERIC Makefile .
+sameboy libretro-sameboy https://github.com/libretro/SameBoy.git master YES GENERIC Makefile . libretro
+scummvm libretro-scummvm https://github.com/libretro/scummvm.git master YES GENERIC Makefile backends/platform/libretro/build
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile . USE_BLARGG_APU=1
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC Makefile.libretro .
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+ume2014 libretro-ume2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume PTR64=1
+uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
+vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
+vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xplus4
+vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xvic
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC Makefile .
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC Makefile libretro

--- a/recipes/windows/cores-windows-x64_seh-noccache
+++ b/recipes/windows/cores-windows-x64_seh-noccache
@@ -1,3 +1,3 @@
-citra libretro-citra https://github.com/libretro/citra.git master SUBMODULE YES CMAKE Makefile build -G "MSYS Makefiles" -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DDISABLE_LIBPNG=1 -DCMAKE_BUILD_TYPE="Release" --target citra_libretro
-px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
+citra libretro-citra https://github.com/libretro/citra.git master YES CMAKE Makefile build -G "MSYS Makefiles" -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DDISABLE_LIBPNG=1 -DCMAKE_BUILD_TYPE="Release" --target citra_libretro
+px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES GENERIC Makefile.libretro .
 

--- a/recipes/windows/cores-windows-x86_dw2-cross
+++ b/recipes/windows/cores-windows-x86_dw2-cross
@@ -1,3 +1,3 @@
-emux_gb libretro-emux_gb https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86 MACHINE=gb
-emux_nes libretro-emux_nes https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86 MACHINE=nes
-emux_sms libretro-emux_sms https://github.com/libretro/emux master PROJECT YES LEIRADEL Makefile libretro x86 MACHINE=sms
+emux_gb libretro-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=gb
+emux_nes libretro-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=nes
+emux_sms libretro-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=sms

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -1,102 +1,102 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master PROJECT YES GENERIC Makefile.libretro .
-3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master PROJECT YES GENERIC_GL Makefile .
-4do libretro-4do https://github.com/libretro/4do-libretro.git master PROJECT YES GENERIC Makefile .
-81 libretro-81 https://github.com/libretro/81-libretro.git master PROJECT YES GENERIC Makefile .
-atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master PROJECT YES GENERIC Makefile .
-bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-bnes libretro-bnes https://github.com/libretro/bnes-libretro.git master PROJECT YES GENERIC Makefile .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro PROJECT YES BSNES Makefile .
-bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master PROJECT YES GENERIC Makefile .
-bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master PROJECT YES BSNES Makefile .
-cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master PROJECT YES GENERIC Makefile .
-chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master SUBMODULE YES GENERIC Makefile .
-craft libretro-craft https://github.com/libretro/craft master PROJECT YES GENERIC Makefile.libretro .
-crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master SUBMODULE YES GENERIC Makefile .
-desmume libretro-desmume https://github.com/libretro/desmume.git master PROJECT YES GENERIC Makefile.libretro desmume
-dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master PROJECT YES GENERIC Makefile .
-dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master PROJECT YES GENERIC Makefile.libretro builds/libretro
-fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master PROJECT YES GENERIC makefile.libretro svn-current/trunk
-fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master PROJECT YES GENERIC makefile.libretro .
-fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master PROJECT YES GENERIC Makefile .
-fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master PROJECT YES GENERIC Makefile.libretro .
-ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master PROJECT YES GENERIC_GL Makefile libretro
-fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master PROJECT YES GENERIC Makefile .
-fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master PROJECT YES GENERIC Makefile .
-gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master PROJECT YES GENERIC Makefile .
-gearboy libretro-gearboy https://github.com/libretro/Gearboy.git master PROJECT YES GENERIC Makefile platforms/libretro
-genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master PROJECT YES GENERIC Makefile.libretro .
-gme libretro-gme https://github.com/libretro/libretro-gme.git master SUBMODULE YES GENERIC Makefile .
-gpsp libretro-gpsp https://github.com/libretro/gpsp.git master PROJECT YES GENERIC Makefile .
-gw libretro-gw https://github.com/libretro/gw-libretro.git master PROJECT YES GENERIC Makefile .
-handy libretro-handy https://github.com/libretro/libretro-handy.git master PROJECT YES GENERIC Makefile .
-hatari libretro-hatari https://github.com/libretro/hatari.git master PROJECT YES GENERIC Makefile.libretro .
-higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro PROJECT YES HIGAN GNUmakefile higan compiler=g++ target=libretro binary=library
-higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master PROJECT YES HIGAN GNUmakefile nSide compiler=g++ target=libretro binary=library
-lutro libretro-lutro https://github.com/libretro/libretro-lutro master PROJECT YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master PROJECT YES GENERIC Makefile.libretro . PTR64=0
-mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master PROJECT YES GENERIC Makefile .
-mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master PROJECT YES GENERIC Makefile .
-mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master PROJECT YES GENERIC Makefile . VRENDER=soft PTR64=0
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mame PTR64=0
-mame2016 libretro-mame2016 https://github.com/libretro/mame2016-libretro master PROJECT YES GENERIC Makefile.libretro . PTR64=0
-mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master PROJECT YES GENERIC Makefile . HAVE_HW=1
-mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master PROJECT YES GENERIC Makefile .
-mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master PROJECT YES GENERIC Makefile .
-melonds libretro-melonds https://github.com/libretro/melonDS.git master PROJECT YES GENERIC Makefile .
-mess2014 libretro-mess2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=mess PTR64=0
-meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master PROJECT YES GENERIC Makefile libretro
-mgba libretro-mgba https://github.com/libretro/mgba.git master PROJECT YES GENERIC Makefile.libretro .
-mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master PROJECT YES GENERIC Makefile .
-mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86
-nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master PROJECT YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master PROJECT YES GENERIC Makefile libretro
-np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master PROJECT YES GENERIC Makefile.libretro sdl2
-nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master PROJECT YES GENERIC Makefile .
-o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master PROJECT YES GENERIC Makefile .
-openlara libretro-openlara https://github.com/libretro/OpenLara.git master PROJECT YES GENERIC Makefile src/platform/libretro
-parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master PROJECT YES GENERIC_GL Makefile . WITH_DYNAREC=x86 HAVE_THR_AL=1 platform=windows_msvc2017_desktop_x86
-pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master PROJECT YES GENERIC Makefile.libretro . USE_DYNAREC=0
-picodrive libretro-picodrive https://github.com/libretro/picodrive.git master SUBMODULE YES GENERIC Makefile.libretro .
-pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master PROJECT YES GENERIC Makefile .
-pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master PROJECT YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master SUBMODULE YES GENERIC_GL Makefile libretro platform=windows_msvc2017_desktop_x86
-prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master PROJECT YES GENERIC Makefile .
-prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master PROJECT YES GENERIC Makefile .
-puae libretro-uae https://github.com/libretro/libretro-uae.git master PROJECT YES GENERIC Makefile .
-px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master PROJECT YES GENERIC Makefile.libretro .
-quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master PROJECT YES GENERIC Makefile .
-remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master PROJECT YES GENERIC Makefile .
-sameboy libretro-sameboy https://github.com/libretro/SameBoy.git master PROJECT YES GENERIC Makefile . libretro
-scummvm libretro-scummvm https://github.com/libretro/scummvm.git master PROJECT YES GENERIC Makefile backends/platform/libretro/build
-snes9x libretro-snes9x https://github.com/libretro/snes9x.git master PROJECT YES GENERIC Makefile libretro
-snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master PROJECT YES GENERIC Makefile .
-snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile .
-snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master PROJECT YES GENERIC Makefile . USE_BLARGG_APU=1
-snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master PROJECT YES GENERIC Makefile.libretro .
-stella libretro-stella https://github.com/libretro/stella-libretro.git master PROJECT YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master PROJECT YES GENERIC Makefile .
-tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master PROJECT YES GENERIC Makefile .
-ume2014 libretro-ume2014 https://github.com/libretro/mame2014-libretro.git master PROJECT YES GENERIC Makefile . TARGET=ume PTR64=0
-uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master PROJECT YES GENERIC Makefile .
-vba_next libretro-vba_next https://github.com/libretro/vba-next.git master PROJECT YES GENERIC Makefile.libretro .
-vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master PROJECT YES GENERIC Makefile src/libretro
-vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master PROJECT YES GENERIC Makefile.libretro .
-vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=x128
-vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile .
-vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xplus4
-vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master PROJECT YES GENERIC Makefile . EMUTYPE=xvic
-virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master PROJECT YES GENERIC Makefile .
-xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master PROJECT YES GENERIC Makefile .
-yabause libretro-yabause https://github.com/libretro/yabause.git master PROJECT YES GENERIC Makefile libretro
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
+3dengine libretro-3dengine https://github.com/libretro/libretro-3dengine.git master YES GENERIC_GL Makefile .
+4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
+bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+bnes libretro-bnes https://github.com/libretro/bnes-libretro.git master YES GENERIC Makefile .
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro YES BSNES Makefile .
+bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
+bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES BSNES Makefile .
+cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master YES GENERIC Makefile .
+chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master YES GENERIC Makefile .
+craft libretro-craft https://github.com/libretro/craft master YES GENERIC Makefile.libretro .
+crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master YES GENERIC Makefile .
+desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC Makefile.libretro desmume
+dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
+dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
+easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
+fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
+fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
+fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .
+fbalpha2012_cps2 libretro-fbalpha2012_cps2 https://github.com/libretro/fbalpha2012_cps2.git master YES GENERIC makefile.libretro .
+fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha2012_neogeo.git master YES GENERIC Makefile .
+fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
+fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .
+gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
+gearboy libretro-gearboy https://github.com/libretro/Gearboy.git master YES GENERIC Makefile platforms/libretro
+genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
+gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .
+gpsp libretro-gpsp https://github.com/libretro/gpsp.git master YES GENERIC Makefile .
+gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
+handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
+hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
+higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro YES HIGAN GNUmakefile higan compiler=g++ target=libretro binary=library
+higan_sfc_balanced libretro-nside https://github.com/hex-usr/nSide.git master YES HIGAN GNUmakefile nSide compiler=g++ target=libretro binary=library
+lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
+mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . PTR64=0
+mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft PTR64=0
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame PTR64=0
+mame2016 libretro-mame2016 https://github.com/libretro/mame2016-libretro master YES GENERIC Makefile.libretro . PTR64=0
+mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
+mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
+mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
+mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
+mednafen_pcfx libretro-beetle_pcfx https://github.com/libretro/beetle-pcfx-libretro.git master YES GENERIC Makefile .
+mednafen_psx libretro-beetle_psx https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile .
+mednafen_psx_hw libretro-beetle_psx_hw https://github.com/libretro/beetle-psx-libretro.git master YES GENERIC Makefile . HAVE_HW=1
+mednafen_saturn libretro-beetle_saturn https://github.com/libretro/beetle-saturn-libretro.git master YES GENERIC Makefile .
+mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libretro.git master YES GENERIC Makefile .
+mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
+mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
+mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
+melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
+mess2014 libretro-mess2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess PTR64=0
+meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
+mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
+mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
+mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
+nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
+nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
+openlara libretro-openlara https://github.com/libretro/OpenLara.git master YES GENERIC Makefile src/platform/libretro
+parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86 HAVE_THR_AL=1 platform=windows_msvc2017_desktop_x86
+pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=0
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
+pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
+ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_GL Makefile libretro platform=windows_msvc2017_desktop_x86
+prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .
+prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
+puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .
+px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES GENERIC Makefile.libretro .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
+remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master YES GENERIC Makefile .
+sameboy libretro-sameboy https://github.com/libretro/SameBoy.git master YES GENERIC Makefile . libretro
+scummvm libretro-scummvm https://github.com/libretro/scummvm.git master YES GENERIC Makefile backends/platform/libretro/build
+snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
+snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC Makefile .
+snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile .
+snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile . USE_BLARGG_APU=1
+snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master YES GENERIC Makefile.libretro .
+stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
+tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
+ume2014 libretro-ume2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume PTR64=0
+uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
+vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
+vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
+vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
+vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
+vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xplus4
+vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xvic
+virtualjaguar libretro-virtualjaguar https://github.com/libretro/virtualjaguar-libretro.git master YES GENERIC Makefile .
+xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .
+yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC Makefile libretro


### PR DESCRIPTION
This adds two commits.

1. For the cores it will now no longer rely on the `$TYPE` in the recipe file and will detect submodules automatically by detecting their presence with `git`.
2. As `$TYPE` is now no longer need by the core recipes it is removed in the effort to further simplify the recipe files. It is still used in the `.ra` files for RetroArch however.