### PR TITLE
Fix typo in CBM-II info file

### DIFF
--- a/dist/info/vice_xcbm2_libretro.info
+++ b/dist/info/vice_xcbm2_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Commodore CBM-II (VICE xcbm2)"
+display_name = "Commodore - CBM-II (VICE xcbm2)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u"
 corename = "VICE"


### PR DESCRIPTION
Just fixed a minor typo (dash missing), thank @sonninnos for notifying me.
