### PR TITLE
Add nekop2 to psp and vita

### DIFF
--- a/recipes/playstation/psp
+++ b/recipes/playstation/psp
@@ -17,6 +17,7 @@ mednafen_pce_fast libretro-beetle_pce_fast https://github.com/aliaspider/beetle-
 mgba libretro-mgba https://github.com/libretro/mgba.git master YES GENERIC Makefile.libretro .
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
 mu libretro-mu https://github.com/libretro/Mu.git master YES GENERIC Makefile libretroBuildSystem
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
 njemu_cps2 libretro-njemu https://github.com/aliaspider/NJEMU-libretro.git master YES GENERIC Makefile .
 np2kai libretro-np2kai https://github.com/libretro/NP2kai.git master YES GENERIC Makefile.libretro sdl2
 nxengine libretro-nxengine https://github.com/libretro/nxengine-libretro.git master YES GENERIC Makefile .

--- a/recipes/playstation/vita
+++ b/recipes/playstation/vita
@@ -37,6 +37,7 @@ mednafen_wswan libretro-beetle_wswan https://github.com/libretro/beetle-wswan-li
 mgba libretro-mgba https://github.com/libretro/mgba.git master NO GENERIC Makefile.libretro .
 mrboom libretro-mrboom https://github.com/libretro/mrboom-libretro.git master YES GENERIC Makefile .
 mu libretro-mu https://github.com/libretro/Mu.git master YES GENERIC Makefile libretroBuildSystem
+nekop2 libretro-nekop2 https://github.com/libretro/libretro-meowPC98.git master YES GENERIC Makefile.libretro libretro
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES Makefile . WITH_DYNAREC=arm
 pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .
 neocd libretro-neocd https://github.com/libretro/neocd_libretro.git master YES GENERIC Makefile .


### PR DESCRIPTION
Depends on https://github.com/libretro/libretro-meowPC98/pull/34 which is
merged