### PR TITLE
Enable theodore core for PSP and PS Vita

### DIFF
--- a/recipes/playstation/psp
+++ b/recipes/playstation/psp
@@ -24,5 +24,5 @@ snes9x2005 libretro-snes9x2005 https://github.com/libretro/snes9x2005.git master
 snes9x2005_plus libretro-snes9x2005_plus https://github.com/libretro/snes9x2005.git master YES GENERIC Makefile . USE_BLARGG_APU=1
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 tempgba libretro-tempgba https://github.com/libretro/TempGBA-libretro.git master YES GENERIC Makefile .
-theodore libretro-theodore https://github.com/Zlika/theodore.git master NO GENERIC Makefile .
+theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .

--- a/recipes/playstation/vita
+++ b/recipes/playstation/vita
@@ -48,7 +48,7 @@ squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.g
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master NO GENERIC Makefile src/libretro
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
-theodore libretro-theodore https://github.com/Zlika/theodore.git master NO GENERIC Makefile .
+theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
 vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
 vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .


### PR DESCRIPTION
The Theodore core should compile under PSP and PS Vita. Let me know if the buildbot fails and I will fix the problem if any.