### PR TITLE
recipes: Update cores-android-cross.conf

### DIFF
--- a/recipes/android/cores-android-cross.conf
+++ b/recipes/android/cores-android-cross.conf
@@ -1,8 +1,8 @@
 ANDROID_HOME /opt/android-sdk-linux
-NDK_ROOT /home/buildbot/tools/android/android-ndk-r13b/
-NDK_ROOT_DIR /home/buildbot/tools/android/android-ndk-r13b/
-ANDROID_NDK /home/buildbot/tools/android/android-ndk-r13b/
-PATH /home/buildbot/tools/android/android-ndk-r13b:/home/buildbot/tools/android/android-sdk/tools
+NDK_ROOT /home/buildbot/tools/android/android-ndk-r15c/
+NDK_ROOT_DIR /home/buildbot/tools/android/android-ndk-r15c/
+ANDROID_NDK /home/buildbot/tools/android/android-ndk-r15c/
+PATH /home/buildbot/tools/android/android-ndk-r15c:/home/buildbot/tools/android/android-sdk-linux/tools:/home/buildbot/tools/android/android-ndk-r15c/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin
 PLATFORM android
 platform android
 MAKE make


### PR DESCRIPTION
This should hopefully also fix a missing toolchain for emux.
```
make: /home/buildbot/tools/android/android-ndk-r13b//toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/bin/arm-linux-androideabi-gcc: Command not found
make: /home/buildbot/tools/android/android-ndk-r13b//toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/bin/arm-linux-androideabi-gcc: Command not found
Makefile.rules:39: recipe for target '../frontends/input/retro_input.android_armeabi.o' failed
make: *** [../frontends/input/retro_input.android_armeabi.o] Error 127
make: *** Waiting for unfinished jobs....
Makefile.rules:39: recipe for target '../frontends/video/retro_video.android_armeabi.o' failed
make: *** [../frontends/video/retro_video.android_armeabi.o] Error 127
Makefile.rules:39: recipe for target '../frontends/audio/retro_audio.android_armeabi.o' failed
make: *** [../frontends/audio/retro_audio.android_armeabi.o] Error 127
COPY CMD: cp -v emux_sms_libretro.android_armeabi.so /home/buildbot/buildbot/android/dist/android//armeabi/emux_sms_libretro_android.so
cp: cannot stat 'emux_sms_libretro.android_armeabi.so': No such file or directory
```
http://p.0bl.net/126546