### PR TITLE
Update cores-android-cmake to use ndk r16b

### DIFF
--- a/recipes/android/cores-android-cmake-aarch64
+++ b/recipes/android/cores-android-cmake-aarch64
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-aarch64 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_TOOLCHAIN=clang -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-aarch64 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-aarch64.conf
+++ b/recipes/android/cores-android-cmake-aarch64.conf
@@ -1,12 +1,11 @@
 ANDROID_HOME /home/buildbot/tools/android/android-sdk-linux
-NDK_ROOT /home/buildbot/tools/android/android-ndk-r15c/
-ANDROID_NDK /home/buildbot/tools/android/android-ndk-r15c/
-PATH /home/buildbot/tools/android/android-ndk-r15c:/home/buildbot/tools/android/android-sdk-linux/tools
+NDK_ROOT /home/buildbot/tools/android/android-ndk-r16b/
+ANDROID_NDK /home/buildbot/tools/android/android-ndk-r16b/
+PATH /home/buildbot/tools/android/android-ndk-r16b:/home/buildbot/tools/android/android-sdk-linux/tools
 PLATFORM android
 platform android
 MAKE make
 NDK ndk-build
-NDK_TOOLCHAIN_VERSION 4.9
 RA NO
 DIST arm64-v8a
 LIBSUFFIX _android

--- a/recipes/android/cores-android-cmake-armv7
+++ b/recipes/android/cores-android-cmake-armv7
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-armv7 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_TOOLCHAIN=clang -DANDROID_STL=c++_static -DANDROID_ARM_NEON=ON -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-armv7 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_STL=c++_static -DANDROID_ARM_NEON=ON -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-armv7.conf
+++ b/recipes/android/cores-android-cmake-armv7.conf
@@ -1,12 +1,11 @@
 ANDROID_HOME /home/buildbot/tools/android/android-sdk-linux
-NDK_ROOT /home/buildbot/tools/android/android-ndk-r15c/
-ANDROID_NDK /home/buildbot/tools/android/android-ndk-r15c/
-PATH /home/buildbot/tools/android/android-ndk-r15c:/home/buildbot/tools/android/android-sdk-linux/tools
+NDK_ROOT /home/buildbot/tools/android/android-ndk-r16b/
+ANDROID_NDK /home/buildbot/tools/android/android-ndk-r16b/
+PATH /home/buildbot/tools/android/android-ndk-r16b:/home/buildbot/tools/android/android-sdk-linux/tools
 PLATFORM android
 platform android
 MAKE make
 NDK ndk-build
-NDK_TOOLCHAIN_VERSION 4.9
 RA NO
 DIST armeabi-v7a
 LIBSUFFIX _android

--- a/recipes/android/cores-android-cmake-x86
+++ b/recipes/android/cores-android-cmake-x86
@@ -1,1 +1,1 @@
-ppsspp libretro-ppsspp-x86 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_TOOLCHAIN=clang -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release
+ppsspp libretro-ppsspp-x86 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-x86.conf
+++ b/recipes/android/cores-android-cmake-x86.conf
@@ -1,12 +1,11 @@
 ANDROID_HOME /home/buildbot/tools/android/android-sdk-linux
-NDK_ROOT /home/buildbot/tools/android/android-ndk-r15c/
-ANDROID_NDK /home/buildbot/tools/android/android-ndk-r15c/
-PATH /home/buildbot/tools/android/android-ndk-r15c:/home/buildbot/tools/android/android-sdk-linux/tools
+NDK_ROOT /home/buildbot/tools/android/android-ndk-r16b/
+ANDROID_NDK /home/buildbot/tools/android/android-ndk-r16b/
+PATH /home/buildbot/tools/android/android-ndk-r16b:/home/buildbot/tools/android/android-sdk-linux/tools
 PLATFORM android
 platform android
 MAKE make
 NDK ndk-build
-NDK_TOOLCHAIN_VERSION 4.9
 RA NO
 LIBSUFFIX _android
 DIST x86


### PR DESCRIPTION
Ppsspp doesn't actively support non-current NDKs and recent commits broke compile on r15c. So, this brings the buildbot in line with what upstream uses.