### PR TITLE
recipes: Add FreeIntv

### DIFF
--- a/recipes/apple/cores-ios-generic
+++ b/recipes/apple/cores-ios-generic
@@ -20,6 +20,7 @@ fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha20
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
 ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
 fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile .
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
 genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
 gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-ios9-generic
+++ b/recipes/apple/cores-ios9-generic
@@ -20,6 +20,7 @@ fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha20
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
 ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
 fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile .
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
 genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
 gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -22,6 +22,7 @@ fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha20
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
 ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
 fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile .
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
 genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
 mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -20,6 +20,7 @@ fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha20
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
 ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
 fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile .
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
 gearboy libretro-gearboy https://github.com/libretro/Gearboy.git master YES GENERIC Makefile platforms/libretro
 genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -26,6 +26,7 @@ fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha20
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
 ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
 fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile .
 fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
 gearboy libretro-gearboy https://github.com/libretro/Gearboy.git master YES GENERIC Makefile platforms/libretro

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -23,6 +23,7 @@ fbalpha2012_neogeo libretro-fbalpha_neogeo https://github.com/libretro/fbalpha20
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
 ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
 fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
+freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile .
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
 genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .
 mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -26,6 +26,7 @@ fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YE
 ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
 fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
 fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .
+freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile .
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
 gearboy libretro-gearboy https://github.com/libretro/Gearboy.git master YES GENERIC Makefile platforms/libretro
 genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -25,6 +25,7 @@ fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YE
 ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC_GL Makefile libretro
 fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
 fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .
+freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile .
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
 gearboy libretro-gearboy https://github.com/libretro/Gearboy.git master YES GENERIC Makefile platforms/libretro
 genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC Makefile.libretro .


### PR DESCRIPTION
Adds the FreeIntv to the ios, ios9, osx, linux-armhf, linux-x86, linux-x64, windows-x64_seh and windows-x86_dw2 recipes.

It does build with the linux recipe at least.

Related issue. https://github.com/libretro/libretro-super/issues/689