### PR TITLE
libretro-database: Add MAME 2003-Plus

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -327,6 +327,7 @@ build_libretro_databases() {
 	build_libretro_database "MAME 2000" "rom.crc"
 	build_libretro_database "MAME 2003" "rom.crc"
 	build_libretro_database "MAME 2003 (Midway)" "rom.crc"
+	build_libretro_database "MAME 2003-Plus" "rom.crc"
 	build_libretro_database "MAME 2010" "rom.crc"
 	build_libretro_database "MAME 2014" "rom.crc"
 	build_libretro_database "MAME 2016" "rom.crc"


### PR DESCRIPTION
Proposed by @markwkidd over at https://github.com/libretro/libretro-database/pull/741 .