### PR TITLE
recipes: Build nestopia with the upstream repo

### DIFF
--- a/recipes/android/cores-android-jni
+++ b/recipes/android/cores-android-jni
@@ -47,7 +47,7 @@ mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YE
 mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC_JNI Makefile libretro/jni
 mupen64plus_gles3 libretro-mupen64plus-gles3 https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC_JNI Makefile libretro/jni GLES3=1 APP_PLATFORM=android-18
 nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC_JNI Makefile.libretro libretro/jni
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC_JNI Makefile libretro/jni
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC_JNI Makefile libretro/jni
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC_JNI Makefile.libretro jni
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC_JNI Makefile jni
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC_JNI Makefile jni

--- a/recipes/android/cores-android-jni-old
+++ b/recipes/android/cores-android-jni-old
@@ -1,3 +1,3 @@
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC_JNI Makefile libretro/jni
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC_JNI Makefile libretro/jni
 quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC_JNI Makefile jni
 bluemsx libretro-bluemsx-old https://github.com/libretro/blueMSX-libretro.git master YES GENERIC_JNI Makefile jni

--- a/recipes/apple/cores-ios-generic
+++ b/recipes/apple/cores-ios-generic
@@ -53,7 +53,7 @@ mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makef
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=arm
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
 nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-ios9-generic
+++ b/recipes/apple/cores-ios9-generic
@@ -53,7 +53,7 @@ mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makef
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile .
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
 nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -61,7 +61,7 @@ mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makef
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile .
 nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .

--- a/recipes/blackberry/cores-qnx-generic
+++ b/recipes/blackberry/cores-qnx-generic
@@ -38,7 +38,7 @@ mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-li
 meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
 mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .

--- a/recipes/emscripten/emscripten
+++ b/recipes/emscripten/emscripten
@@ -34,7 +34,7 @@ mednafen_snes libretro-beetle_snes https://github.com/libretro/beetle-bsnes-libr
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master NO GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -51,7 +51,7 @@ mesen libretro-mesen https://github.com/SourMesen/Mesen.git master YES GENERIC M
 meteor libretro-meteor https://github.com/libretro/meteor-libretro.git master YES GENERIC Makefile libretro
 mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . ARCH=arm
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -68,7 +68,7 @@ mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makef
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
 mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
 nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -59,7 +59,7 @@ mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makef
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
 nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .

--- a/recipes/nintendo/3ds
+++ b/recipes/nintendo/3ds
@@ -20,7 +20,7 @@ mednafen_pce_fast libretro-beetle_pce_fast https://github.com/aliaspider/beetle-
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
 mgba libretro-mgba https://github.com/libretro/mgba.git master NO GENERIC Makefile.libretro .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master NO GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro .

--- a/recipes/nintendo/gamecube
+++ b/recipes/nintendo/gamecube
@@ -14,7 +14,7 @@ mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetl
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master NO GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .

--- a/recipes/nintendo/wii
+++ b/recipes/nintendo/wii
@@ -17,7 +17,7 @@ mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.gi
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
 mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master NO GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .

--- a/recipes/nintendo/wiiu
+++ b/recipes/nintendo/wiiu
@@ -29,7 +29,7 @@ mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-li
 mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
 mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master NO GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .

--- a/recipes/playstation/ps3
+++ b/recipes/playstation/ps3
@@ -25,7 +25,7 @@ mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pc
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
 mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master NO GENERIC Makefile.libretro . USE_DYNAREC=1
 picodrive libretro-picodrive https://github.com/libretro/picodrive.git master NO GENERIC Makefile.libretro .

--- a/recipes/playstation/vita
+++ b/recipes/playstation/vita
@@ -27,7 +27,7 @@ mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.gi
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
 mgba libretro-mgba https://github.com/libretro/mgba.git master NO GENERIC Makefile.libretro .
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES Makefile . WITH_DYNAREC=arm
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master NO GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . USE_DYNAREC=1

--- a/recipes/windows/cores-windows-msvc2003-x86_dw2-generic
+++ b/recipes/windows/cores-windows-msvc2003-x86_dw2-generic
@@ -15,7 +15,7 @@ mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro
 mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .

--- a/recipes/windows/cores-windows-msvc2005-x86_dw2-generic
+++ b/recipes/windows/cores-windows-msvc2005-x86_dw2-generic
@@ -13,7 +13,7 @@ mednafen_supergrafx libretro-beetle_supergrafx https://github.com/libretro/beetl
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-msvc2010-x64_seh-generic
+++ b/recipes/windows/cores-windows-msvc2010-x64_seh-generic
@@ -19,7 +19,7 @@ mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.gi
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
 melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-msvc2010-x86_dw2-generic
+++ b/recipes/windows/cores-windows-msvc2010-x86_dw2-generic
@@ -19,7 +19,7 @@ mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.gi
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
 melonds libretro-melonds https://github.com/libretro/melonDS.git master YES GENERIC Makefile .
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-msvc2017-desktop-x64_seh-generic
+++ b/recipes/windows/cores-windows-msvc2017-desktop-x64_seh-generic
@@ -1,6 +1,6 @@
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
 freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile .
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro

--- a/recipes/windows/cores-windows-msvc2017-desktop-x86_dw2-generic
+++ b/recipes/windows/cores-windows-msvc2017-desktop-x86_dw2-generic
@@ -1,6 +1,6 @@
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
 freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile .
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro

--- a/recipes/windows/cores-windows-msvc2017-uwp-arm-generic
+++ b/recipes/windows/cores-windows-msvc2017-uwp-arm-generic
@@ -1,6 +1,6 @@
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
 freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile .
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro

--- a/recipes/windows/cores-windows-msvc2017-uwp-x64_seh-generic
+++ b/recipes/windows/cores-windows-msvc2017-uwp-x64_seh-generic
@@ -1,6 +1,6 @@
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
 freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile .
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro

--- a/recipes/windows/cores-windows-msvc2017-uwp-x86_dw2-generic
+++ b/recipes/windows/cores-windows-msvc2017-uwp-x86_dw2-generic
@@ -1,6 +1,6 @@
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
 freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master YES GENERIC Makefile .
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -66,7 +66,7 @@ mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makef
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
 mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64
 nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -65,7 +65,7 @@ mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makef
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
 mupen64plus libretro-mupen64plus https://github.com/libretro/mupen64plus-libretro.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86
 nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/AZO234/NP2kai.git master YES GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .

--- a/recipes/xbox/cores-xbox-msvc2003-x86_dw2-generic
+++ b/recipes/xbox/cores-xbox-msvc2003-x86_dw2-generic
@@ -15,7 +15,7 @@ mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro
 mednafen_pce_fast libretro-beetle_pce_fast https://github.com/libretro/beetle-pce-fast-libretro.git master YES GENERIC Makefile .
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
-nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
+nestopia libretro-nestopia https://github.com/0ldsk00l/nestopia.git master YES GENERIC Makefile libretro
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
 o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENERIC Makefile .
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC_ALT Makefile .


### PR DESCRIPTION
These repos are even and we have way too many shallow forks. I think its best we let the upstream repo take the reigns so that issues and pull requests can all be submitted in one place.

Earlier work done in the buildbot script should make this change automatic. The old libretro repos will be removed and the new upstream repo will be cloned and then built.

Also bringing this to the attention of @rdanbrook.