### PR TITLE
add mame2003-plus to ps3 recipes

### DIFF
--- a/recipes/playstation/ps3
+++ b/recipes/playstation/ps3
@@ -22,6 +22,7 @@ hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master NO GENERIC Makefile .
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
+mame2003-plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master YES GENERIC Makefile .
 mame2010 libretro-mame2010 https://github.com/libretro/mame2010-libretro.git master YES GENERIC Makefile .
 mednafen_lynx libretro-beetle_lynx https://github.com/libretro/beetle-lynx-libretro.git master YES GENERIC Makefile .
 mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro.git master YES GENERIC Makefile .


### PR DESCRIPTION
As of now the mame2003 and mame2003-plus Makefiles are synchronized. Because mame2003 builds on PS3 I believe that mame2003-plus will also build.