### PR TITLE
(3DS) Re-enable mGBA build recipe

### DIFF
--- a/recipes/nintendo/3ds
+++ b/recipes/nintendo/3ds
@@ -27,7 +27,7 @@ mednafen_ngp libretro-beetle_ngp https://github.com/libretro/beetle-ngp-libretro
 mednafen_pce_fast libretro-beetle_pce_fast https://github.com/aliaspider/beetle-pce-fast-libretro.git psp_hw_render YES GENERIC Makefile .
 mednafen_vb libretro-beetle_vb https://github.com/libretro/beetle-vb-libretro.git master YES GENERIC Makefile .
 mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-libretro.git master YES GENERIC Makefile .
-mgba libretro-mgba https://github.com/libretro/mgba.git master NO GENERIC Makefile.libretro .
+mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
 mu libretro-mu https://github.com/meepingsnesroms/Mu.git master YES GENERIC Makefile libretroBuildSystem
 nestopia libretro-nestopia https://github.com/libretro/nestopia.git master YES GENERIC Makefile libretro
 np2kai libretro-np2kai https://github.com/libretro/NP2kai.git master NO GENERIC Makefile.libretro sdl2


### PR DESCRIPTION
Building the mGBA core can be re-enabled since it builds without issues.

Thanks @justinweiss for the buildfix:
https://github.com/libretro/mgba/commit/00c2bc910b013ad667096d301f731b4481e2b7f6