### PR TITLE
Update cores-osx-x64-generic

### DIFF
--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -102,6 +102,7 @@ stella libretro-stella https://github.com/stella-emu/stella.git master YES GENER
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DCMAKE_BUILD_TYPE="Release"
+tic80 libretro-tic80 https://github.com/libretro/TIC-80.git master YES CMAKE Makefile builddir -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF -BUILD_DEMO_CARTS=OFF -DBUILD_LIBRETRO=ON
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro


### PR DESCRIPTION
Add TIC-80 to OSX-x64-generic.  Seems to build just fine using the instructions in the readme here:
https://github.com/nesbox/TIC-80/blob/master/src/system/libretro/README.md