### PR TITLE
saturn: Add .bin to supported file extensions

### DIFF
--- a/dist/info/kronos_libretro.info
+++ b/dist/info/kronos_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Sega - Saturn/ST-V (Kronos)"
 authors = "Guillaume Duhammel|Theo Berkau|Anders Montonen|devmiyax|FCare"
-supported_extensions = "cue|iso|mds|ccd|zip|chd"
+supported_extensions = "bin|ccd|chd|cue|iso|mds|zip"
 corename = "Kronos"
 manufacturer = "Sega"
 categories = "Emulator"

--- a/dist/info/mednafen_saturn_libretro.info
+++ b/dist/info/mednafen_saturn_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Sega - Saturn (Beetle Saturn)"
 authors = "Mednafen Team"
-supported_extensions = "bin|ccd|chd|cue|toc|m3u"
+supported_extensions = "ccd|chd|cue|toc|m3u"
 corename = "Beetle Saturn"
 manufacturer = "Sega"
 categories = "Emulator"

--- a/dist/info/mednafen_saturn_libretro.info
+++ b/dist/info/mednafen_saturn_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Sega - Saturn (Beetle Saturn)"
 authors = "Mednafen Team"
-supported_extensions = "cue|toc|m3u|ccd|chd"
+supported_extensions = "bin|ccd|chd|cue|toc|m3u"
 corename = "Beetle Saturn"
 manufacturer = "Sega"
 categories = "Emulator"

--- a/dist/info/yabasanshiro_libretro.info
+++ b/dist/info/yabasanshiro_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Sega - Saturn (YabaSanshiro)"
 authors = "Guillaume Duhammel|Theo Berkau|Anders Montonen|devmiyax"
-supported_extensions = "cue|iso|mds|ccd|zip|chd"
+supported_extensions = "bin|ccd|chd|cue|iso|mds|zip"
 corename = "YabaSanshiro"
 manufacturer = "Sega"
 categories = "Emulator"

--- a/dist/info/yabause_libretro.info
+++ b/dist/info/yabause_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Sega - Saturn (Yabause)"
 authors = "Guillaume Duhammel|Theo Berkau|Anders Montonen"
-supported_extensions = "cue|iso|mds|ccd|zip|chd"
+supported_extensions = "bin|ccd|chd|cue|iso|mds|zip"
 corename = "Yabause"
 manufacturer = "Sega"
 categories = "Emulator"


### PR DESCRIPTION
This adds `.bin` files to the allowed file extensions for all Saturn cores.

- Kronos
- ~~Mednafen~~
- Yabause
- YabaSanshiro

cc @pkos ... Found this when testing out the new scanner.