### PR TITLE
libnx: add caprice32 core

### DIFF
--- a/recipes/nintendo/libnx
+++ b/recipes/nintendo/libnx
@@ -1,6 +1,7 @@
 2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
 4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .
+cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master YES GENERIC Makefile .
 crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master YES GENERIC Makefile .
 dosbox libretro-dosbox https://github.com/libretro/dosbox-libretro.git master YES GENERIC Makefile.libretro .
 desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENERIC Makefile.libretro desmume/src/frontend/libretro


### PR DESCRIPTION
This adds the Caprice32 CPC core to Nintendo Switch builds.

Tested working.

Core-side support for libnx was added here: https://github.com/libretro/libretro-cap32/commit/073c6ecf7d2b0abd794294b8d89627054b071b19