### PR TITLE
Add dosbox-core to linux-x64

### DIFF
--- a/dist/info/dosbox_core_libretro.info
+++ b/dist/info/dosbox_core_libretro.info
@@ -1,0 +1,48 @@
+# Software Information
+display_name = "DOS (DOSBox-core)"
+authors = "DOSBox Team|radius|Nikos Chantziaras"
+supported_extensions = "exe|com|bat|conf|cue|iso"
+corename = "DOSBox-core"
+categories = "Emulator"
+license = "GPLv2"
+permissions = ""
+display_version = "SVN"
+
+# Hardware Information
+manufacturer = "Microsoft"
+systemname = "DOS"
+systemid = "dos"
+
+# BIOS / Firmware
+firmware_count = 4
+firmware0_desc = "MT32_CONTROL.ROM (MT-32 Control ROM v1.07)"
+firmware0_path = "MT32_CONTROL.ROM"
+firmware0_opt = "true"
+firmware1_desc = "MT32_PCM.ROM (MT-32 PCM ROM)"
+firmware1_path = "MT32_PCM.ROM"
+firmware1_opt = "true"
+firmware2_desc = "CM32L_CONTROL.ROM (CM-32L/LAPC-I Control ROM v1.02)"
+firmware2_path = "CM32L_CONTROL.ROM"
+firmware2_opt = "true"
+firmware3_desc = "CM32L_PCM.ROM (CM-32L/CM-64/LAPC-I PCM ROM)"
+firmware3_path = "CM32L_PCM.ROM"
+firmware3_opt = "true"
+notes = "(!) This core requires libsdl1.2 and libsdl-net1.2.|(!) MT32_CONTROL.ROM (md5): 5626206284b22c2734f3e9efefcd2675|(!) MT32_PCM.ROM (md5): 89e42e386e82e0cacb4a2704a03706ca|(!) CM32L_CONTROL.ROM (md5): bfff32b6144c1d706109accb6e6b1113|(!) CM32L_PCM.ROM (md5): 08cdcfa0ed93e9cb16afa76e6ac5f0a4"
+
+# Libretro Features
+database = "DOS"
+supports_no_game = "true"
+savestate = "false"
+savestate_features = "null"
+libretro_saves = "false"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "false"
+core_options = "true"
+core_options_version = "1.0"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "false"
+is_experimental = "false"
+needs_kbd_mouse_focus = "true"

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -28,6 +28,7 @@ dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YE
 dolphin libretro-dolphin https://github.com/libretro/dolphin.git master YES CMAKE Makefile build -DLIBRETRO=ON -DLIBRETRO_STATIC=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++-7 -DCMAKE_C_COMPILER=gcc-7
 dosbox_svn libretro-dosbox_svn https://github.com/libretro/dosbox-svn libretro YES GENERIC Makefile.libretro libretro WITH_DYNAREC=x86_64
 dosbox_svn_ce libretro-dosbox_svn_ce https://github.com/libretro/dosbox-svn community-patches YES GENERIC Makefile.libretro libretro WITH_DYNAREC=x86_64
+dosbox_core libretro-dosbox_core https://github.com/libretro/dosbox-core libretro YES GENERIC Makefile.libretro libretro CC=gcc-9 CXX=g++-9 WITH_DYNAREC=x86_64
 ecwolf libretro-ecwolf https://github.com/libretro/ecwolf.git master YES GENERIC Makefile src/libretro
 easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
 fbneo libretro-fbneo https://github.com/libretro/FBNeo.git master YES GENERIC Makefile src/burner/libretro USE_X64_DRC=1


### PR DESCRIPTION
Adding https://github.com/libretro/dosbox-core to the Linux x64 recipe for starters. Let's see if it builds first before adding it to more recipes.