### PR TITLE
Fix SameBoy target

### DIFF
--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -295,7 +295,8 @@ include_core_sameboy() {
 libretro_sameboy_name="SameBoy"
 libretro_sameboy_git_url="https://github.com/libretro/SameBoy.git"
 libretro_sameboy_build_platform="$FORMAT_COMPILER_TARGET_ALT"
-libretro_sameboy_build_makefile="Makefile.libretro"
+libretro_sameboy_build_subdir="libretro"
+libretro_sameboy_build_makefile="Makefile"
 
 include_core_meteor() {
 	register_module core "meteor" -ngc -ps3 -psp1 -qnx -wii


### PR DESCRIPTION
```
=== SameBoy
Building sameboy...
cd "/run/media/retrowertz/7911DC541A5BA668/msys64/home/Cain/libretro-super/libretro-sameboy"
make -f Makefile.libretro platform="unix" -j2  clean
libretro/Makefile:134: Makefile.common: No such file or directory
make: *** No rule to make target 'Makefile.common'.  Stop.
make -f Makefile.libretro platform="unix" -j2 CC="gcc" CXX="g++" 
libretro/Makefile:134: Makefile.common: No such file or directory
make: *** No rule to make target 'Makefile.common'.  Stop.
```
This PR should sync with this: https://github.com/libretro/SameBoy/pull/7
Does this break any like builbot maybe? 
  