### PR TITLE
libretro-buildbot-recipe.sh: Do not set FORCE and BUILD for fbalpha2012.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -645,11 +645,6 @@ while read line; do
 			BUILD="YES"
 		fi
 
-		if [[ "${PREVCORE}" == *fbalpha2012* ]] && [[ "${PREVBUILD}" = "YES" ]] && [[ "${NAME}" == *fbalpha2012* ]]; then
-			FORCE="YES"
-			BUILD="YES"
-		fi
-
 		for core in 81 emux_nes emux_sms fuse gw mame2010 mgba snes9x_next snes9x-next vba_next; do
 			if [ "${PREVCORE}" = "$core" ] && [ "${PREVBUILD}" = "YES" ] && [ "${NAME}" = "$core" ]; then
 				FORCE="YES"


### PR DESCRIPTION
They now use different source repos so this is not needed. In the event this is no longer true there are now better ways to do this, see how bsnes is handled where it loops over the desired targets.