### PR TITLE
update freeintv .info with additional supported extensions

### DIFF
--- a/dist/info/freeintv_libretro.info
+++ b/dist/info/freeintv_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Mattel - Intellivision (FreeIntv)"
 authors = "David Richardson"
-supported_extensions = "int"
+supported_extensions = "int|bin|rom"
 corename = "FreeIntv"
 manufacturer = "Mattel"
 categories = "Emulator"


### PR DESCRIPTION
per @recompileorg 's RetroPie docs, FreeIntv supports ROMs with the extensions: `int`, `bin`, and `rom`