### PR TITLE
Add manufacturer before core name

### DIFF
--- a/dist/info/fuse_libretro.info
+++ b/dist/info/fuse_libretro.info
@@ -1,4 +1,4 @@
-display_name = "ZX Spectrum (Fuse)"
+display_name = "Sinclair - ZX Spectrum (Fuse)"
 authors = "Team Fuse"
 supported_extensions = "tzx|tap|z80|rzx|scl|trd"
 corename = "Fuse"


### PR DESCRIPTION
That keeps the Sinclair cores (Fuse and 81) altogether in the core list.