### PR TITLE
libretro-buildbot-recipe.sh: Skip build if the .git directory is broken.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -602,6 +602,12 @@ while read line; do
 			git clone --depth=1 -b "$GIT_BRANCH" "$URL" "$DIR"
 			BUILD="YES"
 			UPDATE="NO"
+		else
+			HEAD="$(git --work-tree="$DIR" --git-dir="$DIR/.git" rev-parse HEAD)" || \
+				{ echo 'git directory broken, removing $NAME and skipping.'; \
+				rm -rfv -- "$DIR" && continue; }
+			echo "pulling changes from repo $URL..."
+			git --work-tree="$DIR" --git-dir="$DIR/.git" pull
 		fi
 
 		cd "$DIR" || { echo "Failed to cd to ${DIR}, skipping ${NAME}"; continue; }
@@ -623,10 +629,6 @@ while read line; do
 				echo "found .forcebuild file, building $NAME"
 				BUILD="YES"
 			fi
-
-			echo "pulling changes from repo $URL..."
-			HEAD="$(git rev-parse HEAD)"
-			git pull
 
 			if [ "$HEAD" = "$(git rev-parse HEAD)" ] && [ "${BUILD}" != "YES" ]; then
 				BUILD="NO"


### PR DESCRIPTION
The msvc2005 virtual mafchine had an issue where several of the cloned repos were corrupted and left `.git` in a non-useful state and this caused an infinite loop in the buildbot script. Now if `.git` exists and is broken it will print a warning and remove the repo instead of using it. When the buildbot script next encounters the recipe it will hopefully correctly clone the repo again.

Additionally it will now `git pull` earlier in the script and entirely avoid unintended issues when the branch in the recipe does not match the current broken branch.