### PR TITLE
dosbox_svn_ce: Remove from all recipes

### DIFF
--- a/comptable.py
+++ b/comptable.py
@@ -81,7 +81,6 @@ features_cores = {
     'craft': ['gfxaccel'],
     'dolphin': ['cpu64', 'jit'],
     'dosbox_svn': ['libco'],
-    'dosbox_svn_ce': ['libco'],
     'dosbox_core': ['threads'],
     'ffmpeg': ['threads'],
     'flycast': ['gfxaccel'],

--- a/recipes/android/cores-android
+++ b/recipes/android/cores-android
@@ -18,7 +18,6 @@ desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENE
 desmume2015 libretro-desmume2015 https://github.com/libretro/desmume2015.git master YES GENERIC_JNI Makefile.libretro desmume/src/libretro/jni
 dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC_JNI Makefile jni
 dosbox_svn libretro-dosbox_svn https://github.com/libretro/dosbox-svn libretro YES GENERIC_JNI Makefile.libretro libretro/jni
-dosbox_svn_ce libretro-dosbox_svn_ce https://github.com/libretro/dosbox-svn community-patches YES GENERIC_JNI Makefile.libretro libretro/jni
 ecwolf libretro-ecwolf https://github.com/libretro/ecwolf.git master YES GENERIC_JNI Makefile src/libretro/jni
 fbalpha2012 libretro-fbalpha2012 https://github.com/libretro/fbalpha2012.git master YES GENERIC_JNI makefile.libretro svn-current/trunk/projectfiles/libretro-android/jni
 fbalpha2012_cps1 libretro-fbalpha2012_cps1 https://github.com/libretro/fbalpha2012_cps1.git master YES GENERIC_JNI makefile.libretro projectfiles/libretro-android/jni

--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -23,7 +23,6 @@ dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YE
 dolphin libretro-dolphin https://github.com/libretro/dolphin.git master YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release
 dosbox_core libretro-dosbox_core https://github.com/libretro/dosbox-core libretro YES GENERIC Makefile.libretro libretro download_github_macos
 dosbox_svn libretro-dosbox_svn https://github.com/libretro/dosbox-svn libretro YES GENERIC Makefile.libretro libretro target=x86_64
-dosbox_svn_ce libretro-dosbox_svn_ce https://github.com/libretro/dosbox-svn community-patches YES GENERIC Makefile.libretro libretro target=x86_64
 ecwolf libretro-ecwolf https://github.com/libretro/ecwolf.git master YES GENERIC Makefile src/libretro
 easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
 fbneo libretro-fbneo https://github.com/libretro/FBNeo.git master YES GENERIC Makefile src/burner/libretro

--- a/recipes/linux/cores-linux-arm7neonhf
+++ b/recipes/linux/cores-linux-arm7neonhf
@@ -18,7 +18,6 @@ desmume libretro-desmume https://github.com/libretro/desmume.git master YES GENE
 desmume2015 libretro-desmume2015 https://github.com/libretro/desmume2015.git master YES GENERIC Makefile.libretro desmume
 dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
 dosbox_svn libretro-dosbox_svn https://github.com/libretro/dosbox-svn libretro YES GENERIC Makefile.libretro libretro target=arm WITH_FAKE_SDL=1
-dosbox_svn_ce libretro-dosbox_svn_ce https://github.com/libretro/dosbox-svn community-patches YES GENERIC Makefile.libretro libretro target=arm WITH_FAKE_SDL=1
 easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
 ecwolf libretro-ecwolf https://github.com/libretro/ecwolf.git master YES GENERIC Makefile src/libretro
 fbneo libretro-fbneo https://github.com/libretro/FBNeo.git master YES GENERIC Makefile src/burner/libretro

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -18,7 +18,6 @@ desmume2015 libretro-desmume2015 https://github.com/libretro/desmume2015.git mas
 dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
 dosbox_core libretro-dosbox_core https://github.com/libretro/dosbox-core libretro YES GENERIC Makefile.libretro libretro download_github_armhf
 dosbox_svn libretro-dosbox_svn https://github.com/libretro/dosbox-svn libretro YES GENERIC Makefile.libretro libretro target=arm WITH_FAKE_SDL=1
-dosbox_svn_ce libretro-dosbox_svn_ce https://github.com/libretro/dosbox-svn community-patches YES GENERIC Makefile.libretro libretro target=arm WITH_FAKE_SDL=1
 easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
 ecwolf libretro-ecwolf https://github.com/libretro/ecwolf.git master YES GENERIC Makefile src/libretro
 fbneo libretro-fbneo https://github.com/libretro/FBNeo.git master YES GENERIC Makefile src/burner/libretro

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -27,7 +27,6 @@ dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YE
 dolphin libretro-dolphin https://github.com/libretro/dolphin.git master YES CMAKE Makefile build -DLIBRETRO=ON -DLIBRETRO_STATIC=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++-7 -DCMAKE_C_COMPILER=gcc-7
 dosbox_core libretro-dosbox_core https://github.com/libretro/dosbox-core libretro YES GENERIC Makefile.libretro libretro CC=gcc-9 CXX=g++-9 STATIC_LIBCXX=1 BUNDLED_SDL=1 WITH_DYNAREC=x86_64
 dosbox_svn libretro-dosbox_svn https://github.com/libretro/dosbox-svn libretro YES GENERIC Makefile.libretro libretro WITH_DYNAREC=x86_64
-dosbox_svn_ce libretro-dosbox_svn_ce https://github.com/libretro/dosbox-svn community-patches YES GENERIC Makefile.libretro libretro WITH_DYNAREC=x86_64
 ecwolf libretro-ecwolf https://github.com/libretro/ecwolf.git master YES GENERIC Makefile src/libretro
 easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
 fbneo libretro-fbneo https://github.com/libretro/FBNeo.git master YES GENERIC Makefile src/burner/libretro USE_X64_DRC=1

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -22,7 +22,6 @@ boom3 libretro-boom3 https://github.com/libretro/boom3.git master YES GENERIC Ma
 dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
 dosbox_core libretro-dosbox_core https://github.com/libretro/dosbox-core libretro YES GENERIC Makefile.libretro libretro CC=gcc-9 CXX=g++-9 STATIC_LIBCXX=1 BUNDLED_SDL=1 WITH_DYNAREC=x86
 dosbox_svn libretro-dosbox_svn https://github.com/libretro/dosbox-svn libretro YES GENERIC Makefile.libretro libretro target=x86
-dosbox_svn_ce libretro-dosbox_svn_ce https://github.com/libretro/dosbox-svn community-patches YES GENERIC Makefile.libretro libretro target=x86
 ecwolf libretro-ecwolf https://github.com/libretro/ecwolf.git master YES GENERIC Makefile src/libretro
 easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
 fbneo libretro-fbneo https://github.com/libretro/FBNeo.git master YES GENERIC Makefile src/burner/libretro

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -25,7 +25,6 @@ dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YE
 dolphin libretro-dolphin https://github.com/libretro/dolphin.git master YES CMAKE sln build -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release -G\"Visual Studio 15 2017 Win64\"
 dosbox_core libretro-dosbox_core https://github.com/libretro/dosbox-core libretro YES GENERIC Makefile.libretro libretro download_github_windows_x64
 dosbox_svn libretro-dosbox_svn https://github.com/libretro/dosbox-svn libretro YES GENERIC Makefile.libretro libretro
-dosbox_svn_ce libretro-dosbox_svn_ce https://github.com/libretro/dosbox-svn community-patches YES GENERIC Makefile.libretro libretro
 ecwolf libretro-ecwolf https://github.com/libretro/ecwolf.git master YES GENERIC Makefile src/libretro
 easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
 fbneo libretro-fbneo https://github.com/libretro/FBNeo.git master YES GENERIC Makefile src/burner/libretro USE_X64_DRC=1

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -23,7 +23,6 @@ boom3 libretro-boom3 https://github.com/libretro/boom3.git master YES GENERIC Ma
 dinothawr libretro-dinothawr https://github.com/libretro/Dinothawr.git master YES GENERIC Makefile .
 dosbox_core libretro-dosbox_core https://github.com/libretro/dosbox-core libretro YES GENERIC Makefile.libretro libretro download_github_windows_x86
 dosbox_svn libretro-dosbox_svn https://github.com/libretro/dosbox-svn libretro YES GENERIC Makefile.libretro libretro
-dosbox_svn_ce libretro-dosbox_svn_ce https://github.com/libretro/dosbox-svn community-patches YES GENERIC Makefile.libretro libretro
 ecwolf libretro-ecwolf https://github.com/libretro/ecwolf.git master YES GENERIC Makefile src/libretro
 easyrpg libretro-easyrpg https://github.com/libretro/easyrpg-libretro.git master YES GENERIC Makefile.libretro builds/libretro
 fbneo libretro-fbneo https://github.com/libretro/FBNeo.git master YES GENERIC Makefile src/burner/libretro


### PR DESCRIPTION
This core has no reason to exist anymore. It was offering 3dfx support,
but that has now been merged into dosbox_core. Also, it hasn't been
updated in ages (since its initial commit, actually) and doesn't even
build successfully on most of the recipes its listed in.