### PR TITLE
Update reminiscence_libretro.info

### DIFF
--- a/dist/info/reminiscence_libretro.info
+++ b/dist/info/reminiscence_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Flashback (REminiscence)"
-authors = "Gregory Montoir"
-supported_extensions = "map"
+authors = "Gregory Montoir|Stuart Carnie"
+supported_extensions = "map|aba|seq|lev"
 corename = "REminiscence"
 categories = "Game"
 database = "Flashback"


### PR DESCRIPTION
- Added Stuart Carnie to the authors section since he helped port the core.
- As evidenced by libretro.cpp, REminiscence's core info file is missing some supported extensions, the missing extensions have now been added.

https://github.com/libretro/REminiscence/blob/01528e5d1e155aa8a1775ee5f89dec8e37c7d0fa/src/libretro.cpp#L114-L128