### PR TITLE
database: Disable GoodTools

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -66,9 +66,9 @@ build_libretro_database() {
 		fi
 
 		#Check if meta goodtools is there
-		if [ -f "${LIBRETRODATABASE_META_DAT_DIR}/goodtools/${1}.dat" ]; then
-			COMMAND+=' "${LIBRETRODATABASE_META_DAT_DIR}/goodtools/${1}.dat"'
-		fi
+		#if [ -f "${LIBRETRODATABASE_META_DAT_DIR}/goodtools/${1}.dat" ]; then
+		#	COMMAND+=' "${LIBRETRODATABASE_META_DAT_DIR}/goodtools/${1}.dat"'
+		#fi
 
 		#Check if meta analog DAT is there
 		if [ -f "${LIBRETRODATABASE_META_DAT_DIR}/analog/${1}.dat" ]; then


### PR DESCRIPTION
This keeps GoodTools from being compiled in with the rest of the databases.

See https://github.com/libretro/libretro-database/issues/757