### PR TITLE
(Wii) Fix release asset packaging

### DIFF
--- a/recipes/nintendo/wii.ra
+++ b/recipes/nintendo/wii.ra
@@ -1,3 +1,4 @@
 retroarch retroarch https://github.com/libretro/Retroarch.git PROJECT YES .
 overlays overlays https://github.com/libretro/common-overlays.git ASSETS YES retroarch/media
 libretrodb libretrodb https://github.com/libretro/libretro-database.git ASSETS YES retroarch/media
+assets assets https://github.com/libretro/retroarch-assets.git ASSETS YES retroarch/media


### PR DESCRIPTION
This is an addendum to PR #1059.

I just realised that the RGUI custom theme assets are not being included in the Wii release package. This is because I forgot to add the relevant 'assets' line to `recipes/nintendo/wii.ra` (Oops...)

This PR fixes the issue.