### PR TITLE
recipes: Fix constant rebuilds for thepowderoy.

### DIFF
--- a/recipes/android/cores-android-cmake-aarch64
+++ b/recipes/android/cores-android-cmake-aarch64
@@ -1,2 +1,2 @@
 ppsspp libretro-ppsspp-aarch64 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release
-thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release
+thepowdertoy libretro-thepowdertoy-aarch64 https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-armv7
+++ b/recipes/android/cores-android-cmake-armv7
@@ -1,2 +1,2 @@
 ppsspp libretro-ppsspp-armv7 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_STL=c++_static -DANDROID_ARM_NEON=ON -DANDROID_ARM_MODE=arm -DCMAKE_BUILD_TYPE=Release
-thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DANDROID_STL=c++_static -DANDROID_ARM_NEON=ON -DCMAKE_BUILD_TYPE=Release
+thepowdertoy libretro-thepowdertoy-armv7 https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DANDROID_STL=c++_static -DANDROID_ARM_NEON=ON -DCMAKE_BUILD_TYPE=Release

--- a/recipes/android/cores-android-cmake-x86
+++ b/recipes/android/cores-android-cmake-x86
@@ -1,2 +1,2 @@
 ppsspp libretro-ppsspp-x86 https://github.com/hrydgard/ppsspp.git master YES CMAKE Makefile build -DLIBRETRO=ON -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release
-thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release
+thepowdertoy libretro-thepowdertoy-x86 https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DANDROID_STL=c++_static -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Currently thepowdertoy shares the build directory for three different android builds, aarch64, armv7 and x86. However the recipes for these builds differ and thepowdertoy will constantly rebuild when it finds the recipe file differs with the previous build.

This can be avoid by appending the arch to the build directory and this solution is already used by ppsspp in the same recipes.