### PR TITLE
db: Add Commodore Plus-4 and VIC-20

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -251,6 +251,8 @@ build_libretro_databases() {
 	build_libretro_database "Coleco - ColecoVision" "rom.crc"
 	build_libretro_database "Commodore - 64" "rom.crc"
 	build_libretro_database "Commodore - Amiga" "rom.crc"
+	build_libretro_database "Commodore - Plus-4" "rom.crc"
+	build_libretro_database "Commodore - VIC-20" "rom.crc"
 	build_libretro_database "Dinothawr" "rom.crc"
 	build_libretro_database "Emerson - Arcadia 2001" "rom.crc"
 	build_libretro_database "Entex - Adventure Vision" "rom.crc"


### PR DESCRIPTION
@zach-morris found that Commodore Plus-4 and VIC-20 were missing:
https://github.com/RobLoach/libretro-thumbnails-check/issues/16