### PR TITLE
Yet more android stuff

### DIFF
--- a/recipes/android/cores-android-jni
+++ b/recipes/android/cores-android-jni
@@ -55,7 +55,6 @@ o2em libretro-o2em https://github.com/libretro/libretro-o2em.git master YES GENE
 openlara libretro-openlara https://github.com/libretro/OpenLara.git master YES GENERIC_JNI Makefile src/platform/libretro/jni
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_JNI Makefile jni
 pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC_JNI Makefile.libretro jni
-pcsx_rearmed_interpreter libretro-pcsx_rearmed_interpreter https://github.com/libretro/pcsx_rearmed.git master YES GENERIC_JNI Makefile.libretro . USE_DYNAREC=0
 picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC_JNI Makefile.libretro jni
 pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC_JNI Makefile jni
 pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC_JNI Makefile jni

--- a/recipes/android/cores-android-jni.conf
+++ b/recipes/android/cores-android-jni.conf
@@ -6,7 +6,6 @@ PLATFORM android
 platform android
 MAKE make
 NDK ndk-build
-NDK_TOOLCHAIN_VERSION 4.9
 RA NO
 LIBSUFFIX _android
 CORE_JOB YES


### PR DESCRIPTION
To add to the commit comment on the pcsx interpreter removal, I'm going to take another shot at getting arm64-v8a and x86/64 compiling on the main recipe soon.

But the main part of this is switching the majority of cores over to compiling with clang. With all the recent PRs in, this should be good to go.