### PR TITLE
libretro-buildbot-recipe.sh: Only clean the correct git directory.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -663,12 +663,8 @@ while read line; do
 				LEIRADEL )      build_libretro_leiradel_makefile $NAME $DIR $SUBDIR $MAKEFILE ${PLATFORM} "${ARGS}"                  ;;
 				* )             :                                                                                                    ;;
 			esac
-			BUILD_DIR="${BASE_DIR}/${DIR}"
-			[ "${SUBDIR}" != . ] && BUILD_DIR="${BUILD_DIR}/${SUBDIR}"
-			if [ "$(realpath .)" = "${BUILD_DIR}" ]; then
-				echo "Cleaning repo state after build $URL..."
-				git clean -xdf
-			fi
+			echo "Cleaning repo state after build $URL..."
+			git --work-tree="${BASE_DIR}/${DIR}" --git-dir="${BASE_DIR}/${DIR}/.git" clean -xdf
 		else
 			echo "buildbot job: building $NAME up-to-date"
 		fi


### PR DESCRIPTION
This sets the `--work-tree` and `--git-tree` to the correct repo for `git clean -xdf`. In practice it should already be in the right directory and it should never reach this point unless that is true due to earlier safe guards, but its safer to be explicit. In the event it does not work as planned `git` will harmless complain about a missing `.git` directory and the clean up will fail. This avoids my earlier attempt to test if the script was in the right directory.