### PR TITLE
(Redream) Add "GPL" to the display name

### DIFF
--- a/dist/info/redream_libretro.info
+++ b/dist/info/redream_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Sega - Dreamcast (Redream)"
+display_name = "Sega - Dreamcast (Redream GPL)"
 authors = "inolen"
 supported_extensions = "gdi|chd|cdi"
 corename = "Redream"


### PR DESCRIPTION
This will help clarify that this is the open source version of Redream.

See https://github.com/libretro/libretro-super/issues/867 .