### PR TITLE
libretro-buildbot-recipe.sh: Fix citra builds for windows (Again)

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -367,7 +367,7 @@ build_libretro_generic_makefile() {
 					-DCMAKE_ANDROID_NDK=${NDK_ROOT}"
 			fi
 
-			eval "set -- ${EXTRAARGS} ${CORE_ARGS}"
+			eval "set -- ${EXTRAARGS} \${CORE_ARGS}"
 			echo "BUILD CMD: ${CMAKE} $@" 2>&1 | tee -a "$LOGFILE"
 			echo "$@" .. | xargs ${CMAKE} 2>&1 | tee -a "$LOGFILE"
 			echo "BUILD CMD: ${HELPER} ${MAKE} -f ${MAKEFILE} -j${JOBS}" 2>&1 | tee -a "$LOGFILE"


### PR DESCRIPTION
During one of my clean up efforts I neglected to make sure the quotes
around '-G "MYSYS Makefiles"' were not evaluated. Escaping the variable
containing this option works, but should be noted it only works with bash.
Since this script is inherently a bash script that should be no problem.

Fixes https://github.com/libretro/libretro-super/issues/675