### PR TITLE
Buildbot: PS2 generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-/libretro-*
-/libretro64-*
+/libretro-*/
+/libretro64-*/
 /retroarch/
 /build-summary.log
 /build-revisions/

--- a/environment/ps2-env.sh
+++ b/environment/ps2-env.sh
@@ -1,7 +1,7 @@
 display_usage() { 
    echo -e "\nSetup a RetroArch PS2 build environment on Debian/Ubuntu" 
    echo -e "\nUsage: [install] [build] [export]\n" 
-   echo -e "It will install the toolchain in /home/buildbot/tools\n"
+   echo -e "It will install the toolchain in ~/tools\n"
    echo -e "Arguments:\n"
    echo -e "install:\n install or re(install) the toolchain"
    echo -e "build:\n update the source tree and build everything"
@@ -10,13 +10,11 @@ display_usage() {
 
 update-profile()
 {
-   echo "export PS2DEV=/home/buildbot/tools/ps2dev" >> ~/.profile
-   source ~/.profile
-
-   echo "export PS2SDK=$PS2DEV/ps2sdk" >> ~/.profile
-   source ~/.profile
-
-   echo "export PATH=$PATH:$PS2DEV/bin:$PS2DEV/ee/bin:$PS2DEV/iop/bin:$PS2DEV/dvp/bin:$PS2SDK/bin" >> ~/.profile
+   echo "" >> ~/.profile
+   echo "#### PS2DEV ####" >> ~/.profile
+   echo "export PS2DEV=~/tools/ps2dev" >> ~/.profile
+   echo "export PS2SDK=\$PS2DEV/ps2sdk" >> ~/.profile
+   echo "export PATH=\$PATH:\$PS2DEV/bin:\$PS2DEV/ee/bin:\$PS2DEV/iop/bin:\$PS2DEV/dvp/bin:\$PS2SDK/bin" >> ~/.profile
    source ~/.profile
 }
 
@@ -127,10 +125,11 @@ fi;
 
 if [ "$1" = "install" ]; then
    # Install needed dependencies
-   sudo apt install build-essential git make p7zip tar wget patch
+   sudo apt install -yqqq build-essential git p7zip tar wget patch libucl-dev
+   sudo apt install -yqqq libucl-dev zlib1g-dev
 
-   if [ ! -d /home/buildbot/tools/ps2dev ]; then
-      mkdir -p /home/buildbot/tools/ps2dev
+   if [ ! -d ~/tools/ps2dev ]; then
+      mkdir -p ~/tools/ps2dev
       # Prepare the lbash
       update-profile
    fi
@@ -148,17 +147,11 @@ if [ "$1" = "install" ]; then
    install-gskit
    install-ps2-packer
 
-
-   if [ ! -d "/home/buildbot/tools" ]; then
-      sudo mkdir -p /home/buildbot
-      sudo ln -s ~/tools /home/buildbot/tools
-   fi;
-
    echo $platform environment ready...
 fi;
 
 if [ "$1" = "build" ]; then
-   if [ -d "/home/buildbot/tools/ps2dev/" ]; then
+   if [ -d "~/tools/ps2dev/" ]; then
       cd ~/libretro/ps2
       git pull
       ./libretro-buildbot-recipe.sh recipes/playstation/ps2

--- a/environment/ps2-env.sh
+++ b/environment/ps2-env.sh
@@ -72,7 +72,7 @@ download-ps2-packer()
    fi
 }
 
-donwload-libretro()
+donwload-libretro-super()
 {
    cd ~
    if [ ! -d ~/libretro/ps2 ]; then
@@ -126,6 +126,17 @@ install-ps2-packer()
    make clean && make && make install
 }
 
+build-libretro-super()
+{
+   if [ ! -d ~/libretro/ps2 ]; then
+      echo You need to donwload first the libretro-super
+   fi
+
+   cd ~/libretro/ps2
+   git fetch && git pull
+   ./libretro-buildbot-recipe.sh recipes/playstation/ps2   
+}
+
 #!/bin/bash
 platform=ps2
 
@@ -156,7 +167,7 @@ if [ "$1" = "install" ]; then
       download-ps2sdk-ports
       download-gskit
       download-ps2-packer
-      donwload-libretro
+      donwload-libretro-super
 
       #install everything
       install-ps2toolchain
@@ -174,9 +185,7 @@ if [ "$1" = "build" ]; then
       echo Error: PS2 toolchain is not installed.
       echo $platform environment not found, run with install again...
    else
-      cd ~/libretro/ps2
-      git pull
-      ./libretro-buildbot-recipe.sh recipes/playstation/ps2   
+      build-libretro-super 
    fi
 fi;
 

--- a/environment/ps2-env.sh
+++ b/environment/ps2-env.sh
@@ -1,0 +1,173 @@
+display_usage() { 
+   echo -e "\nSetup a RetroArch PS2 build environment on Debian/Ubuntu" 
+   echo -e "\nUsage: [install] [build] [export]\n" 
+   echo -e "It will install the toolchain in /home/buildbot/tools\n"
+   echo -e "Arguments:\n"
+   echo -e "install:\n install or re(install) the toolchain"
+   echo -e "build:\n update the source tree and build everything"
+   echo -e "prepare-profile:\n update the bash profile with the needed variables"
+} 
+
+update-profile()
+{
+   echo "export PS2DEV=/home/buildbot/tools/ps2dev" >> ~/.profile
+   source ~/.profile
+
+   echo "export PS2SDK=$PS2DEV/ps2sdk" >> ~/.profile
+   source ~/.profile
+
+   echo "export PATH=$PATH:$PS2DEV/bin:$PS2DEV/ee/bin:$PS2DEV/iop/bin:$PS2DEV/dvp/bin:$PS2SDK/bin" >> ~/.profile
+   source ~/.profile
+}
+
+download-ps2toolchain()
+{
+   # PS2Toolchain
+   cd ~
+   if [ ! -d ~/ps2tools/ps2toolchain ]; then
+      mkdir ~/ps2tools
+      cd ps2tools
+      git clone https://github.com/ps2dev/ps2toolchain.git
+   fi
+}
+
+download-ps2sdk-ports()
+{
+   #PS2SDK-Ports
+   cd ~
+   if [ ! -d ~/ps2tools/ps2sdk-ports ]; then
+      mkdir ~/ps2tools
+      cd ps2tools
+      git clone https://github.com/ps2dev/ps2sdk-ports.git
+   fi
+}
+
+download-gskit()
+{
+   #GSKit
+   cd ~
+   if [ ! -d ~/ps2tools/gskit ]; then
+      mkdir ~/ps2tools
+      cd ps2tools
+      git clone https://github.com/ps2dev/gsKit.git
+   fi
+}
+
+download-ps2-packer()
+{
+   #PS2-Packer
+   cd ~
+   if [ ! -d ~/ps2tools/ps2-packer ]; then
+      mkdir ~/ps2tools
+      cd ps2tools
+      git clone https://github.com/ps2dev/ps2-packer.git
+   fi
+}
+
+donwload-libretro()
+{
+   cd ~
+   if [ ! -d ~/libretro/ps2 ]; then
+      mkdir libretro
+      cd libretro
+      git clone https://github.com/libretro/libretro-super.git ps2
+   fi
+}
+
+install-ps2toolchain()
+{
+   if [ ! -d ~/ps2tools/ps2toolchain ]; then
+      echo You need to donwload first the ps2toolchain
+   fi
+
+   cd ~/ps2tools/ps2toolchain
+   git fetch
+   ./toolchain.sh
+}
+
+install-ps2sdk-ports()
+{
+   if [ ! -d ~/ps2tools/ps2sdk-ports ]; then
+      echo You need to donwload first the ps2sdk-ports
+   fi
+
+   cd ~/ps2tools/ps2sdk-ports
+   git fetch
+   make clean && make && make install
+}
+
+install-gskit()
+{
+   if [ ! -d ~/ps2tools/gskit ]; then
+      echo You need to donwload first the gskit
+   fi
+
+   cd ~/ps2tools/gskit
+   git fetch
+   make clean && make && make install
+}
+
+install-ps2-packer()
+{
+   if [ ! -d ~/ps2tools/ps2-packer ]; then
+      echo You need to donwload first the ps2-packer
+   fi
+
+   cd ~/ps2tools/ps2-packer
+   git fetch
+   make clean && make && make install
+}
+
+#!/bin/bash
+platform=ps2
+
+if [ "$1" = "prepare-profile" ]; then
+   update-profile
+fi;
+
+if [ "$1" = "install" ]; then
+   # Install needed dependencies
+   sudo apt install build-essential git make p7zip tar wget patch
+
+   if [ ! -d /home/buildbot/tools/ps2dev ]; then
+      mkdir -p /home/buildbot/tools/ps2dev
+      # Prepare the lbash
+      update-profile
+   fi
+   
+   #Download everything
+   download-ps2toolchain
+   download-ps2sdk-ports
+   download-gskit
+   download-ps2-packer
+   donwload-libretro
+
+   #install everything
+   install-ps2toolchain
+   install-ps2sdk-ports
+   install-gskit
+   install-ps2-packer
+
+
+   if [ ! -d "/home/buildbot/tools" ]; then
+      sudo mkdir -p /home/buildbot
+      sudo ln -s ~/tools /home/buildbot/tools
+   fi;
+
+   echo $platform environment ready...
+fi;
+
+if [ "$1" = "build" ]; then
+   if [ -d "/home/buildbot/tools/ps2dev/" ]; then
+      cd ~/libretro/ps2
+      git pull
+      ./libretro-buildbot-recipe.sh recipes/playstation/ps2
+   else
+      echo $platform environment not found, run with install again...
+   fi
+fi;
+
+if [ $# -le 0 ]; then 
+   display_usage
+fi
+

--- a/environment/ps2-env.sh
+++ b/environment/ps2-env.sh
@@ -4,7 +4,6 @@ display_usage() {
    echo -e "It will install the toolchain in ~/tools\n"
    echo -e "Arguments:\n"
    echo -e "install:\n install or re(install) the toolchain"
-   echo -e "build:\n update the source tree and build everything"
    echo -e "prepare-profile:\n update the bash profile with the needed variables"
    echo -e "export-variables:\n Export in this bash session the needed variables"
 } 
@@ -72,16 +71,6 @@ download-ps2-packer()
    fi
 }
 
-donwload-libretro-super()
-{
-   cd ~
-   if [ ! -d ~/libretro/ps2 ]; then
-      mkdir libretro
-      cd libretro
-      git clone https://github.com/libretro/libretro-super.git ps2
-   fi
-}
-
 install-ps2toolchain()
 {
    if [ ! -d ~/ps2tools/ps2toolchain ]; then
@@ -126,17 +115,6 @@ install-ps2-packer()
    make clean && make && make install
 }
 
-build-libretro-super()
-{
-   if [ ! -d ~/libretro/ps2 ]; then
-      echo You need to donwload first the libretro-super
-   fi
-
-   cd ~/libretro/ps2
-   git fetch && git pull
-   ./libretro-buildbot-recipe.sh recipes/playstation/ps2   
-}
-
 #!/bin/bash
 platform=ps2
 
@@ -167,7 +145,6 @@ if [ "$1" = "install" ]; then
       download-ps2sdk-ports
       download-gskit
       download-ps2-packer
-      donwload-libretro-super
 
       #install everything
       install-ps2toolchain
@@ -178,15 +155,6 @@ if [ "$1" = "install" ]; then
       echo $platform environment ready...
    fi
    
-fi;
-
-if [ "$1" = "build" ]; then
-   if ! [ -x "$(command -v ee-gcc)" ]; then
-      echo Error: PS2 toolchain is not installed.
-      echo $platform environment not found, run with install again...
-   else
-      build-libretro-super 
-   fi
 fi;
 
 if [ $# -le 0 ]; then 

--- a/libretro-build-ps2.sh
+++ b/libretro-build-ps2.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+# vim: set ts=3 sw=3 noet ft=sh : bash
+
+SCRIPT="${0#./}"
+BASE_DIR="${SCRIPT%/*}"
+WORKDIR="$PWD"
+
+if [ "$BASE_DIR" = "$SCRIPT" ]; then
+	BASE_DIR="$WORKDIR"
+else
+	if [[ "$0" != /* ]]; then
+		# Make the path absolute
+		BASE_DIR="$WORKDIR/$BASE_DIR"
+	fi
+fi
+
+platform=ps2 ${BASE_DIR}/libretro-build.sh $@

--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -1154,6 +1154,37 @@ if [ "${PLATFORM}" = "psp1" ] && [ "${RA}" = "YES" ]; then
 	fi
 fi
 
+if [ "${PLATFORM}" = "ps2" ] && [ "${RA}" = "YES" ]; then
+
+	if [ "${BUILD}" == "YES" -o "${FORCE}" == "YES" -o "${FORCE_RETROARCH_BUILD}" == "YES" -o "${CORES_BUILT}" == "YES" ]; then
+
+		cd dist-scripts
+		rm *.a
+		cp -v $RARCH_DIST_DIR/*.a .
+
+		time sh ./dist-cores.sh ps2 2>&1 | tee -a "$LOGFILE"
+
+		RET=${PIPESTATUS[0]}
+		buildbot_handle_message "$RET" "$ENTRY_ID" "retroarch" "$jobid" "$LOGFILE"
+
+		if [ $RET -eq 0 ]; then
+			touch $TMPDIR/built-frontend
+		fi
+
+		ENTRY_ID=""
+
+		echo "Packaging"
+
+		cd $WORK/$RADIR
+		cp retroarch.cfg retroarch.default.cfg
+
+		mkdir -p pkg/ps2/
+		mkdir -p pkg/ps2/info
+		cp -v $RARCH_DIST_DIR/../info/*.info pkg/ps2/info/
+
+	fi
+fi
+
 if [ "${PLATFORM}" == "libnx" ] && [ "${RA}" == "YES" ]; then
 
 	if [ "${BUILD}" == "YES" -o "${FORCE}" == "YES" -o "${FORCE_RETROARCH_BUILD}" == "YES" -o "${CORES_BUILT}" == "YES" ]; then

--- a/libretro-config.sh
+++ b/libretro-config.sh
@@ -473,6 +473,17 @@ case "$platform" in
 		CXX="psp-g++${BINARY_EXT}"
 		;;
 
+	ps2)
+		DIST_DIR="ps2"
+		FORMAT_EXT=a
+		FORMAT=_ps2
+		FORMAT_COMPILER_TARGET=ps2
+		FORMAT_COMPILER_TARGET_ALT=ps2
+
+		CC="ee-gcc${BINARY_EXT}"
+		CXX="ee-g++${BINARY_EXT}"
+		;;
+
 	ctr)
 		DIST_DIR="ctr"
 		FORMAT_EXT=a

--- a/libretro-super.sh
+++ b/libretro-super.sh
@@ -263,6 +263,12 @@ case "$platform" in
 					FORMAT_COMPILER_TARGET="psp1"
 					DIST_DIR="psp1"
 					;;
+				*ps2*)
+					platform=ps2
+					FORMAT_EXT="a"
+					FORMAT_COMPILER_TARGET="ps2"
+					DIST_DIR="ps2"
+					;;
 				*wii*)
 					platform=wii
 					FORMAT_EXT="a"

--- a/recipes/playstation/ps2
+++ b/recipes/playstation/ps2
@@ -1,0 +1,2 @@
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile .
+quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .

--- a/recipes/playstation/ps2
+++ b/recipes/playstation/ps2
@@ -1,2 +1,2 @@
-2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile .
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
 quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .

--- a/recipes/playstation/ps2.conf
+++ b/recipes/playstation/ps2.conf
@@ -1,11 +1,8 @@
-PATH /home/buildbot/tools/devkitpro/devkitPSP/bin/
-DEVKITPRO /home/buildbot/tools/devkitpro/
-DEVKITPSP /home/buildbot/tools/devkitpro/devkitPSP/
+PS2DEV /home/buildbot/tools/ps2dev
+PS2SDK /home/buildbot/tools/ps2dev/ps2sdk
+PATH /home/buildbot/tools/ps2dev/bin:/home/buildbot/tools/ps2dev/ee/bin:/home/buildbot/tools/ps2dev/iop/bin:/home/buildbot/tools/ps2dev/dvp/bin:/home/buildbot/tools/ps2dev/ps2sdk/bin
 platform ps2
 PLATFORM ps2
-CC ee-gcc
-CXX ee-g++
-MAKE /usr/bin/make
 RA YES
 CORE_JOB YES
 MAKE make

--- a/recipes/playstation/ps2.conf
+++ b/recipes/playstation/ps2.conf
@@ -1,0 +1,11 @@
+PATH /home/buildbot/tools/devkitpro/devkitPSP/bin/
+DEVKITPRO /home/buildbot/tools/devkitpro/
+DEVKITPSP /home/buildbot/tools/devkitpro/devkitPSP/
+platform ps2
+PLATFORM ps2
+CC ee-gcc
+CXX ee-g++
+MAKE /usr/bin/make
+RA YES
+CORE_JOB YES
+MAKE make

--- a/recipes/playstation/ps2.ra
+++ b/recipes/playstation/ps2.ra
@@ -1,0 +1,1 @@
+retroarch retroarch https://github.com/libretro/Retroarch.git PROJECT YES .

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -773,7 +773,7 @@ libretro_fmsx_name="fMSX"
 libretro_fmsx_git_url="https://github.com/libretro/fmsx-libretro.git"
 
 include_core_2048() {
-	register_module core "2048" -ngc -sncps3 -ps3 -wii
+	register_module core "2048" -ngc -sncps3 -ps2 -ps3 -wii
 }
 libretro_2048_git_url="https://github.com/libretro/libretro-2048.git"
 libretro_2048_build_makefile="Makefile.libretro"


### PR DESCRIPTION
##Description##

This PR allows the Buildbot to generate the PS2 binaries.
It contains a script, called `environment/ps2-env.sh, where you can download and install everything that you need to compile the `PS2` apps.

In order to install properly the `PS2 tools` you need to execute 2 steps:

1. Bash Variables
Here either you can create temporal variables for your bash session executing: `./ps2-env.sh export-variables` or you can add the variables to your `~/.profile` file executing: `./ps2-env.sh update-profile`
2. Download, Compile and Install the tools
Basically you need to execute `./ps2-env.sh install`, and then, is time for some 🍵 

Once that everything finishes you can check that everything was installed properly executing `ee-gcc -v`

Finally, in order to make this work, another PR in the `RetroArch` must be merged first.
https://github.com/libretro/RetroArch/pull/7852

Thanks