### PR TITLE
Corrected naming of "bsnes-hd beta"

### DIFF
--- a/dist/info/bsnes_hd_beta_libretro.info
+++ b/dist/info/bsnes_hd_beta_libretro.info
@@ -1,8 +1,8 @@
 # Software Information
-display_name = "Nintendo - SNES / SFC (bsnes HD beta)"
+display_name = "Nintendo - SNES / SFC (bsnes-hd beta)"
 categories = "Emulator"
 authors = "byuu|DerKoun"
-corename = "bsnes HD beta"
+corename = "bsnes-hd beta"
 supported_extensions = "sfc|smc|gb|gbc"
 license = "GPLv3"
 permissions = ""

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -15,7 +15,7 @@ include_core_bsnes_hd_beta() {
 	register_module core "bsnes_hd_beta" -theos_ios -ngc -sncps3 -ps3 -psp1 -qnx -wii
 }
 
-libretro_bsnes_hd_beta_name="bsnes HD"
+libretro_bsnes_hd_beta_name="bsnes-hd beta"
 libretro_bsnes_hd_beta_git_url="https://github.com/DerKoun/bsnes-hd.git"
 libretro_bsnes_hd_beta_build_args="compiler=\"${CXX17}\" target=\"libretro\""
 libretro_bsnes_hd_beta_build_subdir="bsnes"


### PR DESCRIPTION
To avoid causing further work by being picky about the naming I put the changes into this pull request, which should merge easily.
I hope I'm not violating any naming conventions or things like that.