### PR TITLE
Add a safety check to retroarch-release.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@
 /dist/unix/
 /dist/win*/
 /dist/osx*/
+/dist/wiiu
 /log/
+.DS_Store

--- a/retroarch-release.sh
+++ b/retroarch-release.sh
@@ -5,13 +5,40 @@
 PRGNAM=RetroArch
 SRCNAM="$(printf %s $PRGNAM | tr '[:upper:]' '[:lower:]')"
 TMP=${TMP:-/tmp/libretro}
+FORCE=0
+CLEAN=0
+
+for x in $@; do
+	if [ "$x" == "--force" ]; then
+        FORCE=1
+	fi
+	if [ "$x" == "--clean" ]; then
+        CLEAN=1
+	fi
+done
 
 # Exit on errors and unset variables
 set -eu
 
 # Ensure a clean and fully updated repo
-[ -d $SRCNAM ] && rm -rf -- $SRCNAM
-
+if [ -d $SRCNAM ]; then
+    if [ $CLEAN -gt 0 ]; then
+		rm -rf -- $SRCNAM
+	elif [ $FORCE -gt 0 ]; then
+		echo "Using existing state of $SRCNAM. If build fails, use --clean to delete and re-clone."
+	else
+		echo "FATAL: $SRCNAM/ exists."
+		echo ""
+		echo " - To build with existing sources: $0 --force"
+		echo " - To delete existing sources and re-clone: $0 --clean"
+		echo ""
+		echo "WARNING: The --clean option does not preserve forks. That is,"
+		echo "the original libretro/$PRGNAM repository will be cloned, not"
+		echo "your personal fork. To build a release build from a fork,"
+		echo "use --force."
+		exit 1
+	fi
+fi
 ./libretro-fetch.sh $SRCNAM
 
 COMMIT="$(git --work-tree=$SRCNAM --git-dir=$SRCNAM/.git describe --abbrev=0 \


### PR DESCRIPTION
== DETAILS
After running this script and inadvertently nuking my fork, I've
added a safety check so that it doesn't happen to anyone else.

Change summary:
- update the .gitignore to ignore wiiu artifacts and Mac OSX junk files
- add two command-line parameters to `retroarch-release.sh`:

  * `--clean` will execute the legacy behavior of deleting and re-
    cloning `libretro/RetroArch`
  * `--force` will execute the release script using the current
    state of `retroarch/` without re-cloning, although it will still
    do a `git pull` and fetch submodules.

  If neither argument is provided, then the script fails with
  instructions if it detects that the `retroarch/` directory already
  exists.

@twinaphex 