### PR TITLE
recipes: Restore the ppsspp jni build.

### DIFF
--- a/recipes/android/cores-android-cmake-aarch64
+++ b/recipes/android/cores-android-cmake-aarch64
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-aarch64 https://github.com/libretro/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-aarch64 https://github.com/libretro/ppsspp.git master NO CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-armv7
+++ b/recipes/android/cores-android-cmake-armv7
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-armv7 https://github.com/libretro/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-armv7 https://github.com/libretro/ppsspp.git master NO CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-x86
+++ b/recipes/android/cores-android-cmake-x86
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-x86 https://github.com/libretro/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-x86 https://github.com/libretro/ppsspp.git master NO CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-jni
+++ b/recipes/android/cores-android-jni
@@ -49,6 +49,7 @@ pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/li
 picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC_JNI Makefile.libretro jni
 pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC_JNI Makefile jni
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC_JNI Makefile jni
+ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_JNI Makefile libretro/jni
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_JNI Makefile jni
 prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC_JNI Makefile jni
 puae libretro-puae https://github.com/libretro/libretro-uae.git master YES GENERIC_JNI Makefile jni


### PR DESCRIPTION
Warning: Untested.

Since cmake does not seem to be recommend for android by upstream and they use their own jni makefile I suggest use jni too.

The ideal solution might be add libretro support to the upstream jni makefile so that it stays in sync with upstream better and there are less files to maintain, but for the short term we can use the old libretro jni makefile.