### PR TITLE
Wii: Add recipe for 2048

### DIFF
--- a/recipes/nintendo/wii
+++ b/recipes/nintendo/wii
@@ -1,3 +1,4 @@
+2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .
 cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master YES GENERIC Makefile .


### PR DESCRIPTION
This core appears to work fine. :smiley:

![wii-2048](https://user-images.githubusercontent.com/5890747/65066162-c3299d80-d97b-11e9-9fff-7cd5166845a3.png)
