### PR TITLE
Enable builds for tempgba

### DIFF
--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -936,11 +936,10 @@ libretro_hatari_git_url="https://github.com/libretro/hatari.git"
 libretro_hatari_build_makefile="Makefile.libretro"
 
 include_core_tempgba() {
-	register_module core "tempgba" none
+	register_module core "tempgba" -psp1
 }
 libretro_tempgba_name="TempGBA"
 libretro_tempgba_git_url="https://github.com/libretro/TempGBA-libretro.git"
-libretro_tempgba_build_rule=none # NEED A BUILD RULE
 
 include_core_gpsp() {
 	register_module core "gpsp" -ngc -sncps3 -ps3 -psp1 -wii


### PR DESCRIPTION
TempGBA builds seem to work fine, the line disabling the rule just needs to be removed.

Before:

```
$ ./libretro-build-psp1.sh tempgba
CC = psp-gcc
CXX = psp-g++
CXX11 = 
STRIP = 
Compiler: CC="psp-gcc" CXX="psp-g++"
psp1
psp1
=== TempGBA
Building tempgba...
Don't have a build rule for tempgba, skipping...
No build actions performed.
$
```

After:

```
$ ./libretro-build-psp1.sh tempgba
CC = psp-gcc
CXX = psp-g++
CXX11 = 
STRIP = 
Compiler: CC="psp-gcc" CXX="psp-g++"
psp1
psp1
=== TempGBA
Building tempgba...
cd "/build/libretro-tempgba"
make platform="psp1" -j7  clean
rm -f libretro.o input.o main.o memory.o sound.o sound_alt.o video_ge.o griffin.o
rm -f tempgba_libretro_psp1.a
make platform="psp1" -j7 CC="psp-gcc" CXX="psp-g++" 
psp-gcc -c -o libretro.o libretro.c -G0 -march=allegrex -mfp32 -mgp32 -mlong32 -mabi=eabi -fomit-frame-pointer -fstrict-aliasing -falign-functions=32 -falign-loops -falign-labels -falign-jumps -Wall -Wundef -Wpointer-arith -Wbad-function-cast -Wwrite-strings -Wsign-compare -D__LIBRETRO__ -DPSP -D_PSP_FW_VERSION=371 -O3 -I. -I/usr/local/pspdev/psp/sdk/include
psp-gcc -c -o input.o input.c -G0 -march=allegrex -mfp32 -mgp32 -mlong32 -mabi=eabi -fomit-frame-pointer -fstrict-aliasing -falign-functions=32 -falign-loops -falign-labels -falign-jumps -Wall -Wundef -Wpointer-arith -Wbad-function-cast -Wwrite-strings -Wsign-compare -D__LIBRETRO__ -DPSP -D_PSP_FW_VERSION=371 -O3 -I. -I/usr/local/pspdev/psp/sdk/include
psp-gcc -c -o main.o main.c -G0 -march=allegrex -mfp32 -mgp32 -mlong32 -mabi=eabi -fomit-frame-pointer -fstrict-aliasing -falign-functions=32 -falign-loops -falign-labels -falign-jumps -Wall -Wundef -Wpointer-arith -Wbad-function-cast -Wwrite-strings -Wsign-compare -D__LIBRETRO__ -DPSP -D_PSP_FW_VERSION=371 -O3 -I. -I/usr/local/pspdev/psp/sdk/include
psp-gcc -c -o memory.o memory.c -G0 -march=allegrex -mfp32 -mgp32 -mlong32 -mabi=eabi -fomit-frame-pointer -fstrict-aliasing -falign-functions=32 -falign-loops -falign-labels -falign-jumps -Wall -Wundef -Wpointer-arith -Wbad-function-cast -Wwrite-strings -Wsign-compare -D__LIBRETRO__ -DPSP -D_PSP_FW_VERSION=371 -O3 -I. -I/usr/local/pspdev/psp/sdk/include
psp-gcc -c -o sound_alt.o sound_alt.c -G0 -march=allegrex -mfp32 -mgp32 -mlong32 -mabi=eabi -fomit-frame-pointer -fstrict-aliasing -falign-functions=32 -falign-loops -falign-labels -falign-jumps -Wall -Wundef -Wpointer-arith -Wbad-function-cast -Wwrite-strings -Wsign-compare -D__LIBRETRO__ -DPSP -D_PSP_FW_VERSION=371 -O3 -I. -I/usr/local/pspdev/psp/sdk/include
psp-ar rcs tempgba_libretro_psp1.a mips_stub.o cpu.o video.o libretro.o input.o main.o memory.o sound_alt.o
cp "tempgba_libretro_psp1.a" "/build/dist/psp1/tempgba_libretro_psp1.a"
1 core(s) successfully processed:
	tempgba
root@6bb8d278e8c5:/build# ls dist/
info/ psp1/ 
$ ls dist/psp1/                        
tempgba_libretro_psp1.a
```

Thanks!