### PR TITLE
ScummVM Fix

### DIFF
--- a/libretro-build-android-mk.sh
+++ b/libretro-build-android-mk.sh
@@ -164,7 +164,8 @@ WANT_CORES=" \
 	xrick \
 	pocketcdg \
 	crocods \
-	puae"
+	puae \
+	scummvm"
 fi
 
 for core in $WANT_CORES; do
@@ -187,6 +188,11 @@ for core in $WANT_CORES; do
 		path="target-libretro/jni"
 		append="_$core"
 	fi
+	
+	if [ $core = "scummvm" ]; then
+		path="backends/platform/libretro/build/jni"
+	fi
+	
 	build_libretro_generic_makefile $core $path $append
    build_libretro_generic_makefile_armv7neon $core $path $append
 done

--- a/recipes/android/cores-android-jni
+++ b/recipes/android/cores-android-jni
@@ -75,7 +75,7 @@ px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES G
 quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC_JNI Makefile jni
 reminiscence libretro-reminiscence https://github.com/libretro/REminiscence.git master YES GENERIC_JNI Makefile jni
 sameboy libretro-sameboy https://github.com/libretro/SameBoy.git buildbot YES GENERIC_JNI Makefile libretro/jni
-scummvm libretro-scummvm https://github.com/webgeek1234/scummvm.git master YES GENERIC_JNI Makefile backends/platform/libretro/build/jni
+scummvm libretro-scummvm https://github.com/libretro/scummvm.git master YES GENERIC_JNI Makefile backends/platform/libretro/build/jni
 snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC_JNI Makefile libretro/jni
 snes9x2002 libretro-snes9x2002 https://github.com/libretro/snes9x2002.git master YES GENERIC_JNI Makefile jni
 snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master YES GENERIC_JNI Makefile jni


### PR DESCRIPTION
I'm currently working on the ScummVM core (adding MIDI support) and I noticed two problems with libretro-super:

- The ScummVM line in the cores-android-jni recipe contains a broken repository link: it should reference 'https://github.com/libretro/scummvm.git', not 'https://github.com/webgeek1234/scummvm.git' (which no longer exists)

-  libretro-build-android-mk.sh omits ScummVM entirely

This pull request just remedies these minor issues.
