### PR TITLE
Fix cannonball info to match database extension

### DIFF
--- a/dist/info/cannonball_libretro.info
+++ b/dist/info/cannonball_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Cannonball"
 authors = "Chris White"
-supported_extensions = "88"
+supported_extensions = "game|88"
 corename = "Cannonball"
 categories = "Game"
 systemname = "Outrun Game Engine"

--- a/dist/info/cannonball_libretro.info
+++ b/dist/info/cannonball_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Cannonball"
 authors = "Chris White"
-supported_extensions = "game"
+supported_extensions = "88"
 corename = "Cannonball"
 categories = "Game"
 systemname = "Outrun Game Engine"


### PR DESCRIPTION
The database looks for the epr-10187.88 file but the core info still referenced the older dummy CannonBall.game

https://github.com/libretro/libretro-database/blob/master/dat/Cannonball.dat#L15