### PR TITLE
libretro-buildbot-recipe.sh: Fix constant rebuilds for some cores.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /libretro-*
+/libretro64-*
 /retroarch/
 /build-summary.log
 /build-revisions/

--- a/recipes/android/cores-android-cross
+++ b/recipes/android/cores-android-cross
@@ -1,32 +1,5 @@
-81 libretro64-81 https://github.com/libretro/81-libretro.git master YES LEIRADEL Makefile build armeabi
-81 libretro64-81 https://github.com/libretro/81-libretro.git master YES LEIRADEL Makefile build armeabi-v7a
-81 libretro64-81 https://github.com/libretro/81-libretro.git master YES LEIRADEL Makefile build arm64-v8a
-81 libretro64-81 https://github.com/libretro/81-libretro.git master YES LEIRADEL Makefile build x86
-emux_chip8 libretro64-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi MACHINE=chip8
-emux_chip8 libretro64-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi-v7a MACHINE=chip8
-emux_chip8 libretro64-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro arm64-v8a MACHINE=chip8
-emux_chip8 libretro64-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=chip8
-emux_gb libretro64-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi MACHINE=gb
-emux_gb libretro64-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi-v7a MACHINE=gb
-emux_gb libretro64-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro arm64-v8a MACHINE=gb
-emux_gb libretro64-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=gb
-emux_nes libretro64-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi MACHINE=nes
-emux_nes libretro64-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi-v7a MACHINE=nes
-emux_nes libretro64-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro arm64-v8a MACHINE=nes
-emux_nes libretro64-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=nes
-emux_sms libretro64-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi MACHINE=sms
-emux_sms libretro64-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro armeabi-v7a MACHINE=sms
-emux_sms libretro64-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro arm64-v8a MACHINE=sms
-emux_sms libretro64-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=sms
-fuse libretro64-fuse https://github.com/libretro/fuse-libretro.git master YES LEIRADEL Makefile build armeabi
-fuse libretro64-fuse https://github.com/libretro/fuse-libretro.git master YES LEIRADEL Makefile build armeabi-v7a
-fuse libretro64-fuse https://github.com/libretro/fuse-libretro.git master YES LEIRADEL Makefile build arm64-v8a
-fuse libretro64-fuse https://github.com/libretro/fuse-libretro.git master YES LEIRADEL Makefile build x86
-gw libretro64-gw https://github.com/libretro/gw-libretro.git master YES LEIRADEL Makefile build armeabi
-gw libretro64-gw https://github.com/libretro/gw-libretro.git master YES LEIRADEL Makefile build armeabi-v7a
-gw libretro64-gw https://github.com/libretro/gw-libretro.git master YES LEIRADEL Makefile build arm64-v8a
-gw libretro64-gw https://github.com/libretro/gw-libretro.git master YES LEIRADEL Makefile build x86
-mgba libretro64-mgba https://github.com/libretro/mgba.git master YES LEIRADEL Makefile libretro-build armeabi
-mgba libretro64-mgba https://github.com/libretro/mgba.git master YES LEIRADEL Makefile libretro-build armeabi-v7a
-mgba libretro64-mgba https://github.com/libretro/mgba.git master YES LEIRADEL Makefile libretro-build arm64-v8a
-mgba libretro64-mgba https://github.com/libretro/mgba.git master YES LEIRADEL Makefile libretro-build x86
+81 libretro64-81 https://github.com/libretro/81-libretro.git master YES LEIRADEL Makefile build | 81:armeabi 81:armeabi-v7a 81:arm64-v8a 81:x86
+emux libretro64-emux https://github.com/libretro/emux master YES LEIRADEL Makefile libretro | "emux_chip8:armeabi MACHINE=chip8" "emux_chip8:armeabi-v7a MACHINE=chip8" "emux_chip8:arm64-v8a MACHINE=chip8" "emux_chip8:x86 MACHINE=chip8" "emux_gb:armeabi MACHINE=gb" "emux_gb:armeabi-v7a MACHINE=gb" "emux_gb:arm64-v8a MACHINE=gb" "emux_gb:x86 MACHINE=gb" "emux_nes:armeabi MACHINE=nes" "emux_nes:armeabi-v7a MACHINE=nes" "emux_nes:arm64-v8a MACHINE=nes" "emux_nes:x86 MACHINE=nes" "emux_sms:armeabi MACHINE=sms" "emux_sms:armeabi-v7a MACHINE=sms" "emux_sms:arm64-v8a MACHINE=sms" "emux_sms:x86 MACHINE=sms"
+fuse libretro64-fuse https://github.com/libretro/fuse-libretro.git master YES LEIRADEL Makefile build | fuse:armeabi fuse:armeabi-v7a fuse:arm64-v8a fuse:x86
+gw libretro64-gw https://github.com/libretro/gw-libretro.git master YES LEIRADEL Makefile build | gw:armeabi gw:armeabi-v7a gw:arm64-v8a gw:x86
+mgba libretro64-mgba https://github.com/libretro/mgba.git master YES LEIRADEL Makefile libretro-build | mgba:armeabi mgba:armeabi-v7a mgba:arm64-v8a mgba:x86

--- a/recipes/blackberry/cores-qnx-generic
+++ b/recipes/blackberry/cores-qnx-generic
@@ -5,10 +5,7 @@ bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master
 crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master YES GENERIC Makefile .
 dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
 dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
-emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=chip8
-emux_gb libretro-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=gb
-emux_nes libretro-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=nes
-emux_sms libretro-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro MACHINE=sms
+emux libretro-emux https://github.com/libretro/emux master YES LEIRADEL Makefile libretro | emux_chip8:MACHINE=chip8 emux_gb:MACHINE=gb emux_nes:MACHINE=nes emux_sms:MACHINE=sms
 fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
 fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
 fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -11,10 +11,7 @@ chailove libretro-chailove https://github.com/RobLoach/ChaiLove.git master YES G
 desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC Makefile.libretro desmume platform=armv7-neon-hardfloat
 dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
 dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
-emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=chip8
-emux_gb libretro-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=gb
-emux_nes libretro-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=nes
-emux_sms libretro-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=sms
+emux libretro-emux https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 | emux_chip8:MACHINE=chip8 emux_gb:MACHINE=gb emux_nes:MACHINE=nes emux_sms:MACHINE=sms
 fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENERIC makefile.libretro .
 fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC makefile.libretro svn-current/trunk
 fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC makefile.libretro .

--- a/recipes/linux/cores-linux-x64-cross
+++ b/recipes/linux/cores-linux-x64-cross
@@ -1,4 +1,1 @@
-emux_nes libretro-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=nes
-emux_sms libretro-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=sms
-emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=chip8
-emux_gb libretro-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=gb
+emux libretro-emux https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 | emux_nes:MACHINE=nes emux_sms:MACHINE=sms emux_chip8:MACHINE=chip8 emux_gb:MACHINE=gb

--- a/recipes/windows/cores-windows-x64_seh-cross
+++ b/recipes/windows/cores-windows-x64_seh-cross
@@ -1,4 +1,1 @@
-emux_chip8 libretro-emux_chip8 https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=chip8
-emux_gb libretro-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=gb
-emux_nes libretro-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=nes
-emux_sms libretro-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 MACHINE=sms
+emux libretro-emux https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86_64 | emux_chip8:MACHINE=chip8 emux_gb:MACHINE=gb emux_nes:MACHINE=nes emux_sms:MACHINE=sms

--- a/recipes/windows/cores-windows-x86_dw2-cross
+++ b/recipes/windows/cores-windows-x86_dw2-cross
@@ -1,3 +1,1 @@
-emux_gb libretro-emux_gb https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=gb
-emux_nes libretro-emux_nes https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=nes
-emux_sms libretro-emux_sms https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 MACHINE=sms
+emux libretro-emux https://github.com/libretro/emux master YES LEIRADEL Makefile libretro x86 | emux_chip8:MACHINE=chip8 emux_gb:MACHINE=gb emux_nes:MACHINE=nes emux_sms:MACHINE=sms


### PR DESCRIPTION
A few cores built with the LEIRADEL command had an issue where a hack used to build certain cores broke and caused them to be built every time the buildbot encountered the recipe.

To fix this the build_libretro_leiradel_makefile function was removed and incorporated into the build_libretro_generic_makefile function. This allowed the script to easily use new logic to build multiple cores with one recipe which entirely avoids the need for the broken hack.