### PR TITLE
Add nib to supported extensions for all vice cores

### DIFF
--- a/dist/info/vice_x128_libretro.info
+++ b/dist/info/vice_x128_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Commodore - C128 (VICE x128)"
 authors = "VICE Core Team Members"
-supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib"
 corename = "VICE"
 manufacturer = "Commodore"
 categories = "Emulator"

--- a/dist/info/vice_x64_libretro.info
+++ b/dist/info/vice_x64_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Commodore - C64 (VICE x64, fast)"
 authors = "VICE Core Team Members"
-supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib"
 corename = "VICE"
 manufacturer = "Commodore"
 categories = "Emulator"

--- a/dist/info/vice_x64sc_libretro.info
+++ b/dist/info/vice_x64sc_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Commodore - C64 (VICE x64sc, accurate)"
 authors = "VICE Core Team Members"
-supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib"
 corename = "VICE"
 manufacturer = "Commodore"
 categories = "Emulator"

--- a/dist/info/vice_xcbm2_libretro.info
+++ b/dist/info/vice_xcbm2_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Commodore - CBM-II (VICE xcbm2)"
 authors = "VICE Core Team Members"
-supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib"
 corename = "VICE"
 manufacturer = "Commodore"
 categories = "Emulator"

--- a/dist/info/vice_xpet_libretro.info
+++ b/dist/info/vice_xpet_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Commodore - PET (VICE xpet)"
 authors = "VICE Core Team Members"
-supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib"
 corename = "VICE"
 manufacturer = "Commodore"
 categories = "Emulator"

--- a/dist/info/vice_xplus4_libretro.info
+++ b/dist/info/vice_xplus4_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Commodore - PLUS4 (VICE xplus4)"
 authors = "VICE Core Team Members"
-supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib"
 corename = "VICE"
 manufacturer = "Commodore"
 categories = "Emulator"

--- a/dist/info/vice_xvic_libretro.info
+++ b/dist/info/vice_xvic_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Commodore - VIC20 (VICE xvic)"
 authors = "VICE Core Team Members"
-supported_extensions = "20|40|60|a0|b0|d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf"
+supported_extensions = "20|40|60|a0|b0|d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib"
 corename = "VICE"
 manufacturer = "Commodore"
 categories = "Emulator"


### PR DESCRIPTION
Support was added in libretro/vice-libretro#232.