### PR TITLE
Use official VICE emulator names in core info

### DIFF
--- a/dist/info/vice_x128_libretro.info
+++ b/dist/info/vice_x128_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Commodore - C128 (VICE C128)"
+display_name = "Commodore - C128 (VICE x128)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|m3u"
 corename = "VICE"

--- a/dist/info/vice_x64_libretro.info
+++ b/dist/info/vice_x64_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Commodore - C64 (VICE C64)"
+display_name = "Commodore - C64 (VICE x64, fast)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|m3u"
 corename = "VICE"

--- a/dist/info/vice_x64sc_libretro.info
+++ b/dist/info/vice_x64sc_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Commodore - C64 (VICE C64-SC, Accurate)"
+display_name = "Commodore - C64 (VICE x64sc, accurate)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|m3u"
 corename = "VICE"

--- a/dist/info/vice_xpet_libretro.info
+++ b/dist/info/vice_xpet_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Commodore - PET (VICE PET)"
+display_name = "Commodore - PET (VICE xpet)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|m3u"
 corename = "VICE"

--- a/dist/info/vice_xplus4_libretro.info
+++ b/dist/info/vice_xplus4_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Commodore - PLUS4 (VICE PLUS4)"
+display_name = "Commodore - PLUS4 (VICE xplus4)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|m3u"
 corename = "VICE"

--- a/dist/info/vice_xvic_libretro.info
+++ b/dist/info/vice_xvic_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Commodore - VIC20 (VICE VIC20)"
+display_name = "Commodore - VIC20 (VICE xvic)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64||g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|a0|20|60|m3u"
 corename = "VICE"


### PR DESCRIPTION
The name in info file in parentheses should be the official emulator name. So I changed the VICE core name in parentheses from `(VICE C128)` to `(VICE x128)` etc. I then added the labels `fast` and `accurate` to x64 and x64sc respectively to make the difference more clear to users who have never used VICE.

Ready to merge, @twinaphex , thanks!
