### PR TITLE
libretro-buildbot-recipe.sh: Fix bsnes android builds.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -485,7 +485,7 @@ build_libretro_generic_jni() {
 	for core do
 		if [ "${NAME}" = "bsnes" ] || [ "${NAME}" = "bsnes_mercury" ]; then
 			CORE_ARGS="profile=${core##*_} ${ARGS}"
-			LIBNAM="libretro_${NAME}"
+			LIBNAM="libretro_${core}"
 		else
 			CORE_ARGS="${ARGS}"
 		fi


### PR DESCRIPTION
I failed to change one of the `$NAME` variables to `$core`...

See.
```
[armeabi] Compile++ arm  : retro_bsnes_mercury_accuracy <= libretro.cpp
[armeabi] SharedLibrary  : libretro_bsnes_mercury_accuracy.so
[armeabi] Install        : libretro_bsnes_mercury_accuracy.so => libs/armeabi/libretro_bsnes_mercury_accuracy.so
COPY CMD: cp -v ../libs/armeabi/libretro_bsnes_mercury.so /home/buildbot/buildbot/android/dist/android/armeabi/bsnes_mercury_accuracy_libretro_android.so
cp: cannot stat '../libs/armeabi/libretro_bsnes_mercury.so': No such file or directory
```
http://p.0bl.net/121804