### PR TITLE
dosbox_core: download windows x64 build from github

### DIFF
--- a/recipes/windows/cores-windows-x64_seh-noccache
+++ b/recipes/windows/cores-windows-x64_seh-noccache
@@ -1,5 +1,5 @@
 citra libretro-citra https://github.com/libretro/citra.git master YES CMAKE Makefile build -G "MSYS Makefiles" -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DENABLE_WEB_SERVICE=0 -DCMAKE_BUILD_TYPE="Release" --target citra_libretro
 citra_canary libretro-citra_canary https://github.com/libretro/citra.git canary YES CMAKE Makefile build -G "MSYS Makefiles" -DENABLE_LIBRETRO=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DENABLE_WEB_SERVICE=0 -DCMAKE_BUILD_TYPE="Release" --target citra_canary_libretro
-dosbox_core libretro-dosbox_core https://github.com/libretro/dosbox-core libretro YES GENERIC Makefile.libretro libretro STATIC_LIBCXX=1 BUNDLED_AUDIO_CODECS=0 BUNDLED_LIBSNDFILE=0 STATIC_PACKAGES=1 EXTRA_PACKAGES="ogg iconv" CMAKE_GENERATOR="MSYS Makefiles" WITH_DYNAREC=x86_64
+dosbox_core libretro-dosbox_core https://github.com/libretro/dosbox-core libretro YES GENERIC Makefile.libretro libretro download_github_windows_x64
 px68k libretro-px68k https://github.com/libretro/px68k-libretro.git master YES GENERIC Makefile.libretro .
 thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -G "MSYS Makefiles" -DCMAKE_BUILD_TYPE="Release"


### PR DESCRIPTION
I tried. Nothing works. The buildbot's msys2 environment is just not
cooperating. So don't try to build the core, just download the github
build instead.