### PR TITLE
Fix and simplify android cmake path

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -363,10 +363,9 @@ build_libretro_generic_makefile() {
 		echo -------------------------------------------------- | tee -a "$LOGFILE"
 		if [ "${COMMAND}" = "CMAKE" ]; then
 			if [ "${PLATFORM}" = "android" ]; then
-				EXTRAARGS="-DCMAKE_SYSTEM_NAME=Android \
-					-DCMAKE_SYSTEM_VERSION=${API_LEVEL} \
-					-DCMAKE_ANDROID_ARCH_ABI=${ABI_OVERRIDE} \
-					-DCMAKE_ANDROID_NDK=${NDK_ROOT}"
+				EXTRAARGS="-DANDROID_PLATFORM=android-${API_LEVEL} \
+					-DANDROID_ABI=${ABI_OVERRIDE} \
+					-DCMAKE_TOOLCHAIN_FILE=${NDK_ROOT}/build/cmake/android.toolchain.cmake"
 			fi
 
 			eval "set -- ${EXTRAARGS} \${CORE_ARGS}"

--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -396,6 +396,8 @@ build_libretro_generic_makefile() {
 
 		if [ "${PLATFORM}" = "windows" ] || [ "${PLATFORM}" = "unix" ]; then
 			${STRIP:=strip} -s ${OUT}/${CORENAM}
+		elif [ "${PLATFORM}" = "android" -a ! -z "${STRIPPATH+x}" ]; then
+			${NDK_ROOT}/${STRIPPATH} -s ${OUT}/${CORENAM}
 		fi
 
 		echo "COPY CMD: cp -v ${OUT}/${ORIGNAM} ${OUTPUT}" 2>&1 | tee -a "$LOGFILE"

--- a/recipes/android/cores-android-cmake-aarch64
+++ b/recipes/android/cores-android-cmake-aarch64
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-aarch64 https://github.com/libretro/ppsspp.git master NO CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-aarch64 https://github.com/libretro/ppsspp.git master NO CMAKE Makefile build -DLIBRETRO=ON -DANDROID_TOOLCHAIN=clang -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-aarch64.conf
+++ b/recipes/android/cores-android-cmake-aarch64.conf
@@ -14,3 +14,4 @@ CORE_JOB YES
 ABI_OVERRIDE arm64-v8a
 API_LEVEL 21
 CMAKE cmake
+STRIPPATH toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-strip

--- a/recipes/android/cores-android-cmake-armv7
+++ b/recipes/android/cores-android-cmake-armv7
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-armv7 https://github.com/libretro/ppsspp.git master NO CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-armv7 https://github.com/libretro/ppsspp.git master NO CMAKE Makefile build -DLIBRETRO=ON -DANDROID_TOOLCHAIN=clang -DANDROID_STL=c++_static -DANDROID_ARM_NEON=ON -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-armv7.conf
+++ b/recipes/android/cores-android-cmake-armv7.conf
@@ -14,3 +14,4 @@ CORE_JOB YES
 ABI_OVERRIDE armeabi-v7a
 API_LEVEL 9
 CMAKE cmake
+STRIPPATH toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin/arm-linux-androideabi-strip

--- a/recipes/android/cores-android-cmake-x86
+++ b/recipes/android/cores-android-cmake-x86
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-x86 https://github.com/libretro/ppsspp.git master NO CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_static -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-x86 https://github.com/libretro/ppsspp.git master NO CMAKE Makefile build -DLIBRETRO=ON -DANDROID_TOOLCHAIN=clang -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-x86.conf
+++ b/recipes/android/cores-android-cmake-x86.conf
@@ -14,3 +14,4 @@ CORE_JOB YES
 ABI_OVERRIDE x86
 API_LEVEL 9
 CMAKE cmake
+STRIPPATH toolchains/x86-4.9/prebuilt/linux-x86_64/bin/i686-linux-android-strip


### PR DESCRIPTION
After some more research, I found that using the toolchain file is the actually supported method of compiling android projects through cmake. I've tested compiling ppsspp against upstream plus my open PR to fix gles platforms. This is a precursor to switching ppsspp back to cmake on android.