### PR TITLE
libretro-buildbot-recipe.sh: Switch repos for new urls.

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -612,7 +612,14 @@ while read line; do
 			{ echo "git directory broken, removing $DIR and skipping $NAME."; \
 			rm -rfv -- "$DIR" && continue; }
 
-		if [ -z "${NOCLEAN}" ]; then
+		OLDURL="$(git --work-tree="$DIR" --git-dir="$DIR/.git" config --get remote.origin.url)"
+
+		if [ "$URL" != "$OLDURL" ]; then
+			rm -rvf -- "$DIR"
+			echo "cloning repo $URL..."
+			git clone --depth=1 -b "$GIT_BRANCH" "$URL" "$DIR"
+			BUILD="YES"
+		elif [ -z "${NOCLEAN}" ]; then
 			echo "fetching changes from repo $URL..."
 			git --work-tree="$DIR" --git-dir="$DIR/.git" fetch --depth 1 origin "${GIT_BRANCH}"
 


### PR DESCRIPTION
If the current remote url is different from the new url in the recipe it will now remove the old repo and clone the new url before building.

This issue was exposed by the previous PR (https://github.com/libretro/libretro-super/pull/1024) to change stella to the new upstream repo. I thought this was already implemented, but apparently not...

Also see further discussion in upstream issue https://github.com/stella-emu/stella/issues/377.