### PR TITLE
Updated Beetle Lynx display name

### DIFF
--- a/dist/info/mednafen_lynx_libretro.info
+++ b/dist/info/mednafen_lynx_libretro.info
@@ -1,4 +1,4 @@
-display_name = "Atari - Lynx (Beetle Handy)"
+display_name = "Atari - Lynx (Beetle Lynx)"
 authors = "K. Wilkins|Mednafen Team"
 supported_extensions = "lnx|o"
 corename = "Beetle Lynx"


### PR DESCRIPTION
Currently it's displayed as Beetle Handy, which defies the convention for Beetle cores and provides a second name to confuse users.