### PR TITLE
Add The Powder Toy to the Android recipes

### DIFF
--- a/recipes/android/cores-android-cmake-aarch64
+++ b/recipes/android/cores-android-cmake-aarch64
@@ -1,1 +1,2 @@
 ppsspp libretro-ppsspp-aarch64 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release
+thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-armv7
+++ b/recipes/android/cores-android-cmake-armv7
@@ -1,1 +1,2 @@
 ppsspp libretro-ppsspp-armv7 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_STL=c++_static -DANDROID_ARM_NEON=ON -DCMAKE_BUILD_TYPE=Release
+thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DANDROID_STL=c++_static -DANDROID_ARM_NEON=ON -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-x86
+++ b/recipes/android/cores-android-cmake-x86
@@ -1,1 +1,2 @@
 ppsspp libretro-ppsspp-x86 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release
+thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
This adds The Powder Toy to all 3 LibRetro targets. Android now builds and works fine with the newest changes to the repository.