### PR TITLE
Fix theodore core name

### DIFF
--- a/dist/info/theodore_libretro.info
+++ b/dist/info/theodore_libretro.info
@@ -1,7 +1,7 @@
 display_name = "Thomson - MO/TO (Theodore)"
 authors = "T. Lorblanches"
 supported_extensions = "fd|sap|k7|m7|m5|rom"
-corename = "Theodore"
+corename = "theodore"
 database = "Thomson - MOTO"
 manufacturer = "Thomson"
 categories = "Emulator"


### PR DESCRIPTION
The name of the core declared in the info file is not consistent with the one declared by the core. Because of that, the "auto detect core" and "netplay" features are not working correctly.