### PR TITLE
Add CMake field to linux-armhf target

### DIFF
--- a/recipes/linux/cores-linux-armhf-generic.conf
+++ b/recipes/linux/cores-linux-armhf-generic.conf
@@ -3,6 +3,7 @@ PLATFORM linux
 MAKEPORTABLE YES
 CORE_JOB YES
 MAKE make
+CMAKE cmake
 PATH /usr/lib/ccache
 CC arm-linux-gnueabihf-gcc
 CXX arm-linux-gnueabihf-g++


### PR DESCRIPTION
Currently, the linux-armhf target doesn't specify a path to CMake, and therefore doesn't provide any means of invoking it from the build scripts (instead attempting to invoke a executable with a empty string path). This fixes this and uses the generic CMake binary for this target.