### PR TITLE
Revert "Add a safety check to retroarch-release.sh"

### DIFF
--- a/retroarch-release.sh
+++ b/retroarch-release.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# vim: set ts=3 sw=3 noet ft=sh : bash
-# RetroArch packaging script
+# vim: set ts=3 sw=3 noet ft=sh : sh
+# RetroArch packaging script for release tarballs
 
 PRGNAM=RetroArch
 SRCNAM="$(printf %s $PRGNAM | tr '[:upper:]' '[:lower:]')"
@@ -10,7 +10,15 @@ TMP=${TMP:-/tmp/libretro}
 set -eu
 
 # Ensure a clean and fully updated repo
-[ -d $SRCNAM ] && rm -rf -- $SRCNAM
+if [ -d $SRCNAM ]; then
+	printf %s\\n "WARNING: The $PRGNAM directory already exists." \
+		"Remove the $PRGNAM directory and continue? (y/n)" >&2
+	read -r answer
+	case "$answer" in
+		[yY]|[yY][eE][sS] ) rm -rf -- $SRCNAM ;;
+		* ) printf %s\\n 'Exiting ...'; exit 0 ;;
+	esac
+fi
 
 ./libretro-fetch.sh $SRCNAM
 

--- a/retroarch-release.sh
+++ b/retroarch-release.sh
@@ -5,40 +5,13 @@
 PRGNAM=RetroArch
 SRCNAM="$(printf %s $PRGNAM | tr '[:upper:]' '[:lower:]')"
 TMP=${TMP:-/tmp/libretro}
-FORCE=0
-CLEAN=0
-
-for x in $@; do
-	if [ "$x" == "--force" ]; then
-        FORCE=1
-	fi
-	if [ "$x" == "--clean" ]; then
-        CLEAN=1
-	fi
-done
 
 # Exit on errors and unset variables
 set -eu
 
 # Ensure a clean and fully updated repo
-if [ -d $SRCNAM ]; then
-    if [ $CLEAN -gt 0 ]; then
-		rm -rf -- $SRCNAM
-	elif [ $FORCE -gt 0 ]; then
-		echo "Using existing state of $SRCNAM. If build fails, use --clean to delete and re-clone."
-	else
-		echo "FATAL: $SRCNAM/ exists."
-		echo ""
-		echo " - To build with existing sources: $0 --force"
-		echo " - To delete existing sources and re-clone: $0 --clean"
-		echo ""
-		echo "WARNING: The --clean option does not preserve forks. That is,"
-		echo "the original libretro/$PRGNAM repository will be cloned, not"
-		echo "your personal fork. To build a release build from a fork,"
-		echo "use --force."
-		exit 1
-	fi
-fi
+[ -d $SRCNAM ] && rm -rf -- $SRCNAM
+
 ./libretro-fetch.sh $SRCNAM
 
 COMMIT="$(git --work-tree=$SRCNAM --git-dir=$SRCNAM/.git describe --abbrev=0 \


### PR DESCRIPTION
This reverts commit 9ce305940bfb0f0f63d3148e48f3a3c9de0c4a94.

@twinaphex I don't know why this was merged, but this is clearly wrong and the user didn't understand what this script is for....

In short it breaks making tarballs for RetroArch releases.

Edit: Linking the original PR. https://github.com/libretro/libretro-super/pull/881