### PR TITLE
fix newlines on windows machines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh eol=lf
+recipes/** eol=lf


### PR DESCRIPTION
Might fix the issues we're having on Windows. Buildbot's msvc2017 (and probably all builds that happen in a windows VM) directory wiped to get the new files.