### PR TITLE
Added firmware entries to x1 info

### DIFF
--- a/dist/info/x1_libretro.info
+++ b/dist/info/x1_libretro.info
@@ -9,5 +9,14 @@ license = "BSD"
 permissions = ""
 display_version = "0.60"
 supports_no_game = "false"
+
+# BIOS / Firmware
+firmware_count = 2
+firmware0_desc = "Sharp X1 IPL ROM"
+firmware0_path = "xmil/IPLROM.X1"
+firmware0_opt = "true"
+firmware1_desc = "Sharp X1 8x8 Font ROM"
+firmware1_path = "xmil/IPLROM.X1T"
+firmware1_opt = "true"
 notes = "(!) xmil/IPLROM.X1 (md5): eeeea1cd29c6e0e8b094790ae969bfa7|(!) xmil/IPLROM.X1T (md5): 851e4a5936f17d13f8c39a980cf00d77"
 


### PR DESCRIPTION
Previously, the firmware md5s were listed, but not the actual firmware entries. This remedies that.