### PR TITLE
add mame 2003 and 2010 to ps3 buildbot

### DIFF
--- a/recipes/playstation/ps3
+++ b/recipes/playstation/ps3
@@ -16,6 +16,8 @@ gpsp libretro-gpsp https://github.com/libretro/gpsp.git master NO GENERIC Makefi
 handy libretro-handy https://github.com/libretro/libretro-handy.git master YES GENERIC Makefile .
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master NO GENERIC Makefile .
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
+mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile .
 mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .
 mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .


### PR DESCRIPTION
PS3 already seems to be set up already in the respective Makefiles.

This would close https://github.com/libretro/mame2010-libretro/issues/42