### PR TITLE
Remove ffmpeg from libnx recipes, does not link on buildbot

### DIFF
--- a/recipes/nintendo/libnx
+++ b/recipes/nintendo/libnx
@@ -14,7 +14,6 @@ dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master NO
 ecwolf libretro-ecwolf https://github.com/libretro/ecwolf.git master YES GENERIC Makefile src/libretro
 easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
 fceumm libretro-fceumm https://github.com/libretro/libretro-fceumm.git master YES GENERIC Makefile.libretro .
-ffmpeg libretro-ffmpeg https://github.com/libretro/FFmpeg.git master YES GENERIC Makefile libretro
 fmsx libretro-fmsx https://github.com/libretro/fmsx-libretro.git master YES GENERIC Makefile .
 freechaf libretro-freechaf https://github.com/libretro/FreeChaF.git master YES GENERIC Makefile .
 freeintv libretro-freeintv https://github.com/libretro/FreeIntv.git master YES GENERIC Makefile .


### PR DESCRIPTION
AFAIK, this core will never link on buildbot with custom Switch toolchain, because it conflicts with the installed Switch libs used for ppsspp. I think @m4xw is working on a fixed separate ffmpeg core, but this one here should not be built on libnx. @phcoder the toolchain on buildbot has a few extra things not in standard devkitpro toolchain, such as the ppsspp ffmpeg stuff. AFAIK, in this particular case this causes a conflict between symbols at link time. See the reference to ppsspp-specific lib here in the buildbot errors:
``` 
/opt/devkitpro/devkitA64/lib/gcc/aarch64-none-elf/9.2.0/../../../../aarch64-none-elf/bin/ld: /opt/devkitpro/portlibs/switch/lib/libavcodec.a(tiff.o): in function `tiff_uncompress_lzma':
/opt/devkitpro/ppsspp-ffmpeg/libavcodec/tiff.c:396: undefined reference to `lzma_stream_decoder'
/opt/devkitpro/devkitA64/lib/gcc/aarch64-none-elf/9.2.0/../../../../aarch64-none-elf/bin/ld: /opt/devkitpro/ppsspp-ffmpeg/libavcodec/tiff.c:401: undefined reference to `lzma_code'
/opt/devkitpro/devkitA64/lib/gcc/aarch64-none-elf/9.2.0/../../../../aarch64-none-elf/bin/ld: /opt/devkitpro/ppsspp-ffmpeg/libavcodec/tiff.c:402: undefined reference to `lzma_end'
collect2: error: ld returned 1 exit status
```

Ready to merge @twinaphex . 