### PR TITLE
player-rules: Replace ./fetch-submodules.sh

### DIFF
--- a/rules.d/player-rules.sh
+++ b/rules.d/player-rules.sh
@@ -4,4 +4,4 @@ register_module player retroarch
 libretro_retroarch_name="RetroArch"
 libretro_retroarch_dir="retroarch"
 libretro_retroarch_git_url="https://github.com/libretro/RetroArch.git"
-libretro_retroarch_post_fetch_cmd="git submodule update --init"
+libretro_retroarch_post_fetch_cmd="git submodule update --init --recursive"

--- a/rules.d/player-rules.sh
+++ b/rules.d/player-rules.sh
@@ -4,4 +4,4 @@ register_module player retroarch
 libretro_retroarch_name="RetroArch"
 libretro_retroarch_dir="retroarch"
 libretro_retroarch_git_url="https://github.com/libretro/RetroArch.git"
-libretro_retroarch_post_fetch_cmd="./fetch-submodules.sh"
+libretro_retroarch_post_fetch_cmd="git submodule update --init"


### PR DESCRIPTION
`./fetch-submodules.sh` no longer exists? Replace it with `git submodule update --init`