### PR TITLE
(core info) Add m3u extension to DuckStation

### DIFF
--- a/dist/info/duckstation_libretro.info
+++ b/dist/info/duckstation_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Sony - PlayStation (DuckStation)"
 authors = "stenzek"
-supported_extensions = "cue|bin|img|chd"
+supported_extensions = "cue|bin|img|chd|m3u"
 corename = "DuckStation"
 manufacturer = "Sony"
 categories = "Emulator"


### PR DESCRIPTION
As of https://github.com/stenzek/duckstation/commit/f3df4f91a280dbd9e04d6b6d016ecbf22634bbc2, DuckStation supports loading m3u playlists and the libretro disk control interface.