### PR TITLE
Remove px68k on windows x64 

### DIFF
--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -87,7 +87,6 @@ ppsspp libretro-ppsspp https://github.com/hrydgard/ppsspp.git master YES GENERIC
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .
 prosystem libretro-prosystem https://github.com/libretro/prosystem-libretro.git master YES GENERIC Makefile .
 puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERIC Makefile .
-px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES GENERIC Makefile.libretro .
 quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
 redream libretro-redream https://github.com/libretro/redream.git master YES GENERIC Makefile deps/libretro
 reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master YES GENERIC Makefile . HAVE_OIT=1


### PR DESCRIPTION
As of last buildbot update, px68k has been failing. @bparker06 said that px68k's cache might need updating. I see the px68k is already in the noccache recipe and guess this was the purpose to not use ccache for this core:
https://github.com/libretro/libretro-super/blob/master/recipes/windows/cores-windows-x64_seh-noccache#L3

`<retrobot> px68k: [status: fail] [recipes/windows/cores-windows-x64_seh-generic] LOG: http://p.0bl.net/86789 Last good build: N/A`