### PR TITLE
Revert "libretro-buildbot-recipe.sh: Remove seemingly unneeded and non-portable bash redirection."

### DIFF
--- a/libretro-build-common.sh
+++ b/libretro-build-common.sh
@@ -282,7 +282,12 @@ libretro_build_core() {
 		exec 6>&1
 		echo "Building ${1}..." >> $log_module
 
-		exec > $log_module
+		# TODO: Possibly a shell function for tee?
+		if [[ -n "$LIBRETRO_DEVELOPER" && -n "${cmd_tee:=$(find_tool "tee")}" ]]; then
+			exec > >($cmd_tee -a $log_module)
+		else
+			exec > $log_module
+		fi
 	fi
 
 	case "$core_build_rule" in


### PR DESCRIPTION
Reverts libretro/libretro-super#635

My idea had issues unfortunately, see. https://github.com/libretro/libretro-super/pull/646

I suggest reverting this for now and accepting that some older bash versions may not have this functionality. I'll try to figure out a better way, but its not nearly easy as I had hoped.