### PR TITLE
Android jni build system updates

### DIFF
--- a/libretro-config.sh
+++ b/libretro-config.sh
@@ -43,7 +43,7 @@ export BUILD_LIBRETRO_GL=1
 #ANDROID DEFINES
 #================
 
-export TARGET_ABIS="armeabi armeabi-v7a arm64-v8a x86"
+export TARGET_ABIS="armeabi armeabi-v7a arm64-v8a x86 x86_64"
 
 #uncomment to define NDK standalone toolchain for ARM
 #export NDK_ROOT_DIR_ARM = 
@@ -917,4 +917,3 @@ case "$platform" in
 		fi
 		;;
 esac
-

--- a/recipes/android/cores-android-jni.conf
+++ b/recipes/android/cores-android-jni.conf
@@ -1,7 +1,7 @@
 ANDROID_HOME /home/buildbot/tools/android/android-sdk-linux
-NDK_ROOT /home/buildbot/tools/android/android-ndk-r15c/
-ANDROID_NDK /home/buildbot/tools/android/android-ndk-r15c/
-PATH /home/buildbot/tools/android/android-ndk-r15c:/home/buildbot/tools/android/android-sdk-linux/tools
+NDK_ROOT /home/buildbot/tools/android/android-ndk-r16b/
+ANDROID_NDK /home/buildbot/tools/android/android-ndk-r16b/
+PATH /home/buildbot/tools/android/android-ndk-r16b:/home/buildbot/tools/android/android-sdk-linux/tools
 PLATFORM android
 platform android
 MAKE make


### PR DESCRIPTION
Switch to NDK r16b for the jni recipe, add x86_64 support, and refector jni build sequence.