### PR TITLE
libretro-buildbot-recipe.sh: Allow building specific bsnes and mame c…

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -573,7 +573,9 @@ while read line; do
 	ARGS="${ARGS# }"
 	ARGS="${ARGS%"${ARGS##*[![:space:]]}"}"
 
-	if [ "$SINGLE_CORE" ] && [ "$NAME" != "$SINGLE_CORE" ]; then
+	if [ -z "${SINGLE_CORE:-}" ]; then
+		CORE=""
+	elif [ "$NAME" != "$SINGLE_CORE" ]; then
 		continue
 	fi
 

--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -315,9 +315,9 @@ build_libretro_generic_makefile() {
 	cd "${SUBDIR}"
 
 	if [ "${COMMAND}" = "BSNES" ]; then
-		CORE="${NAME}_accuracy ${NAME}_balanced ${NAME}_performance"
+		CORE="${CORE:-${NAME}_accuracy ${NAME}_balanced ${NAME}_performance}"
 	elif [ "${NAME}" = "mame2014" ]; then
-		CORE="${NAME} mess2014 ume2014"
+		CORE="${CORE:-${NAME} mess2014 ume2014}"
 	else
 		CORE="${NAME}"
 	fi
@@ -472,7 +472,7 @@ build_libretro_generic_jni() {
 	fi
 
 	if [ "${COMMAND}" = "BSNES_JNI" ]; then
-		CORE="${NAME}_accuracy ${NAME}_balanced ${NAME}_performance"
+		CORE="${CORE:-${NAME}_accuracy ${NAME}_balanced ${NAME}_performance}"
 	else
 		CORE="${NAME}"
 	fi

--- a/travis/build-3ds.sh
+++ b/travis/build-3ds.sh
@@ -20,5 +20,7 @@ if [ "${TRAVIS_BUILD_DIR}" ]; then
   mv ${TRAVIS_BUILD_DIR} ${CORE_DIRNAME}
 fi
 
+[ -z "${NAME:-}" ] && NAME="${CORE}"
+
 # only build the one core specified in $CORE
-FORCE=YES SINGLE_CORE=${CORE} ./libretro-buildbot-recipe.sh ${RECIPE}
+FORCE=YES SINGLE_CORE="${CORE}" CORE="${NAME}" ./libretro-buildbot-recipe.sh "${RECIPE}"

--- a/travis/build-linux_x64.sh
+++ b/travis/build-linux_x64.sh
@@ -10,5 +10,7 @@ if [ "${TRAVIS_BUILD_DIR}" ]; then
   mv ${TRAVIS_BUILD_DIR} ${CORE_DIRNAME}
 fi
 
+[ -z "${NAME:-}" ] && NAME="${CORE}"
+
 # only build the one core specified in $CORE
-FORCE=YES SINGLE_CORE=${CORE} ./libretro-buildbot-recipe.sh ${RECIPE}
+FORCE=YES SINGLE_CORE="${CORE}" CORE="${NAME}" ./libretro-buildbot-recipe.sh "${RECIPE}"

--- a/travis/build-ngc.sh
+++ b/travis/build-ngc.sh
@@ -21,5 +21,7 @@ if [ "${TRAVIS_BUILD_DIR}" ]; then
   mv ${TRAVIS_BUILD_DIR} ${CORE_DIRNAME}
 fi
 
+[ -z "${NAME:-}" ] && NAME="${CORE}"
+
 # only build the one core specified in $CORE
-FORCE=YES SINGLE_CORE=${CORE} ./libretro-buildbot-recipe.sh ${RECIPE}
+FORCE=YES SINGLE_CORE="${CORE}" CORE="${NAME}" ./libretro-buildbot-recipe.sh "${RECIPE}"

--- a/travis/build-osx_x64.sh
+++ b/travis/build-osx_x64.sh
@@ -10,5 +10,7 @@ if [ "${TRAVIS_BUILD_DIR}" ]; then
   mv ${TRAVIS_BUILD_DIR} ${CORE_DIRNAME}
 fi
 
+[ -z "${NAME:-}" ] && NAME="${CORE}"
+
 # only build the one core specified in $CORE
-FORCE=YES SINGLE_CORE=${CORE} ./libretro-buildbot-recipe.sh ${RECIPE}
+FORCE=YES SINGLE_CORE="${CORE}" CORE="${NAME}" ./libretro-buildbot-recipe.sh "${RECIPE}"

--- a/travis/build-wii.sh
+++ b/travis/build-wii.sh
@@ -21,5 +21,7 @@ if [ "${TRAVIS_BUILD_DIR}" ]; then
   mv ${TRAVIS_BUILD_DIR} ${CORE_DIRNAME}
 fi
 
+[ -z "${NAME:-}" ] && NAME="${CORE}"
+
 # only build the one core specified in $CORE
-FORCE=YES SINGLE_CORE=${CORE} ./libretro-buildbot-recipe.sh ${RECIPE}
+FORCE=YES SINGLE_CORE="${CORE}" CORE="${NAME}" ./libretro-buildbot-recipe.sh "${RECIPE}"

--- a/travis/build-wiiu.sh
+++ b/travis/build-wiiu.sh
@@ -20,5 +20,7 @@ if [ "${TRAVIS_BUILD_DIR}" ]; then
   mv ${TRAVIS_BUILD_DIR} ${CORE_DIRNAME}
 fi
 
+[ -z "${NAME:-}" ] && NAME="${CORE}"
+
 # only build the one core specified in $CORE
-FORCE=YES SINGLE_CORE=${CORE} ./libretro-buildbot-recipe.sh ${RECIPE}
+FORCE=YES SINGLE_CORE="${CORE}" CORE="${NAME}" ./libretro-buildbot-recipe.sh "${RECIPE}"


### PR DESCRIPTION
This could be useful for travis to capture regressions if the only one of the cores is affected. Additionally it is required for fixing travis with mame2014. If the core is not bsnes-libretro, bsnes-mercury or mame2014 the $CORE variable in the travis scripts will be ignored.

When this is merged I can do the work to make sure bsnes-libretro, bsnes-mercury and mame2014 use it.