### PR TITLE
Update pokemini_libretro.info

### DIFF
--- a/dist/info/pokemini_libretro.info
+++ b/dist/info/pokemini_libretro.info
@@ -13,5 +13,5 @@ supports_no_game = "false"
 firmware_count = 1
 firmware0_desc = "bios.min (Pokémon Mini BIOS)"
 firmware0_path = "bios.min"
-firmware0_opt = "false"
+firmware0_opt = "true"
 notes = "Suggested md5sum:|1e4fb124a3a886865acb574f388c803d = bios.min"


### PR DESCRIPTION
Pokemon Mini BIOS is optional. It has HLE BIOS emulation built in.

Proof: https://github.com/libretro/PokeMini/blob/master/readme.txt#L20