### PR TITLE
recipes: Make reicast_wince use its own directory.

### DIFF
--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -85,7 +85,7 @@ puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERI
 px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES GENERIC Makefile.libretro .
 quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
 reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master YES GENERIC Makefile .
-reicast_wince libretro-reicast https://github.com/libretro/reicast-emulator.git fh/wince YES GENERIC Makefile .
+reicast_wince libretro-reicast_wince https://github.com/libretro/reicast-emulator.git fh/wince YES GENERIC Makefile .
 redream libretro-redream https://github.com/libretro/redream.git master YES GENERIC Makefile deps/libretro
 reminiscence libretro-reminiscence https://github.com/libretro/REminiscence.git master YES GENERIC Makefile .
 remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -96,7 +96,7 @@ px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES G
 quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
 redream libretro-redream https://github.com/libretro/redream.git master YES GENERIC Makefile deps/libretro
 reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master YES GENERIC Makefile . HAVE_OIT=1
-reicast_wince libretro-reicast https://github.com/libretro/reicast-emulator.git fh/wince YES GENERIC Makefile . HAVE_OIT=1
+reicast_wince libretro-reicast_wince https://github.com/libretro/reicast-emulator.git fh/wince YES GENERIC Makefile . HAVE_OIT=1
 reminiscence libretro-reminiscence https://github.com/libretro/REminiscence.git master YES GENERIC Makefile .
 remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master YES GENERIC Makefile .
 sameboy libretro-sameboy https://github.com/libretro/SameBoy.git buildbot YES GENERIC Makefile libretro

--- a/recipes/recipes.info
+++ b/recipes/recipes.info
@@ -7,4 +7,8 @@ Ex:
 2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
 bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes_accuracy:profile=accuracy bsnes_balanced:profile=balanced bsnes_performance:profile=performance
 
-Command should usually be GENERIC and REPOTYPE should usually be project. Notable exceptions are PPSSPP and PICODRIVE. Those are submodule repos.
+Command should usually be GENERIC and REPOTYPE should usually be project.
+Notable exceptions are PPSSPP and PICODRIVE. Those are submodule repos.
+
+When adding multiple recipes for the same repo make sure they use different
+directories.

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -93,7 +93,7 @@ puae libretro-uae https://github.com/libretro/libretro-uae.git master YES GENERI
 quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
 redream libretro-redream https://github.com/libretro/redream.git master YES GENERIC Makefile deps/libretro
 reicast libretro-reicast https://github.com/libretro/reicast-emulator.git master YES GENERIC Makefile . HAVE_OIT=1
-reicast_wince libretro-reicast https://github.com/libretro/reicast-emulator.git fh/wince YES GENERIC Makefile . HAVE_OIT=1
+reicast_wince libretro-reicast_wince https://github.com/libretro/reicast-emulator.git fh/wince YES GENERIC Makefile . HAVE_OIT=1
 reminiscence libretro-reminiscence https://github.com/libretro/REminiscence.git master YES GENERIC Makefile .
 remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master YES GENERIC Makefile .
 sameboy libretro-sameboy https://github.com/libretro/SameBoy.git buildbot YES GENERIC Makefile libretro


### PR DESCRIPTION
This avoids constant rebuilds since the buildbot will switch branches and rebuild automatically.