### PR TITLE
TIC-80: Use upstream and don't build demo carts

### DIFF
--- a/recipes/android/cores-android
+++ b/recipes/android/cores-android
@@ -92,7 +92,7 @@ stella libretro-stella https://github.com/stella-emu/stella.git master YES GENER
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC_JNI Makefile jni
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC_JNI Makefile jni
 thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES ANDROID_CMAKE Makefile build
-tic80 libretro-tic80 https://github.com/RobLoach/TIC-80.git libretro YES ANDROID_CMAKE Makefile builddir -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF
+tic80 libretro-tic80 https://github.com/nesbox/TIC-80.git libretro YES ANDROID_CMAKE Makefile builddir -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF -DBUILD_DEMO_CARTS=OFF
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC_JNI Makefile jni
 uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC_JNI Makefile jni
 vba_next libretro-vba-next https://github.com/libretro/vba-next.git master YES GENERIC_JNI Makefile libretro/jni

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -113,7 +113,7 @@ stella libretro-stella https://github.com/stella-emu/stella.git master YES GENER
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DCMAKE_BUILD_TYPE=Release
-tic80 libretro-tic80 https://github.com/RobLoach/TIC-80.git libretro YES CMAKE Makefile builddir -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF
+tic80 libretro-tic80 https://github.com/nesbox/TIC-80.git libretro YES CMAKE Makefile builddir -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF -DBUILD_DEMO_CARTS=OFF
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
 uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -106,7 +106,7 @@ stella libretro-stella https://github.com/stella-emu/stella.git master YES GENER
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DCMAKE_BUILD_TYPE=Release
-tic80 libretro-tic80 https://github.com/RobLoach/TIC-80.git libretro YES CMAKE Makefile builddir -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF
+tic80 libretro-tic80 https://github.com/nesbox/TIC-80.git libretro YES CMAKE Makefile builddir -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF -DBUILD_DEMO_CARTS=OFF
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
 uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -109,7 +109,7 @@ stella libretro-stella https://github.com/stella-emu/stella.git master YES GENER
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
-tic80 libretro-tic80 https://github.com/RobLoach/TIC-80.git libretro YES CMAKE Makefile build -G\"Unix Makefiles\" -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF
+tic80 libretro-tic80 https://github.com/nesbox/TIC-80.git libretro YES CMAKE Makefile build -G\"Unix Makefiles\" -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF -DBUILD_DEMO_CARTS=OFF
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
 uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -108,7 +108,7 @@ squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.g
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DCMAKE_BUILD_TYPE="Release"
-tic80 libretro-tic80 https://github.com/RobLoach/TIC-80.git libretro YES CMAKE Makefile build -G\"Unix Makefiles\" -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF
+tic80 libretro-tic80 https://github.com/nesbox/TIC-80.git libretro YES CMAKE Makefile build -G\"Unix Makefiles\" -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF -DBUILD_DEMO_CARTS=OFF
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
 uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENERIC Makefile .
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1057,7 +1057,7 @@ include_core_tic80() {
 	register_module core "tic80" -theos_ios -ngc -sncps3 -ps3 -psp1 -qnx -wii
 }
 libretro_tic80_name="TIC-80"
-libretro_tic80_git_url="https://github.com/RobLoach/TIC-80.git"
+libretro_tic80_git_url="https://github.com/nesbox/TIC-80.git"
 libretro_tic80_git_submodules="yes"
 libretro_tic80_build_makefile="Makefile"
 libretro_tic80_build_subdir="build"


### PR DESCRIPTION
We can now use the upstream repository:
https://github.com/nesbox/TIC-80

This also disables building the demo carts.