### PR TITLE
Update fbneo info

### DIFF
--- a/dist/info/fbneo_libretro.info
+++ b/dist/info/fbneo_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Arcade (FinalBurn Neo)"
 authors = "Team FBNeo"
-supported_extensions = "zip|7z"
+supported_extensions = "zip|7z|cue"
 corename = "FinalBurn Neo"
 manufacturer = "Various"
 categories = "Emulator"


### PR DESCRIPTION
With [this commit](https://github.com/libretro/FBNeo/commit/7e36520808dace1b2ddf8e0ca7691e4f5b55df77), FBNeo can now load neo geo cue files if they are in the correctly named folder (neocd), without using the load subsystem menu.