### PR TITLE
remove non-existent MAME 2003-Midway db from list

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -326,7 +326,6 @@ build_libretro_databases() {
 	build_libretro_database "MAME" "rom.crc"
 	build_libretro_database "MAME 2000" "rom.crc"
 	build_libretro_database "MAME 2003" "rom.crc"
-	build_libretro_database "MAME 2003 (Midway)" "rom.crc"
 	build_libretro_database "MAME 2003-Plus" "rom.crc"
 	build_libretro_database "MAME 2010" "rom.crc"
 	build_libretro_database "MAME 2014" "rom.crc"


### PR DESCRIPTION
There are two ideas behind this PR:

1. There is no existing MAME 2003-Midway database
2. It seems like there sufficient functionality in the other existing databases to allow a Midway-only user to scan playlists. 1) scan the Midway-only collection with the existing databases, 2) they get a MAME 2003 playlist 2) associate the playlist with the Midway-only version of the core

Also, the Midway core is not being built by the buildbot.