### PR TITLE
info: Standardize the Display Names of cores

### DIFF
--- a/dist/info/00_example_libretro.info
+++ b/dist/info/00_example_libretro.info
@@ -1,7 +1,7 @@
 ## All data is optional, but helps improve user experience.
 
 # Name displayed when the user is selecting the core:
-# display_name = "NES / Famicom"
+# display_name = "Nintendo - Game Boy (Core Name)"
 
 # Name of the authors who wrote the core:
 # authors = "Martin Freij|R. Belmont|R. Danbrook"

--- a/dist/info/4do_libretro.info
+++ b/dist/info/4do_libretro.info
@@ -1,4 +1,4 @@
-display_name = "3DO (4DO)"
+display_name = "The 3DO Company - 3DO (4DO)"
 authors = "JohnnyDude|FreeDO team"
 supported_extensions = "iso|cue"
 corename = "4DO"

--- a/dist/info/81_libretro.info
+++ b/dist/info/81_libretro.info
@@ -1,4 +1,4 @@
-display_name = "ZX81 (EightyOne)"
+display_name = "Sinclair - ZX 81 (EightyOne)"
 authors = "Michael D Wynne"
 supported_extensions = "p|tzx|t81"
 corename = "81"

--- a/dist/info/atari800_libretro.info
+++ b/dist/info/atari800_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Atari 8-bit computer systems and 5200 (Atari800)"
+display_name = "Atari - 5200 (Atari800)"
 authors = "Petr Stehlik"
 supported_extensions = "xfd|atr|atx|cdm|cas|bin|a52|xex|zip"
 corename = "Atari800"

--- a/dist/info/blastem_libretro.info
+++ b/dist/info/blastem_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Sega MD (BlastEm)"
+display_name = "Sega - Mega Drive - Genesis (BlastEm)"
 authors = "Mike Pavone"
 supported_extensions = "md|bin|smd"
 corename = "BlastEm"

--- a/dist/info/bnes_libretro.info
+++ b/dist/info/bnes_libretro.info
@@ -1,4 +1,4 @@
-display_name = "NES / Famicom (bnes)"
+display_name = "Nintendo - NES (bnes)"
 authors = "byuu|Ryphecha"
 supported_extensions = "nes"
 corename = "bnes/higan"

--- a/dist/info/bsnes_accuracy_libretro.info
+++ b/dist/info/bsnes_accuracy_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (bsnes Accuracy)"
+display_name = "Nintendo - SNES / Famicom (bsnes Accuracy)"
 authors = "byuu"
 supported_extensions = "sfc|smc|bml"
 corename = "bsnes/higan Accuracy"

--- a/dist/info/bsnes_balanced_libretro.info
+++ b/dist/info/bsnes_balanced_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (bsnes Balanced)"
+display_name = "Nintendo - SNES / Famicom (bsnes Balanced)"
 authors = "byuu"
 supported_extensions = "sfc|smc|bml"
 corename = "bsnes/higan Balanced"

--- a/dist/info/bsnes_cplusplus98_libretro.info
+++ b/dist/info/bsnes_cplusplus98_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (bsnes C++98 (v085))"
+display_name = "Nintendo - SNES / Famicom (bsnes C++98 (v085))"
 authors = "byuu|Themaister|Ver GreenEyes"
 supported_extensions = "sfc|smc"
 corename = "bsnes C++98 (v085)"

--- a/dist/info/bsnes_mercury_accuracy_libretro.info
+++ b/dist/info/bsnes_mercury_accuracy_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (bsnes-mercury Accuracy)"
+display_name = "Nintendo - SNES / Famicom (bsnes-mercury Accuracy)"
 authors = "byuu|Alcaro"
 supported_extensions = "sfc|smc|bml"
 corename = "bsnes-mercury Accuracy"

--- a/dist/info/bsnes_mercury_balanced_libretro.info
+++ b/dist/info/bsnes_mercury_balanced_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (bsnes-mercury Balanced)"
+display_name = "Nintendo - SNES / Famicom (bsnes-mercury Balanced)"
 authors = "byuu|Alcaro"
 supported_extensions = "sfc|smc|bml"
 corename = "bsnes-mercury Balanced"

--- a/dist/info/bsnes_mercury_performance_libretro.info
+++ b/dist/info/bsnes_mercury_performance_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (bsnes-mercury Performance)"
+display_name = "Nintendo - SNES / Famicom (bsnes-mercury Performance)"
 authors = "byuu|Alcaro"
 supported_extensions = "sfc|smc|bml"
 corename = "bsnes-mercury Performance"

--- a/dist/info/bsnes_performance_libretro.info
+++ b/dist/info/bsnes_performance_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (bsnes Performance)"
+display_name = "Nintendo - SNES / Famicom (bsnes Performance)"
 authors = "byuu"
 supported_extensions = "sfc|smc|bml"
 corename = "bsnes/higan Performance"

--- a/dist/info/cap32_libretro.info
+++ b/dist/info/cap32_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Amstrad CPC (Caprice32)"
+display_name = "Amstrad - CPC (Caprice32)"
 authors = "Ulrich Doewich|dantoine"
 supported_extensions = "dsk|sna|zip|tap|cdt|voc"
 corename = "Caprice32"

--- a/dist/info/citra_libretro.info
+++ b/dist/info/citra_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Nintendo 3DS (Citra)"
+display_name = "Nintendo - 3DS (Citra)"
 authors = "Citra Emulation Project"
 supported_extensions = "3ds|3dsx|elf|axf|cci|cxi|app"
 corename = "Citra"

--- a/dist/info/crocods_libretro.info
+++ b/dist/info/crocods_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Amstrad CPC (CrocoDS)"
+display_name = "Amstrad - CPC (CrocoDS)"
 authors = "RedBug"
 supported_extensions = "dsk|sna|kcr"
 corename = "CrocoDS"

--- a/dist/info/desmume_libretro.info
+++ b/dist/info/desmume_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Nintendo DS (DeSmuME)"
+display_name = "Nintendo - DS (DeSmuME)"
 authors = "YopYop156|Zeromus"
 supported_extensions = "nds|bin"
 corename = "DeSmuME"

--- a/dist/info/dolphin_libretro.info
+++ b/dist/info/dolphin_libretro.info
@@ -1,4 +1,4 @@
-display_name = "GameCube / Wii (Dolphin)"
+display_name = "Nintendo - GameCube / Wii (Dolphin)"
 authors = "Team Dolphin"
 supported_extensions = "gcm|iso|wbfs|ciso|gcz|elf|dol|dff|tgc|wad"
 corename = "Dolphin"

--- a/dist/info/emux_gb_libretro.info
+++ b/dist/info/emux_gb_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Game Boy / Game Boy Color (Emux GB)"
+display_name = "Nintendo - Game Boy / Color (Emux GB)"
 authors = "Sebastien Ronsse"
 supported_extensions = "gb|bin|rom"
 corename = "Emux GB"

--- a/dist/info/emux_nes_libretro.info
+++ b/dist/info/emux_nes_libretro.info
@@ -1,4 +1,4 @@
-display_name = "NES / Famicom (Emux NES)"
+display_name = "Nintendo - NES / Famicom (Emux NES)"
 authors = "Sebastien Ronsse"
 supported_extensions = "nes|bin|rom"
 corename = "Emux NES"

--- a/dist/info/emux_sms_libretro.info
+++ b/dist/info/emux_sms_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Sega Master System (Emux SMS)"
+display_name = "Sega - Master System (Emux SMS)"
 authors = "Sebastien Ronsse"
 supported_extensions = "sms|bin|rom"
 corename = "Emux SMS"

--- a/dist/info/fceumm_libretro.info
+++ b/dist/info/fceumm_libretro.info
@@ -1,4 +1,4 @@
-display_name = "NES / Famicom (FCEUmm)"
+display_name = "Nintendo - NES / Famicom (FCEUmm)"
 authors = "FCEU Team|CaH4e3"
 supported_extensions = "fds|nes|unif|unf"
 corename = "FCEUmm"

--- a/dist/info/fmsx_libretro.info
+++ b/dist/info/fmsx_libretro.info
@@ -1,4 +1,4 @@
-display_name = "MSX (fMSX)"
+display_name = "Microsoft - MSX (fMSX)"
 authors = "Marat Fayzullin"
 supported_extensions = "rom|mx1|mx2|dsk|cas"
 corename = "fMSX"

--- a/dist/info/gambatte_libretro.info
+++ b/dist/info/gambatte_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Game Boy / Game Boy Color (Gambatte)"
+display_name = "Nintendo - Game Boy / Color (Gambatte)"
 authors = "Sinamas"
 supported_extensions = "gb|gbc|dmg"
 corename = "Gambatte"

--- a/dist/info/gearboy_libretro.info
+++ b/dist/info/gearboy_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Game Boy / Game Boy Color (Gearboy)"
+display_name = "Nintendo - Game Boy / Color (Gearboy)"
 authors = "Ignacio Sanchez"
 supported_extensions = "gb|dmg|gbc|cgb|sgb"
 corename = "Gearboy"

--- a/dist/info/genesis_plus_gx_libretro.info
+++ b/dist/info/genesis_plus_gx_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Sega MS/GG/MD/CD (Genesis Plus GX)"
+display_name = "Sega - MS/GG/MD/CD (Genesis Plus GX)"
 authors = "Charles McDonald|Eke-Eke"
 supported_extensions = "mdx|md|smd|gen|bin|cue|iso|sms|gg|sg|68k|chd"
 corename = "Genesis Plus GX"

--- a/dist/info/gpsp_libretro.info
+++ b/dist/info/gpsp_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Game Boy Advance (gpSP)"
+display_name = "Nintendo - Game Boy Advance (gpSP)"
 authors = "Exophase"
 supported_extensions = "gba|bin"
 corename = "gpSP"

--- a/dist/info/handy_libretro.info
+++ b/dist/info/handy_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Atari Lynx (Handy)"
+display_name = "Atari - Lynx (Handy)"
 authors = "K. Wilkins"
 supported_extensions = "lnx"
 corename = "Handy"

--- a/dist/info/hatari_libretro.info
+++ b/dist/info/hatari_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Atari ST/STE/TT/Falcon (Hatari)"
+display_name = "Atari - ST/STE/TT/Falcon (Hatari)"
 authors = "Nicolas Pomarède"
 supported_extensions = "st|msa|zip|stx|dim|ipf"
 corename = "Hatari"

--- a/dist/info/higan_sfc_balanced_libretro.info
+++ b/dist/info/higan_sfc_balanced_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (nSide Balanced)"
+display_name = "Nintendo - SNES / Famicom (nSide Balanced)"
 authors = "hex-usr"
 supported_extensions = "sfc|smc|gb|gbc|bml|rom"
 corename = "nSide (Super Famicom Balanced)"

--- a/dist/info/higan_sfc_libretro.info
+++ b/dist/info/higan_sfc_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (higan Accuracy)"
+display_name = "Nintendo - SNES / Famicom (higan Accuracy)"
 authors = "byuu"
 supported_extensions = "sfc|smc|gb|gbc|bml|rom"
 corename = "higan (Super Famicom Accuracy)"

--- a/dist/info/mednafen_gba_libretro.info
+++ b/dist/info/mednafen_gba_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Game Boy Advance (Beetle GBA)"
+display_name = "Nintendo - Game Boy Advance (Beetle GBA)"
 authors = "Forgotten|Mednafen Team"
 supported_extensions = "gba|agb|bin"
 corename = "Beetle GBA"

--- a/dist/info/mednafen_lynx_libretro.info
+++ b/dist/info/mednafen_lynx_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Atari Lynx (Beetle Handy)"
+display_name = "Atari - Lynx (Beetle Handy)"
 authors = "K. Wilkins|Mednafen Team"
 supported_extensions = "lnx"
 corename = "Beetle Lynx"

--- a/dist/info/mednafen_ngp_libretro.info
+++ b/dist/info/mednafen_ngp_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Neo Geo Pocket/Color (Beetle NeoPop)"
+display_name = "SNK - Neo Geo Pocket / Color (Beetle NeoPop)"
 authors = "neopop_uk|Mednafen Team"
 supported_extensions = "ngp|ngc|ngpc"
 corename = "Beetle NeoPop"

--- a/dist/info/mednafen_pce_fast_libretro.info
+++ b/dist/info/mednafen_pce_fast_libretro.info
@@ -1,4 +1,4 @@
-display_name = "PC Engine/PCE-CD (Beetle PCE FAST)"
+display_name = "NEC - PC Engine / CD (Beetle PCE FAST)"
 authors = "Mednafen Team"
 supported_extensions = "pce|cue|ccd|iso|img|bin|chd"
 corename = "Beetle PCE Fast"

--- a/dist/info/mednafen_pcfx_libretro.info
+++ b/dist/info/mednafen_pcfx_libretro.info
@@ -1,4 +1,4 @@
-display_name = "PC-FX (Beetle PC-FX)"
+display_name = "NEC - PC-FX (Beetle PC-FX)"
 authors = "Mednafen Team"
 supported_extensions = "cue|ccd|toc|chd"
 corename = "Beetle PC-FX"

--- a/dist/info/mednafen_psx_hw_libretro.info
+++ b/dist/info/mednafen_psx_hw_libretro.info
@@ -1,4 +1,4 @@
-display_name = "PlayStation (Beetle PSX HW)"
+display_name = "Sony - PlayStation (Beetle PSX HW)"
 authors = "Mednafen Team"
 supported_extensions = "cue|toc|m3u|ccd|exe|pbp|chd"
 corename = "Beetle PSX HW"

--- a/dist/info/mednafen_psx_libretro.info
+++ b/dist/info/mednafen_psx_libretro.info
@@ -1,4 +1,4 @@
-display_name = "PlayStation (Beetle PSX)"
+display_name = "Sony - PlayStation (Beetle PSX)"
 authors = "Mednafen Team"
 supported_extensions = "cue|toc|m3u|ccd|exe|pbp|chd"
 corename = "Beetle PSX"

--- a/dist/info/mednafen_saturn_libretro.info
+++ b/dist/info/mednafen_saturn_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Sega Saturn (Beetle Saturn)"
+display_name = "Sega - Saturn (Beetle Saturn)"
 authors = "Mednafen Team"
 supported_extensions = "cue|toc|m3u|ccd|chd"
 corename = "Beetle Saturn"

--- a/dist/info/mednafen_snes_libretro.info
+++ b/dist/info/mednafen_snes_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (Beetle bsnes)"
+display_name = "Nintendo - SNES / Famicom (Beetle bsnes)"
 authors = "byuu|Mednafen Team"
 supported_extensions = "smc|fig|bs|st|sfc"
 corename = "Beetle bsnes"

--- a/dist/info/mednafen_supergrafx_libretro.info
+++ b/dist/info/mednafen_supergrafx_libretro.info
@@ -1,4 +1,4 @@
-display_name = "PC Engine SuperGrafx (Beetle SGX)"
+display_name = "NEC - PC Engine SuperGrafx (Beetle SGX)"
 authors = "Mednafen Team"
 supported_extensions = "pce|sgx|cue|ccd|chd"
 corename = "Beetle SGX"

--- a/dist/info/mednafen_vb_libretro.info
+++ b/dist/info/mednafen_vb_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Virtual Boy (Beetle VB)"
+display_name = "Nintendo - Virtual Boy (Beetle VB)"
 authors = "Mednafen Team"
 supported_extensions = "vb|vboy|bin"
 corename = "Beetle VB"

--- a/dist/info/mednafen_wswan_libretro.info
+++ b/dist/info/mednafen_wswan_libretro.info
@@ -1,4 +1,4 @@
-display_name = "WonderSwan/Color (Beetle Cygne)"
+display_name = "Bandai - WonderSwan/Color (Beetle Cygne)"
 authors = "Dox|Mednafen Team"
 supported_extensions = "ws|wsc"
 corename = "Beetle WonderSwan"

--- a/dist/info/melonds_libretro.info
+++ b/dist/info/melonds_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Nintendo DS (melonDS)"
+display_name = "Nintendo - DS (melonDS)"
 authors = "StapleButter"
 supported_extensions = "nds"
 corename = "melonDS"

--- a/dist/info/mesen_libretro.info
+++ b/dist/info/mesen_libretro.info
@@ -1,4 +1,4 @@
-display_name = "NES / Famicom (Mesen)"
+display_name = "Nintendo - NES / Famicom (Mesen)"
 authors = "M. Bibaud (aka Sour)"
 supported_extensions = "nes|fds|unf|unif"
 corename = "Mesen"

--- a/dist/info/meteor_libretro.info
+++ b/dist/info/meteor_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Game Boy Advance (Meteor)"
+display_name = "Nintendo - Game Boy Advance (Meteor)"
 authors = "Philippe Daouadi"
 supported_extensions = "gba"
 corename = "Meteor"

--- a/dist/info/mgba_libretro.info
+++ b/dist/info/mgba_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Game Boy Advance (mGBA)"
+display_name = "Nintendo - Game Boy Advance (mGBA)"
 authors = "Jeffrey Pfau"
 supported_extensions = "gb|gbc|gba"
 corename = "mGBA"

--- a/dist/info/mupen64plus_gles3_libretro.info
+++ b/dist/info/mupen64plus_gles3_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Nintendo 64 (Mupen64Plus GLES3)"
+display_name = "Nintendo - Nintendo 64 (Mupen64Plus GLES3)"
 authors = "Hacktarux|Mupen64Plus Team"
 supported_extensions = "n64|v64|z64|bin|u1|ndd"
 corename = "Mupen64Plus"

--- a/dist/info/mupen64plus_libretro.info
+++ b/dist/info/mupen64plus_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Nintendo 64 (Mupen64Plus)"
+display_name = "Nintendo - Nintendo 64 (Mupen64Plus)"
 authors = "Hacktarux|Mupen64Plus Team"
 supported_extensions = "n64|v64|z64|bin|u1|ndd"
 corename = "Mupen64Plus OpenGL"

--- a/dist/info/nekop2_libretro.info
+++ b/dist/info/nekop2_libretro.info
@@ -1,4 +1,4 @@
-display_name = "NEC PC-98 (Neko Project II)"
+display_name = "NEC - PC-98 (Neko Project II)"
 authors = "Neko Project II Team"
 supported_extensions = "d98|zip|98d|fdi|fdd|2hd|tfd|d88|88d|hdm|xdf|dup|cmd|hdi|thd|nhd|hdd"
 corename = "Neko Project II"

--- a/dist/info/nestopia_libretro.info
+++ b/dist/info/nestopia_libretro.info
@@ -1,4 +1,4 @@
-display_name = "NES / Famicom (Nestopia UE)"
+display_name = "Nintendo - NES / Famicom (Nestopia UE)"
 authors = "Martin Freij|R. Belmont|R. Danbrook"
 supported_extensions = "nes|fds|unf|unif"
 corename = "Nestopia"

--- a/dist/info/np2kai_libretro.info
+++ b/dist/info/np2kai_libretro.info
@@ -1,4 +1,4 @@
-display_name = "NEC PC-98 (Neko Project II Kai)"
+display_name = "NEC - PC-98 (Neko Project II Kai)"
 authors = "Neko Project II Team, Tomohiro Yoshidomi"
 supported_extensions = "d98|zip|98d|fdi|fdd|2hd|tfd|d88|88d|hdm|xdf|dup|cmd|hdi|thd|nhd|hdd|hdn"
 corename = "Neko Project II"

--- a/dist/info/o2em_libretro.info
+++ b/dist/info/o2em_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Odyssey2 / Videopac+ (O2EM)"
+display_name = "Magnavox - Odyssey2 / Phillips Videopac+ (O2EM)"
 authors = "Daniel Boris|Andre de la Rocha|Arlindo M. de Oliveira"
 supported_extensions = "bin"
 corename = "O2EM"

--- a/dist/info/opentyrian_libretro.info
+++ b/dist/info/opentyrian_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Tyrian (Open Tyrian)"
+display_name = "Tyrian (OpenTyrian)"
 authors = ""
 supported_extensions = ""
 corename = "OpenTyrian"

--- a/dist/info/parallel_n64_debug_libretro.info
+++ b/dist/info/parallel_n64_debug_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Nintendo 64 (ParaLLEl) (Debug)"
+display_name = "Nintendo - Nintendo 64 (ParaLLEl) (Debug)"
 authors = "Hacktarux|Mupen64Plus Team|TinyTiger|Libretro"
 supported_extensions = "n64|v64|z64|bin|u1|ndd"
 corename = "ParaLLEl (Debug)"

--- a/dist/info/parallel_n64_libretro.info
+++ b/dist/info/parallel_n64_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Nintendo 64 (ParaLLEl N64)"
+display_name = "Nintendo - Nintendo 64 (ParaLLEl N64)"
 authors = "Hacktarux|Mupen64Plus Team|TinyTiger|Libretro"
 supported_extensions = "n64|v64|z64|bin|u1|ndd"
 corename = "ParaLLEl N64"

--- a/dist/info/pcsx1_libretro.info
+++ b/dist/info/pcsx1_libretro.info
@@ -1,4 +1,4 @@
-display_name = "PlayStation (PCSX1)"
+display_name = "Sony - PlayStation (PCSX1)"
 authors = "PCSX Team|notaz|Exophase"
 supported_extensions = "bin|cue|img|mdf|pbp|toc|cbn|m3u"
 corename = "PCSX1"

--- a/dist/info/pcsx_rearmed_interpreter_libretro.info
+++ b/dist/info/pcsx_rearmed_interpreter_libretro.info
@@ -1,4 +1,4 @@
-display_name = "PlayStation (PCSX ReARMed) [Interpreter]"
+display_name = "Sony - PlayStation (PCSX ReARMed) [Interpreter]"
 authors = "PCSX Team|notaz|Exophase"
 supported_extensions = "bin|cue|img|mdf|pbp|cbn|toc"
 corename = "PCSX ReARMed [Interpreter]"

--- a/dist/info/pcsx_rearmed_libretro.info
+++ b/dist/info/pcsx_rearmed_libretro.info
@@ -1,4 +1,4 @@
-display_name = "PlayStation (PCSX ReARMed)"
+display_name = "Sony - PlayStation (PCSX ReARMed)"
 authors = "PCSX Team|notaz|Exophase"
 supported_extensions = "bin|cue|img|mdf|pbp|toc|cbn|m3u"
 corename = "PCSX ReARMed"

--- a/dist/info/pcsx_rearmed_libretro_neon.info
+++ b/dist/info/pcsx_rearmed_libretro_neon.info
@@ -1,4 +1,4 @@
-display_name = "PlayStation (PCSX ReARMed) [NEON]"
+display_name = "Sony - PlayStation (PCSX ReARMed) [NEON]"
 authors = "PCSX Team|notaz|Exophase"
 supported_extensions = "bin|cue|img|mdf|pbp|toc|cbn|m3u"
 corename = "PCSX ReARMed [NEON]"

--- a/dist/info/picodrive_libretro.info
+++ b/dist/info/picodrive_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Sega MS/MD/CD/32X (PicoDrive)"
+display_name = "Sega - MS/MD/CD/32X (PicoDrive)"
 authors = "notaz|fdave"
 supported_extensions = "bin|gen|smd|md|32x|cue|iso|sms|68k"
 corename = "PicoDrive"

--- a/dist/info/pokemini_libretro.info
+++ b/dist/info/pokemini_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Pokémon Mini (PokeMini)"
+display_name = "Nintendo - Pokémon Mini (PokeMini)"
 authors = "JustBurn"
 supported_extensions = "min"
 corename = "PokeMini"

--- a/dist/info/ppsspp_libretro.info
+++ b/dist/info/ppsspp_libretro.info
@@ -1,4 +1,4 @@
-display_name = "PSP (PPSSPP)"
+display_name = "Sony - PlayStation Portable (PPSSPP)"
 authors = "Henrik Hrydgard"
 supported_extensions = "elf|iso|cso|prx|pbp"
 corename = "PPSSPP"

--- a/dist/info/prosystem_libretro.info
+++ b/dist/info/prosystem_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Atari 7800 (ProSystem)"
+display_name = "Atari - 7800 (ProSystem)"
 authors = "Greg Stanton|Brian Berlin|Leonis|Greg DeMent"
 supported_extensions = "a78|bin"
 corename = "ProSystem"

--- a/dist/info/puae_libretro.info
+++ b/dist/info/puae_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Amiga (P-UAE)"
+display_name = "Commodore - Amiga (P-UAE)"
 authors = "GnoStiC"
 supported_extensions = "adf|dms|fdi|ipf|zip|uae"
 corename = "PUAE"

--- a/dist/info/px68k_libretro.info
+++ b/dist/info/px68k_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Sharp X68000 (PX68k)"
+display_name = "Sharp - X68000 (PX68k)"
 authors = "hissorii"
 supported_extensions = "dim|zip|img|d88|88d|hdm|dup|2hd|xdf|hdf|cmd|m3u"
 corename = "PX68k"

--- a/dist/info/quicknes_libretro.info
+++ b/dist/info/quicknes_libretro.info
@@ -1,4 +1,4 @@
-display_name = "NES / Famicom (QuickNES)"
+display_name = "Nintendo - NES / Famicom (QuickNES)"
 authors = "blargg|kode54"
 supported_extensions = "nes"
 corename = "QuickNES"

--- a/dist/info/redream_libretro.info
+++ b/dist/info/redream_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Sega Dreamcast (Redream)"
+display_name = "Sega - Dreamcast (Redream)"
 authors = "inolen"
 supported_extensions = "gdi|chd|cdi"
 corename = "Redream"

--- a/dist/info/reicast_libretro.info
+++ b/dist/info/reicast_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Sega Dreamcast (Reicast)"
+display_name = "Sega - Dreamcast (Reicast)"
 authors = "skmp"
 supported_extensions = "cdi|gdi|chd|cue"
 corename = "Reicast"

--- a/dist/info/reicast_naomi_libretro.info
+++ b/dist/info/reicast_naomi_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Sega NAOMI (Reicast NAOMI)"
+display_name = "Sega - NAOMI (Reicast NAOMI)"
 authors = "skmp"
 supported_extensions = "chd|cdi|iso|elf|bin|cue|gdi"
 corename = "Reicast NAOMI"

--- a/dist/info/rustation_libretro.info
+++ b/dist/info/rustation_libretro.info
@@ -1,4 +1,4 @@
-display_name = "PlayStation (Rustation)"
+display_name = "Sony - PlayStation (Rustation)"
 authors = "Simias"
 supported_extensions = "cue|toc|m3u|ccd|exe"
 corename = "Rustation"

--- a/dist/info/sameboy_libretro.info
+++ b/dist/info/sameboy_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Game Boy / Game Boy Color (SameBoy)"
+display_name = "Nintendo - Game Boy / Color (SameBoy)"
 authors = "LIJI32"
 supported_extensions = "gb|gbc"
 corename = "SameBoy"

--- a/dist/info/snes9x2002_libretro.info
+++ b/dist/info/snes9x2002_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (Snes9x 2002)"
+display_name = "Nintendo - SNES / Famicom (Snes9x 2002)"
 authors = "Snes9x Team|PocketSNES Team|Toadking"
 supported_extensions = "smc|fig|sfc|gd3|gd7|dx2|bsx|swc"
 corename = "Snes9x 2002"

--- a/dist/info/snes9x2005_libretro.info
+++ b/dist/info/snes9x2005_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (Snes9x 2005)"
+display_name = "Nintendo - SNES / Famicom (Snes9x 2005)"
 authors = "Snes9x Team|dking|BassAceGold|ShadauxCat|Nebuleon"
 supported_extensions = "smc|fig|sfc|gd3|gd7|dx2|bsx|swc"
 corename = "Snes9x 2005"

--- a/dist/info/snes9x2005_plus_libretro.info
+++ b/dist/info/snes9x2005_plus_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (Snes9x 2005 Plus)"
+display_name = "Nintendo - SNES / Famicom (Snes9x 2005 Plus)"
 authors = "Snes9x Team|dking|BassAceGold|ShadauxCat|Nebuleon"
 supported_extensions = "smc|fig|sfc|gd3|gd7|dx2|bsx|swc"
 corename = "Snes9x 2005 Plus"

--- a/dist/info/snes9x2010_libretro.info
+++ b/dist/info/snes9x2010_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (Snes9x 2010)"
+display_name = "Nintendo - SNES / Famicom (Snes9x 2010)"
 authors = "Snes9x Team|Squarepusher"
 supported_extensions = "smc|fig|sfc|gd3|gd7|dx2|bsx|swc"
 corename = "Snes9x 2010"

--- a/dist/info/snes9x_libretro.info
+++ b/dist/info/snes9x_libretro.info
@@ -1,4 +1,4 @@
-display_name = "SNES / Super Famicom (Snes9x)"
+display_name = "Nintendo - SNES / Famicom (Snes9x)"
 authors = "Snes9x Team"
 supported_extensions = "smc|sfc|swc|fig|bs"
 corename = "Snes9x"

--- a/dist/info/stella_libretro.info
+++ b/dist/info/stella_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Atari 2600 (Stella)"
+display_name = "Atari - 2600 (Stella)"
 authors = "Stephen Anthony|Bradford Mott|Eckhard Stolberg|Brian Watson"
 supported_extensions = "a26|bin"
 corename = "Stella"

--- a/dist/info/tempgba_libretro.info
+++ b/dist/info/tempgba_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Game Boy Advance (TempGBA)"
+display_name = "Nintendo - Game Boy Advance (TempGBA)"
 authors = "Exophase|Takka|Nebuleon|Normmatt|BassAceGold"
 supported_extensions = "gba|bin|agb|gbz"
 corename = "TempGBA"

--- a/dist/info/tgbdual_libretro.info
+++ b/dist/info/tgbdual_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Game Boy / Game Boy Color (TGB Dual)"
+display_name = "Nintendo - Game Boy / Game Boy Color (TGB Dual)"
 authors = "GIGO|Hii"
 supported_extensions = "gb|gbc|sgb"
 corename = "TGB Dual"

--- a/dist/info/uae4arm_libretro.info
+++ b/dist/info/uae4arm_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Amiga (UAE4ARM)"
+display_name = "Commodore - Amiga (UAE4ARM)"
 authors = "GnoStiC"
 supported_extensions = "adf|dms|zip|ipf|adz|uae"
 corename = "UAE4ARM"

--- a/dist/info/vba_next_libretro.info
+++ b/dist/info/vba_next_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Game Boy Advance (VBA Next)"
+display_name = "Nintendo - Game Boy Advance (VBA Next)"
 authors = "Forgotten|VBA-M Team|Squarepusher"
 supported_extensions = "gba"
 corename = "VBA Next"

--- a/dist/info/vbam_libretro.info
+++ b/dist/info/vbam_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Game Boy Advance (VBA-M)"
+display_name = "Nintendo - Game Boy Advance (VBA-M)"
 authors = "Forgotten|VBA-M Team"
 supported_extensions = "gba"
 corename = "VBA-M"

--- a/dist/info/vecx_libretro.info
+++ b/dist/info/vecx_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Vectrex (vecx)"
+display_name = "GCE - Vectrex (vecx)"
 authors = "Valavan Manohararajah|John Hawthorn|Nikita Zimin|Demeth"
 supported_extensions = "bin|vec"
 corename = "vecx"

--- a/dist/info/vice_x128_libretro.info
+++ b/dist/info/vice_x128_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Commodore 128 (VICE C128)"
+display_name = "Commodore - C128 (VICE C128)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z"
 corename = "VICE"

--- a/dist/info/vice_x64_libretro.info
+++ b/dist/info/vice_x64_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Commodore 64 (VICE C64)"
+display_name = "Commodore - C64 (VICE C64)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z"
 corename = "VICE"

--- a/dist/info/vice_xplus4_libretro.info
+++ b/dist/info/vice_xplus4_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Commodore PLUS4 (VICE PLUS4)"
+display_name = "Commodore - PLUS4 (VICE PLUS4)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z"
 corename = "VICE"

--- a/dist/info/vice_xvic_libretro.info
+++ b/dist/info/vice_xvic_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Commodore VIC20 (VICE VIC20)"
+display_name = "Commodore - VIC20 (VICE VIC20)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z"
 corename = "VICE"

--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Atari Jaguar (Virtual Jaguar)"
+display_name = "Atari - Jaguar (Virtual Jaguar)"
 authors = "David Raingeard|Shamus"
 supported_extensions = "j64|jag|rom|abs|cof|bin|prg"
 corename = "Virtual Jaguar"

--- a/dist/info/yabause_libretro.info
+++ b/dist/info/yabause_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Sega Saturn (Yabause)"
+display_name = "Sega - Saturn (Yabause)"
 authors = "Guillaume Duhammel|Theo Berkau|Anders Montonen"
 supported_extensions = "bin|cue|iso"
 corename = "Yabause"


### PR DESCRIPTION
There were cases where the manufacturer of the system was prefixed in the core's display name, other times not so much. It would be good to standardize them.

This makes the manufacturer's name appear in the beginning of the display name when it makes sense, bringing some consistency in the names. Makes it look more like their playlist/database name. Below is what the Core Updater screen looks like when this change is applied:

![screenshot at 2018-01-27 20-47-20](https://user-images.githubusercontent.com/25086/35478154-7e13b302-03a3-11e8-92c8-e7046cd4ee4c.png)
