### PR TITLE
recipes: Fix the freeintv android recipe.

### DIFF
--- a/recipes/android/cores-android-jni
+++ b/recipes/android/cores-android-jni
@@ -14,7 +14,7 @@ fbalpha libretro-fbalpha https://github.com/libretro/fbalpha.git master YES GENE
 fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC_JNI makefile.libretro svn-current/trunk/projectfiles/libretro-android/jni
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC_JNI Makefile.libretro jni
 fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC_JNI Makefile jni
-freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile jni 
+freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC_JNI Makefile jni
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC_JNI Makefile libgambatte/libretro/jni
 genesis_plus_gx libretro-genesis_plus_gx https://github.com/libretro/Genesis-Plus-GX.git master YES GENERIC_JNI Makefile.libretro libretro/jni
 gme libretro-gme https://github.com/libretro/libretro-gme.git master YES GENERIC_JNI Makefile jni


### PR DESCRIPTION
It should use `GENERIC_JNI` and not `GENERIC`.

Also see https://github.com/libretro/libretro-super/pull/712.