### PR TITLE
libretro-buildbot-recipe.sh: Build all three mame2014 cores at once.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -323,7 +323,12 @@ build_libretro_generic_makefile() {
 	eval "set -- $CORE"
 	for core do
 		NAME="$core"
-		[ "${COMMAND}" = "BSNES" ] && ARGS="profile=${core##*_}"
+
+		if [ "${COMMAND}" = "BSNES" ]; then
+			CORE_ARGS="profile=${core##*_} ${ARGS}"
+		else
+			CORE_ARGS="${ARGS}"
+		fi
 
 		echo --------------------------------------------------| tee $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
 		cat $TMPDIR/vars | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
@@ -334,7 +339,7 @@ build_libretro_generic_makefile() {
 				rm -fv obj/*.{o,"${FORMAT_EXT}"} 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
 				rm -fv out/*.{o,"${FORMAT_EXT}"} 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
 			else
-				eval "set -- ${HELPER} ${MAKE} -f ${MAKEFILE} platform=${PLATFORM} -j${JOBS} ${ARGS} clean"
+				eval "set -- ${HELPER} ${MAKE} -f ${MAKEFILE} platform=${PLATFORM} -j${JOBS} ${CORE_ARGS} clean"
 				echo "CLEANUP CMD: $@" 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
 				"$@" 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
 			fi
@@ -357,7 +362,7 @@ build_libretro_generic_makefile() {
 				EXTRAARGS="-DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=${API_LEVEL} -DCMAKE_ANDROID_ARCH_ABI=${ABI_OVERRIDE} -DCMAKE_ANDROID_NDK=${NDK_ROOT}"
 			fi
 
-			eval "set -- ${EXTRAARGS} ${ARGS}"
+			eval "set -- ${EXTRAARGS} ${CORE_ARGS}"
 			echo "BUILD CMD: ${CMAKE} $@" 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
 			echo "$@" .. | xargs ${CMAKE} 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
 			echo "BUILD CMD: ${HELPER} ${MAKE} -f ${MAKEFILE} -j${JOBS}" 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
@@ -366,10 +371,10 @@ build_libretro_generic_makefile() {
 			find . -mindepth 2 -name "${NAME}_libretro${FORMAT}${LIBSUFFIX}.${FORMAT_EXT}" -exec cp -f "{}" . \;
 		elif [ "${COMMAND}" = "HIGAN" ]; then
 			platform=""
-			echo "BUILD CMD: ${HELPER} ${MAKE} -f ${MAKEFILE} -j${JOBS}" ${ARGS} 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
-			${HELPER} ${MAKE} -f ${MAKEFILE} -j${JOBS} ${ARGS} 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
+			echo "BUILD CMD: ${HELPER} ${MAKE} -f ${MAKEFILE} -j${JOBS}" ${CORE_ARGS} 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
+			${HELPER} ${MAKE} -f ${MAKEFILE} -j${JOBS} ${CORE_ARGS} 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
 		else
-			eval "set -- ${HELPER} ${MAKE} -f ${MAKEFILE} platform=${PLATFORM} -j${JOBS} ${ARGS}"
+			eval "set -- ${HELPER} ${MAKE} -f ${MAKEFILE} platform=${PLATFORM} -j${JOBS} ${CORE_ARGS}"
 			echo "BUILD CMD: $@" 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
 			"$@" 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
 		fi
@@ -481,8 +486,10 @@ build_libretro_generic_jni() {
 		NAME="${core}"
 
 		if [ "${COMMAND}" = "BSNES_JNI" ]; then
-			ARGS="profile=${core##*_}"
+			CORE_ARGS="profile=${core##*_} ${ARGS}"
 			LIBNAM="libretro_${NAME}"
+		else
+			CORE_ARGS="${ARGS}"
 		fi
 
 		for a in "${ABIS[@]}"; do
@@ -491,8 +498,8 @@ build_libretro_generic_jni() {
 
 			echo -------------------------------------------------- 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}_${a}.log
 			if [ -z "${NOCLEAN}" ]; then
-				echo "CLEANUP CMD: ${NDK} -j${JOBS} ${ARGS} APP_ABI=${a} clean" 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}_${a}.log
-				${NDK} -j${JOBS} ${ARGS} APP_ABI=${a} clean 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}_${a}.log
+				echo "CLEANUP CMD: ${NDK} -j${JOBS} ${CORE_ARGS} APP_ABI=${a} clean" 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}_${a}.log
+				${NDK} -j${JOBS} ${CORE_ARGS} APP_ABI=${a} clean 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}_${a}.log
 
 				if [ $? -eq 0 ]; then
 					echo buildbot job: $jobid $a ${NAME} cleanup success!
@@ -502,7 +509,7 @@ build_libretro_generic_jni() {
 			fi
 
 			echo -------------------------------------------------- 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}_${a}.log
-			eval "set -- ${NDK} -j${JOBS} APP_ABI=${a} ${ARGS}"
+			eval "set -- ${NDK} -j${JOBS} APP_ABI=${a} ${CORE_ARGS}"
 			echo "BUILD CMD: $@" 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}_${a}.log
 			"$@" 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}_${a}.log
 

--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -645,7 +645,7 @@ while read line; do
 			BUILD="YES"
 		fi
 
-		for core in 81 emux_nes emux_sms fuse gw mame2010 mgba snes9x_next snes9x-next vba_next; do
+		for core in 81 emux_nes emux_sms fuse gw mgba; do
 			if [ "${PREVCORE}" = "$core" ] && [ "${PREVBUILD}" = "YES" ] && [ "${NAME}" = "$core" ]; then
 				FORCE="YES"
 				BUILD="YES"

--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -316,6 +316,8 @@ build_libretro_generic_makefile() {
 
 	if [ "${COMMAND}" = "BSNES" ]; then
 		CORE="${NAME}_accuracy ${NAME}_balanced ${NAME}_performance"
+	elif [ "${NAME}" = "mame2014" ]; then
+		CORE="${NAME} mess2014 ume2014"
 	else
 		CORE="${NAME}"
 	fi
@@ -326,6 +328,8 @@ build_libretro_generic_makefile() {
 
 		if [ "${COMMAND}" = "BSNES" ]; then
 			CORE_ARGS="profile=${core##*_} ${ARGS}"
+		elif [ "${NAME}" = "mame2014" ] || [ "${NAME}" = "mess2014" ] || [ "${NAME}" = "ume2014" ]; then
+			CORE_ARGS="TARGET=${core%%[0-9]*} ${ARGS}"
 		else
 			CORE_ARGS="${ARGS}"
 		fi
@@ -352,11 +356,6 @@ build_libretro_generic_makefile() {
 		fi
 
 		echo -------------------------------------------------- 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
-		if [ "${NAME}" == "mame2010" ]; then
-			echo "BUILD CMD: PLATFORM="" platform="" ${HELPER} ${MAKE} -f ${MAKEFILE} "VRENDER=soft" "NATIVE=1" buildtools -j${JOBS}" 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
-			PLATFORM="" platform="" ${HELPER} ${MAKE} -f ${MAKEFILE} "VRENDER=soft" "NATIVE=1" buildtools -j${JOBS} 2>&1 | tee -a $TMPDIR/log/${BOT}/${LOGDATE}/${LOGDATE}_${NAME}_${PLATFORM}.log
-		fi
-
 		if [ "${COMMAND}" = "CMAKE" ]; then
 			if [ "${PLATFORM}" = "android" ]; then
 				EXTRAARGS="-DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=${API_LEVEL} -DCMAKE_ANDROID_ARCH_ABI=${ABI_OVERRIDE} -DCMAKE_ANDROID_NDK=${NDK_ROOT}"
@@ -641,16 +640,6 @@ while read line; do
 
 		FORCE_ORIG=$FORCE
 		OLDBUILD=$BUILD
-
-		if [ "${PREVCORE}" = "mame2014" ] && [ "${PREVBUILD}" = "YES" ] && [ "${NAME}" = "mess2014" ]; then
-			FORCE="YES"
-			BUILD="YES"
-		fi
-
-		if [ "${PREVCORE}" = "mess2014" ] && [ "${PREVBUILD}" = "YES" ] && [ "${NAME}" = "ume2014" ]; then
-			FORCE="YES"
-			BUILD="YES"
-		fi
 
 		for core in 81 emux_nes emux_sms fuse gw mgba; do
 			if [ "${PREVCORE}" = "$core" ] && [ "${PREVBUILD}" = "YES" ] && [ "${NAME}" = "$core" ]; then

--- a/recipes/android/cores-android-armv7-ndk-old-mame
+++ b/recipes/android/cores-android-armv7-ndk-old-mame
@@ -1,4 +1,2 @@
-mame2014 libretro-mame2014o https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame
-mess2014 libretro-mame2014o https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess
-ume2014 libretro-mame2014o https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume
+mame2014 libretro-mame2014o https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile .
 mame2016 libretro-mame2016o https://github.com/libretro/mame2016-libretro master YES GENERIC makefile . OSD=retro RETRO=1 NOWERROR=1 NOASM=1 gcc=android-arm gcc_version=4.9 TARGETOS=android-arm CONFIG=libretro NO_USE_MIDI=1 OS=linux VERBOSE=1 verbose=1 OVERRIDE_CC=/home/buildbot/tools/android/android-ndk-r10e/toolchains/llvm-3.5/prebuilt/linux-x86_64/bin/clang OVERRIDE_CXX=/home/buildbot/tools/android/android-ndk-r10e/toolchains/llvm-3.5/prebuilt/linux-x86_64/bin/clang++ TARGET=mame

--- a/recipes/apple/cores-ios-generic
+++ b/recipes/apple/cores-ios-generic
@@ -31,7 +31,7 @@ mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC makef
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile .
 mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
 mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
 mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
@@ -42,7 +42,6 @@ mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libr
 mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess
 melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
 meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
 mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
@@ -73,7 +72,6 @@ snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC
 stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
 vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .

--- a/recipes/apple/cores-ios9-generic
+++ b/recipes/apple/cores-ios9-generic
@@ -31,7 +31,7 @@ mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC makef
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile .
 mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
 mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
 mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
@@ -42,7 +42,6 @@ mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libr
 mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess
 melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
 meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
 mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
@@ -73,7 +72,6 @@ snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC
 stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
 vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .

--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -92,9 +92,7 @@ vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git maste
 vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xplus4
 xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .
 yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC Makefile libretro
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile .
 uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
 gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
 81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .

--- a/recipes/blackberry/cores-qnx-generic
+++ b/recipes/blackberry/cores-qnx-generic
@@ -25,7 +25,7 @@ hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile .
 mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
 mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
 mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -35,7 +35,7 @@ mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makef
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ LD=arm-linux-gnueabihf-g++ platform=armv7-neon-hardfloat PTR64=0
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile .
 mednafen_gba libretro-mednafen_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
 mednafen_lynx libretro-mednafen_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
 mednafen_ngp libretro-mednafen_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
@@ -47,7 +47,6 @@ mednafen_snes libretro-mednafen_snes https://github.com/libretro/beetle-bsnes-li
 mednafen_supergrafx libretro-mednafen_supergrafx https://github.com/libretro/beetle-supergrafx-libretro.git master YES GENERIC Makefile .
 mednafen_vb libretro-mednafen_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-mednafen_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess
 meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
 mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . ARCH=arm
@@ -71,7 +70,6 @@ snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC
 stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume PTR64=0 PARTIAL=1
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
 vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -42,7 +42,7 @@ mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makef
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft PTR64=1
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame PTR64=1
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . PTR64=1
 mame2016 libretro-mame2016 https://github.com/libretro/mame2016-libretro.git master YES GENERIC Makefile.libretro . PTR64=1
 mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
 mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
@@ -57,7 +57,6 @@ mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetl
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
 melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
-mess2014 libretro-mess2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess PTR64=1
 meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
 mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
@@ -92,7 +91,6 @@ snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master
 stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
-ume2014 libretro-ume2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume PTR64=1
 uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -88,9 +88,7 @@ vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git maste
 vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xplus4
 xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .
 yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC Makefile libretro
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame PTR64=0
-mess2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess PTR64=0
-ume2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume PTR64=0
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . PTR64=0
 uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
 gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Makefile .
 81 libretro-81 https://github.com/libretro/81-libretro.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -41,7 +41,7 @@ mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makef
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft PTR64=1
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame PTR64=1
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . PTR64=1
 mame2016 libretro-mame2016 https://github.com/libretro/mame2016-libretro.git master YES GENERIC Makefile.libretro . PTR64=1
 mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
 mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
@@ -56,7 +56,6 @@ mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetl
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
 melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
-mess2014 libretro-mess2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess PTR64=1
 meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
 mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
@@ -91,7 +90,6 @@ snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master
 stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
-ume2014 libretro-ume2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume PTR64=1
 uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -40,7 +40,7 @@ mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makef
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft PTR64=0
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mame PTR64=0
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . PTR64=0
 mame2016 libretro-mame2016 https://github.com/libretro/mame2016-libretro master YES GENERIC Makefile.libretro . PTR64=0
 mednafen_gba libretro-beetle_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
 mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
@@ -55,7 +55,6 @@ mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetl
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
 melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
-mess2014 libretro-mess2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=mess PTR64=0
 meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
 mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
@@ -88,7 +87,6 @@ snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master
 stella libretro-stella https://github.com/libretro/stella-libretro.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
-ume2014 libretro-ume2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . TARGET=ume PTR64=0
 uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro


### PR DESCRIPTION
This adds three commits, the first two are minor and are included to avoid merge conflicts.

The last commit should allow to have only one `mame2014` recipe per file and it will build all three libretro cores, `mame2014`, `mess2014` and `ume2014`.

Some side effects:

1. `recipes/blackberry/cores-qnx-generic` was previously missing the `mess2014` and `ume2014` cores.
2. In `recipes/linux/cores-linux-armhf-generic` only the `ume2014` sets `PTR64=0` and `PARTIAL=1` while neither `mame2014` or `mess2014` does. I'm not sure if this is intended, but assuming it is I think fixing this in the `mame2014` Makefile would be the best solution. Alternatively I can accommodate in this script by adding a hack. The buildbot should be able to test this either way.