### PR TITLE
tic80 : Switch to libretro Makefile for linux x64

### DIFF
--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -125,7 +125,7 @@ stella libretro-stella https://github.com/stella-emu/stella.git master YES GENER
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DCMAKE_BUILD_TYPE=Release
-tic80 libretro-tic80 https://github.com/nesbox/TIC-80.git master YES CMAKE Makefile builddir -DBUILD_PLAYER=OFF -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF -DBUILD_DEMO_CARTS=OFF -DBUILD_LIBRETRO=ON
+tic80 libretro-tic80 https://github.com/nesbox/TIC-80.git master YES GENERIC Makefile build/libretro
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .
 vitaquake2 libretro-vitaquake2 https://github.com/libretro/vitaquake2.git libretro YES GENERIC Makefile .
 vitaquake3 libretro-vitaquake3 https://github.com/libretro/vitaquake3.git libretro YES GENERIC Makefile .


### PR DESCRIPTION
- Following this [commit upstream](https://github.com/nesbox/TIC-80/commit/8d86c0f09a744a6d538eae2dc9a012142f955bad)
- Test first on linux x64