### PR TITLE
(Wii) Add pokemini core

### DIFF
--- a/recipes/nintendo/wii
+++ b/recipes/nintendo/wii
@@ -26,6 +26,7 @@ mu libretro-mu https://github.com/meepingsnesroms/Mu.git master YES GENERIC Make
 nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/libretro/NP2kai.git master NO GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .
+pokemini libretro-pokemini https://github.com/libretro/PokeMini.git master YES GENERIC Makefile .
 prboom libretro-prboom https://github.com/libretro/libretro-prboom.git master YES GENERIC Makefile .
 quasi88 libretro-quasi88 https://github.com/libretro/quasi88-libretro.git master YES GENERIC Makefile .
 quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .


### PR DESCRIPTION
This PR just adds the pokemini core to the Wii recipe.

The core has been tested on real hardware. The only thing that doesn't work is save states - but these will be fixed once [PokeMini PR #22](https://github.com/libretro/PokeMini/pull/22) is merged.