### PR TITLE
libretro-buildbot-recipe.sh: Remove old .libretro-core-recipe files.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -605,6 +605,7 @@ while read line; do
 	if [ -f "$DIR/.libretro-core-recipe" ]; then
 		recipe="$(cat "$DIR/.libretro-core-recipe")"
 		if [ "$line" != "$recipe" ]; then
+			rm -f -- "$DIR/.libretro-core-recipe"
 			echo "$line" > "$DIR/.libretro-core-recipe"
 			BUILD="YES"
 		fi


### PR DESCRIPTION
This is probably not needed, but it is probably safer to make sure the old files are removed instead of watching the core rebuild endlessly when its not.