### PR TITLE
libretro-buildbot-recipe.sh: Rebuild cores when using a new recipe.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -627,9 +627,19 @@ while read line; do
 		else
 			echo "resetting repo state $URL..."
 			git --work-tree="$DIR" --git-dir="$DIR/.git" reset --hard FETCH_HEAD
-			git --work-tree="$DIR" --git-dir="$DIR/.git" clean -xdf
+			git --work-tree="$DIR" --git-dir="$DIR/.git" clean -xdf -e .libretro-core-recipe
 			BUILD="YES"
 		fi
+	fi
+
+	if [ -f "$DIR/.libretro-core-recipe" ]; then
+		recipe="$(cat "$DIR/.libretro-core-recipe")"
+		if [ "$line" != "$recipe" ]; then
+			echo "$line" > "$DIR/.libretro-core-recipe"
+			BUILD="YES"
+		fi
+	else
+		echo "$line" > "$DIR/.libretro-core-recipe"
 	fi
 
 	CURRENT_BRANCH="$(git --work-tree="$DIR" --git-dir="$DIR/.git" rev-parse --abbrev-ref HEAD)"
@@ -667,7 +677,7 @@ while read line; do
 			* )           :                                                                                                    ;;
 		esac
 		echo "Cleaning repo state after build $URL..."
-		git --work-tree="${BASE_DIR}/${DIR}" --git-dir="${BASE_DIR}/${DIR}/.git" clean -xdf
+		git --work-tree="${BASE_DIR}/${DIR}" --git-dir="${BASE_DIR}/${DIR}/.git" clean -xdf -e .libretro-core-recipe
 	else
 		echo "buildbot job: building $NAME up-to-date"
 	fi


### PR DESCRIPTION
Before when changing a recipe the core would not rebuild until the repo was removed in the buildbot server or when the core itself was updated with new commits. This will now store `.libretro-core-recipe` in the core's own repo which then can be compared with the recipe its using, if they differ it will force a rebuild.