### PR TITLE
Track ppsspp upstream

### DIFF
--- a/recipes/android/cores-android-cmake-aarch64
+++ b/recipes/android/cores-android-cmake-aarch64
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-aarch64 https://github.com/libretro/ppsspp.git master NO CMAKE Makefile build -DLIBRETRO=ON -DANDROID_TOOLCHAIN=clang -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-aarch64 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_TOOLCHAIN=clang -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-armv7
+++ b/recipes/android/cores-android-cmake-armv7
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-armv7 https://github.com/libretro/ppsspp.git master NO CMAKE Makefile build -DLIBRETRO=ON -DANDROID_TOOLCHAIN=clang -DANDROID_STL=c++_static -DANDROID_ARM_NEON=ON -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-armv7 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_TOOLCHAIN=clang -DANDROID_STL=c++_static -DANDROID_ARM_NEON=ON -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-x86
+++ b/recipes/android/cores-android-cmake-x86
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-x86 https://github.com/libretro/ppsspp.git master NO CMAKE Makefile build -DLIBRETRO=ON -DANDROID_TOOLCHAIN=clang -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-x86 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_TOOLCHAIN=clang -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-jni
+++ b/recipes/android/cores-android-jni
@@ -54,7 +54,7 @@ pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/li
 picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC_JNI Makefile.libretro jni
 pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC_JNI Makefile jni
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC_JNI Makefile jni
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_JNI Makefile libretro/jni
+ppsspp libretro-ppsspp https://github.com/hrydgard/ppsspp.git master NO GENERIC_JNI Makefile libretro/jni
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_JNI Makefile jni
 prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC_JNI Makefile jni
 puae libretro-puae https://github.com/libretro/libretro-uae.git master YES GENERIC_JNI Makefile jni

--- a/recipes/apple/cores-ios-generic
+++ b/recipes/apple/cores-ios-generic
@@ -62,7 +62,7 @@ pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/li
 picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
 pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_GL Makefile libretro
+ppsspp libretro-ppsspp https://github.com/hrydgard/ppsspp.git master YES GENERIC_GL Makefile libretro
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
 prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
 puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-ios9-generic
+++ b/recipes/apple/cores-ios9-generic
@@ -62,7 +62,7 @@ pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/li
 picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
 pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_GL Makefile libretro
+ppsspp libretro-ppsspp https://github.com/hrydgard/ppsspp.git master YES GENERIC_GL Makefile libretro
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
 prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
 puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -71,7 +71,7 @@ pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/li
 picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
 pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_GL Makefile libretro
+ppsspp libretro-ppsspp https://github.com/hrydgard/ppsspp.git master YES GENERIC_GL Makefile libretro
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
 prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
 puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -58,7 +58,7 @@ o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENE
 pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=0
 picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_GL Makefile libretro platform=armv7-neon-hardfloat ARCH=arm CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++
+ppsspp libretro-ppsspp https://github.com/hrydgard/ppsspp.git master YES GENERIC_GL Makefile libretro platform=armv7-neon-hardfloat ARCH=arm CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
 prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
 puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -78,7 +78,7 @@ pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git 
 picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
 pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .
 prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
 puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -68,7 +68,7 @@ pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git 
 picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
 pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .
 prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
 puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -76,7 +76,7 @@ pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git 
 picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
 pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_GL Makefile libretro platform=windows_msvc2017_desktop_x64
+ppsspp libretro-ppsspp https://github.com/hrydgard/ppsspp.git master YES GENERIC_GL Makefile libretro platform=windows_msvc2017_desktop_x64
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .
 prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
 puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -75,7 +75,7 @@ pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git 
 picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
 pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
-ppsspp libretro-ppsspp https://github.com/libretro/ppsspp.git master YES GENERIC_GL Makefile libretro platform=windows_msvc2017_desktop_x86
+ppsspp libretro-ppsspp https://github.com/hrydgard/ppsspp.git master YES GENERIC_GL Makefile libretro platform=windows_msvc2017_desktop_x86
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .
 prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
 puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .


### PR DESCRIPTION
Now that libretro has been merged upstream, the bot can track it directly without having to wait on merges downstream here.