### PR TITLE
libnx: add atari800 core

### DIFF
--- a/recipes/nintendo/libnx
+++ b/recipes/nintendo/libnx
@@ -1,5 +1,6 @@
 2048 libretro-2048 https://github.com/libretro/libretro-2048.git master YES GENERIC Makefile.libretro .
 4do libretro-4do https://github.com/libretro/4do-libretro.git master YES GENERIC Makefile .
+atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .
 cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master YES GENERIC Makefile .


### PR DESCRIPTION
Ready to merge @twinaphex AFTER https://github.com/libretro/libretro-atari800/pull/41 is merged.