### PR TITLE
Update craft_libretro.info

### DIFF
--- a/dist/info/craft_libretro.info
+++ b/dist/info/craft_libretro.info
@@ -1,5 +1,5 @@
 display_name = "Minecraft (Craft)"
-authors = "Snes9x Team|dking|BassAceGold|ShadauxCat|Nebuleon"
+authors = "Michael Fogleman"
 supported_extensions = ""
 corename = "Craft"
 categories = "Game"


### PR DESCRIPTION
Fixed author section. Looks like this got accidentally copy and pasted from Snes9x 2005.

Proof: https://www.michaelfogleman.com/projects/craft/