### PR TITLE
libretro-buildbot-recipe.sh: Fix builds with force pushes.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -619,15 +619,17 @@ while read line; do
 		HEAD="$(git --work-tree="$DIR" --git-dir="$DIR/.git" rev-parse HEAD)" || \
 			{ echo "git directory broken, removing $DIR and skipping $NAME."; \
 			rm -rfv -- "$DIR" && continue; }
-		echo "pulling changes from repo $URL..."
-		git --work-tree="$DIR" --git-dir="$DIR/.git" pull
+
+		echo "fetching changes from repo $URL..."
+		git --work-tree="$DIR" --git-dir="$DIR/.git" fetch origin "$GIT_BRANCH"
+
+		echo "resetting repo state $URL..."
+		git --work-tree="." --git-dir=".git" -C "$DIR" reset --hard FETCH_HEAD
+		git --work-tree="$DIR" --git-dir="$DIR/.git" clean -xdf -e .libretro-core-recipe
 
 		if [ "$HEAD" = "$(git --work-tree="$DIR" --git-dir="$DIR/.git" rev-parse HEAD)" ] && [ "${BUILD}" != "YES" ]; then
 			BUILD="NO"
 		else
-			echo "resetting repo state $URL..."
-			git --work-tree="$DIR" --git-dir="$DIR/.git" reset --hard FETCH_HEAD
-			git --work-tree="$DIR" --git-dir="$DIR/.git" clean -xdf -e .libretro-core-recipe
 			BUILD="YES"
 		fi
 	fi


### PR DESCRIPTION
The script will no longer git pull, but will fetch the any changes from the remote branch and then reset the repo to that branch.

If there are changes the HEAD commit will change and it will rebuild.

This will also work if the old history was changed instead of the new history.