### PR TITLE
Add m3u as valid extension for Vice cores

### DIFF
--- a/dist/info/vice_x128_libretro.info
+++ b/dist/info/vice_x128_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Commodore - C128 (VICE C128)"
 authors = "VICE Core Team Members"
-supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z"
+supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|m3u"
 corename = "VICE"
 manufacturer = "Commodore"
 categories = "Emulator"

--- a/dist/info/vice_x64_libretro.info
+++ b/dist/info/vice_x64_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Commodore - C64 (VICE C64)"
 authors = "VICE Core Team Members"
-supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z"
+supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|m3u"
 corename = "VICE"
 manufacturer = "Commodore"
 categories = "Emulator"

--- a/dist/info/vice_x64sc_libretro.info
+++ b/dist/info/vice_x64sc_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Commodore - C64 (VICE C64-SC, Accurate)"
 authors = "VICE Core Team Members"
-supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z"
+supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|m3u"
 corename = "VICE"
 manufacturer = "Commodore"
 categories = "Emulator"

--- a/dist/info/vice_xpet_libretro.info
+++ b/dist/info/vice_xpet_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Commodore - PET (VICE PET)"
 authors = "VICE Core Team Members"
-supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z"
+supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|m3u"
 corename = "VICE"
 manufacturer = "Commodore"
 categories = "Emulator"

--- a/dist/info/vice_xplus4_libretro.info
+++ b/dist/info/vice_xplus4_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Commodore - PLUS4 (VICE PLUS4)"
 authors = "VICE Core Team Members"
-supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z"
+supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|m3u"
 corename = "VICE"
 manufacturer = "Commodore"
 categories = "Emulator"

--- a/dist/info/vice_xvic_libretro.info
+++ b/dist/info/vice_xvic_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Commodore - VIC20 (VICE VIC20)"
 authors = "VICE Core Team Members"
-supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|a0|20|60"
+supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|a0|20|60|m3u"
 corename = "VICE"
 manufacturer = "Commodore"
 categories = "Emulator"


### PR DESCRIPTION
m3u was missing. Fixed.

Ready to merge @twinaphex , thanks!
