### PR TITLE
Updated Beetle Handy core name

### DIFF
--- a/dist/info/mednafen_lynx_libretro.info
+++ b/dist/info/mednafen_lynx_libretro.info
@@ -1,7 +1,7 @@
 display_name = "Atari - Lynx (Beetle Handy)"
 authors = "K. Wilkins|Mednafen Team"
 supported_extensions = "lnx|o"
-corename = "Beetle Lynx"
+corename = "Beetle Handy"
 manufacturer = "Atari"
 categories = "Emulator"
 systemname = "Lynx"


### PR DESCRIPTION
Updated core name to match the update from libretro/beetle-lynx-libretro#37. Should only be merged if that PR is merged.