### PR TITLE
Add new vice cores to WiiU

### DIFF
--- a/recipes/nintendo/wiiu
+++ b/recipes/nintendo/wiiu
@@ -62,7 +62,10 @@ gw libretro-gw https://github.com/libretro/gw-libretro.git master YES GENERIC Ma
 fuse libretro-fuse https://github.com/libretro/fuse-libretro.git master YES GENERIC Makefile .
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
 vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
+vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
 vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
-vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xvic
+vice_x64sc libretro-vice_x64sc https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x64sc
+vice_xpet libretro-vice_xpet https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xpet
 vice_xplus4 libretro-vice_xplus4 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xplus4
+vice_xvic libretro-vice_xvic https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=xvic
 x64sdl libretro-x64sdl https://github.com/r-type/sdlvice-libretro.git master YES GENERIC makefile.libretro .


### PR DESCRIPTION
I forgot the WiiU in my last PR to add Vice cores everywhere where x64 was built.

This fixes that. Ready to merge @twinaphex . Thanks!