### PR TITLE
[PS2] Add PicoDrive to PS2 recipes

### DIFF
--- a/recipes/playstation/ps2
+++ b/recipes/playstation/ps2
@@ -1,3 +1,4 @@
 2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
 quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
+picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .


### PR DESCRIPTION
Picodrive is included in the PS2 recipes