### PR TITLE
recipes: Try to fix mame2014 for armhf.

### DIFF
--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -35,7 +35,7 @@ mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makef
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile . VRENDER=soft CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ LD=arm-linux-gnueabihf-g++ platform=armv7-neon-hardfloat PTR64=0
-mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile .
+mame2014 libretro-mame2014 https://github.com/libretro/mame2014-libretro.git master YES GENERIC Makefile . PTR64=0
 mednafen_gba libretro-mednafen_gba https://github.com/libretro/beetle-gba-libretro.git master YES GENERIC Makefile .
 mednafen_lynx libretro-mednafen_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
 mednafen_ngp libretro-mednafen_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .


### PR DESCRIPTION
This restores the `PTR64=0` which was used for `ume2014`. `mame2014`, `mess2014` and `ume2014` now all fail due to the same error and my guess is this will help. However I will need to test it with the buildbot...

See
```
obj/libexpat.a: error adding symbols: File format not recognized
collect2: error: ld returned 1 exit status
Makefile:909: recipe for target 'mame2014' failed
make: *** [mame2014] Error 1
```
http://p.0bl.net/119116