### PR TITLE
recipes: Try to fix emux cores for cores-linux-armhf-generic.

### DIFF
--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -11,10 +11,10 @@ chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master YES G
 desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC Makefile.libretro desmume platform=armv7-neon-hardfloat
 dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
 dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
-emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=chip8
-emux_gb libretro-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=gb
-emux_nes libretro-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=nes
-emux_sms libretro-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=sms
+emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=chip8
+emux_gb libretro-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=gb
+emux_nes libretro-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=nes
+emux_sms libretro-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=sms
 fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
 fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
 fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .

--- a/recipes/linux/cores-linux-armhf-generic.conf
+++ b/recipes/linux/cores-linux-armhf-generic.conf
@@ -1,5 +1,5 @@
-platform unix
-PLATFORM unix
+platform linux
+PLATFORM linux
 MAKEPORTABLE YES
 CORE_JOB YES
 MAKE make


### PR DESCRIPTION
These cores last built for `armhf` in 2015...the problem is that the `LEIRADEL` command requires the first `$ARGS` to be the makefile suffix where its missing here and resulted in the following issue. Additionally it uses `$PLATFORM` to help determine what makefile to use and in this case it should be `linux` not `unix`. Reading the script I don't think changing the platform here should break anything and other `.conf` files already set it as `linux`.
```
CLEANUP CMD:  make -f Makefile.unix_MACHINE=nes platform=unix_MACHINE=nes -j6 clean
make: Makefile.unix_MACHINE=nes: No such file or directory
make: *** No rule to make target 'Makefile.unix_MACHINE=nes'.  Stop.
--------------------------------------------------
BUILD CMD:  make -f Makefile.unix_MACHINE=nes platform=unix_MACHINE=nes -j6
make: Makefile.unix_MACHINE=nes: No such file or directory
make: *** No rule to make target 'Makefile.unix_MACHINE=nes'.  Stop.
COPY CMD: cp -v emux_nes_libretro.unix_MACHINE=nes.so /home/buildbot/buildbot/linux_armhf/dist/unix//MACHINE=nes/emux_nes_libretro.so
cp: cannot stat 'emux_nes_libretro.unix_MACHINE=nes.so': No such file or directory
```
@fr500 Does this look good to you?