### PR TITLE
(tic80) Fix Windows MSYS2 builds

### DIFF
--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -108,7 +108,7 @@ stella libretro-stella https://github.com/stella-emu/stella.git master YES GENER
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
-tic80 libretro-tic80 https://github.com/RobLoach/TIC-80.git libretro YES CMAKE Makefile builddir -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF
+tic80 libretro-tic80 https://github.com/RobLoach/TIC-80.git libretro YES CMAKE Makefile build -G\"Unix Makefiles\" -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
 uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -107,7 +107,7 @@ squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.g
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DCMAKE_BUILD_TYPE="Release"
-tic80 libretro-tic80 https://github.com/RobLoach/TIC-80.git libretro YES CMAKE Makefile builddir -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF
+tic80 libretro-tic80 https://github.com/RobLoach/TIC-80.git libretro YES CMAKE Makefile build -G\"Unix Makefiles\" -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
 uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1069,7 +1069,7 @@ libretro_tic80_name="TIC-80"
 libretro_tic80_git_url="https://github.com/RobLoach/TIC-80.git"
 libretro_tic80_git_submodules="yes"
 libretro_tic80_build_makefile="Makefile"
-libretro_tic80_build_subdir="src/system/libretro"
+libretro_tic80_build_subdir="build"
 
 include_core_squirreljme() {
 	register_module core "squirreljme"


### PR DESCRIPTION
Renames the build folder to simply `build`

The CMake script is doing some copy tap-dancing, after building, the core appears in `build/bin` but also in `build`. This kludge should be undone and instead an extra line should be added to `core-rules.sh`, to specify the build_products path