### PR TITLE
PSP is having issues with Mu remove it to prevent breaking compiling

### DIFF
--- a/recipes/playstation/psp
+++ b/recipes/playstation/psp
@@ -8,7 +8,6 @@ freeintv libretro-freeintv https://github.com/markwkidd/FreeIntv.git master NO G
 gambatte libretro-gambatte https://github.com/libretro/gambatte-libretro.git master YES GENERIC Makefile .
 mednafen_pce_fast libretro-beetle_pce_fast https://github.com/aliaspider/beetle-pce-fast-libretro.git psp_hw_render YES GENERIC Makefile .
 mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
-mu libretro-mu https://github.com/meepingsnesroms/Mu.git master YES GENERIC Makefile libretroBuildSystem
 njemu_cps2 libretro-njemu https://github.com/aliaspider/NJEMU-libretro.git master YES GENERIC Makefile .
 np2kai libretro-np2kai https://github.com/libretro/NP2kai.git master NO GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .


### PR DESCRIPTION
libretro-common/file/file_path.c:79:23: fatal error: pspkernel.h: No such file or directory

I will come back to this once everything else is working.
That file may be able to be removed.