### PR TITLE
(3DS) Enable TGB-Dual recipe

### DIFF
--- a/recipes/nintendo/3ds
+++ b/recipes/nintendo/3ds
@@ -62,7 +62,7 @@ stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.g
 stella libretro-stella https://github.com/stella-emu/stella.git master NO GENERIC Makefile src/libretro
 test libretro-samples https://github.com/libretro/libretro-samples.git master YES GENERIC Makefile tests/test
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
-tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master NO GENERIC Makefile .
+tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DCMAKE_BUILD_TYPE=Release -DLIBRETRO_STATIC=ON -DLIBRETRO_SUFFIX=_ctr
 tic80 libretro-tic80 https://github.com/nesbox/TIC-80.git master YES CMAKE Makefile builddir -DBUILD_PLAYER=OFF -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF -DBUILD_DEMO_CARTS=OFF -DBUILD_LIBRETRO=ON -DDISABLE_NETWORKING=ON -DLIBRETRO_STATIC=ON -DLIBRETRO_SUFFIX=_ctr
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .


### PR DESCRIPTION
Re-enable building TGB-Dual core.

Related PR: https://github.com/libretro/RetroArch/pull/10495