### PR TITLE
(Wii) Improve release packaging

### DIFF
--- a/libretro-buildbot-recipe.sh
+++ b/libretro-buildbot-recipe.sh
@@ -1273,13 +1273,27 @@ if [ "${PLATFORM}" == "wii" ] && [ "${RA}" == "YES" ]; then
 		echo 'Packaging'
 
 		cd $WORK/$RADIR
+
 		cp retroarch.cfg retroarch.default.cfg
-		mkdir -p pkg/wii/
-		mkdir -p pkg/wii/cheats
-		mkdir -p pkg/wii/remaps
-		mkdir -p pkg/wii/overlays
-		cp $RARCH_DIST_DIR/../info/*.info pkg/
-		cp -rf media/overlays/wii/* pkg/wii/overlays
+
+		mkdir -p pkg/wii/build/apps/retroarch-wii
+		mkdir -p pkg/wii/build/apps/retroarch-wii/cheats
+		mkdir -p pkg/wii/build/apps/retroarch-wii/remaps
+		mkdir -p pkg/wii/build/apps/retroarch-wii/overlays
+		mkdir -p pkg/wii/build/apps/retroarch-wii/info
+		mkdir -p pkg/wii/build/apps/retroarch-wii/filters/audio
+		mkdir -p pkg/wii/build/apps/retroarch-wii/filters/video
+
+		cp pkg/wii/icon.png pkg/wii/build/apps/retroarch-wii/
+		cp pkg/wii/meta.xml pkg/wii/build/apps/retroarch-wii/
+		cp pkg/wii/.empty pkg/wii/build/apps/retroarch-wii/
+		cp pkg/wii/*.dol pkg/wii/build/apps/retroarch-wii/
+
+		cp $RARCH_DIST_DIR/../info/*.info pkg/wii/build/apps/retroarch-wii/info/
+		cp -rf media/overlays/wii/* pkg/wii/build/apps/retroarch-wii/overlays/
+		cp $WORK/$RADIR/libretro-common/audio/dsp_filters/*.dsp pkg/wii/build/apps/retroarch-wii/filters/audio/
+		cp $WORK/$RADIR/gfx/video_filters/*.filt pkg/wii/build/apps/retroarch-wii/filters/video/
+
 	fi
 fi
 


### PR DESCRIPTION
This PR makes the following improvements to the Wii release packaging:

- The output directory structure has been changed to:

```
apps
`- retroarch-wii
   `- <core files, etc.>
```

This matches existing online guides for using RetroArch on the Wii, and provides new users with a clear indication of where the files should be placed (at present, the release packages are just a loose file dump - a new user has no idea where to copy everything)

- Core info files are now correctly included

- Video/audio filters have been added (video filters in particular can greatly enhance the RetroArch experience on Wii when using an LCD display)