### PR TITLE
libretro-buildbot-recipe.sh: Don't fetch changes or reset the repo if…

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -575,12 +575,14 @@ while read line; do
 			{ echo "git directory broken, removing $DIR and skipping $NAME."; \
 			rm -rfv -- "$DIR" && continue; }
 
-		echo "fetching changes from repo $URL..."
-		git --work-tree="$DIR" --git-dir="$DIR/.git" fetch --depth 1 origin "${GIT_BRANCH}"
+		if [ -z "${NOCLEAN}" ]; then
+			echo "fetching changes from repo $URL..."
+			git --work-tree="$DIR" --git-dir="$DIR/.git" fetch --depth 1 origin "${GIT_BRANCH}"
 
-		echo "resetting repo state $URL..."
-		git --work-tree="." --git-dir=".git" -C "$DIR" reset --hard FETCH_HEAD
-		git --work-tree="$DIR" --git-dir="$DIR/.git" clean -xdf -e .libretro-core-recipe
+			echo "resetting repo state $URL..."
+			git --work-tree="." --git-dir=".git" -C "$DIR" reset --hard FETCH_HEAD
+			git --work-tree="$DIR" --git-dir="$DIR/.git" clean -xdf -e .libretro-core-recipe
+		fi
 
 		if [ "$HEAD" = "$(git --work-tree="$DIR" --git-dir="$DIR/.git" rev-parse HEAD)" ] && [ "${BUILD}" != "YES" ]; then
 			BUILD="NO"

--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -628,8 +628,11 @@ while read line; do
 			LEIRADEL )    build_libretro_generic_makefile $NAME $DIR $SUBDIR $MAKEFILE ${PLATFORM} "${ARGS}" "${CORES}"               ;;
 			* )           :                                                                                                           ;;
 		esac
-		echo "Cleaning repo state after build $URL..."
-		git --work-tree="${BASE_DIR}/${DIR}" --git-dir="${BASE_DIR}/${DIR}/.git" clean -xdf -e .libretro-core-recipe
+
+		if [ -z "${NOCLEAN}" ]; then
+			echo "Cleaning repo state after build $URL..."
+			git --work-tree="${BASE_DIR}/${DIR}" --git-dir="${BASE_DIR}/${DIR}/.git" clean -xdf -e .libretro-core-recipe
+		fi
 	else
 		echo "buildbot job: building $NAME up-to-date"
 	fi


### PR DESCRIPTION
… $NOCLEAN is set.

This should allow using `NOCLEAN=1 ./libretro-buildbot-recipe.sh` to disable fetching changes and resetting the repo which is useful for debugging some platforms.