### PR TITLE
Create core_info_package.yml

### DIFF
--- a/.github/workflows/core_info_package.yml
+++ b/.github/workflows/core_info_package.yml
@@ -1,0 +1,27 @@
+name: libretro Core Info Package
+
+on:
+  # Trigger the workflow on push, but only for the master branch
+  push:
+    branches:
+      - master
+  watch: # this is a hack that lets repo owners trigger a build by starring
+    types: [started]
+    if: github.actor == github.event.repository.owner.login
+
+jobs:
+  Assets:
+    name: Bundle Core Info Files
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - run: cd dist/info && 7z a -mx=9 info.7z *
+    - name: Upload core info bundle
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: dist/info/info.7z
+        tag: Latest
+        asset_name: info.7z
+        overwrite: true

--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -51,7 +51,7 @@ higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro YES GENERIC
 higan_sfc_balanced libretro-nside https://github.com/libretro/nSide.git master NO GENERIC GNUmakefile nSide compiler=clang++ target=libretro binary=library
 kronos libretro-kronos https://github.com/libretro/yabause.git kronos YES GENERIC Makefile yabause/src/libretro
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . download_github_macos
+mame libretro-mame https://github.com/libretro/mame.git master NO GENERIC Makefile.libretro . download_github_macos
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile . PTR64=1
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -51,7 +51,7 @@ higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro YES GENERIC
 higan_sfc_balanced libretro-nside https://github.com/libretro/nSide.git master NO GENERIC GNUmakefile nSide compiler=clang++ target=libretro binary=library
 kronos libretro-kronos https://github.com/libretro/yabause.git kronos YES GENERIC Makefile yabause/src/libretro
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro .
+mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . download_github_macos
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile . PTR64=1
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -60,7 +60,7 @@ ishiiruka libretro-ishiiruka https://github.com/libretro/Ishiiruka.git master YE
 kronos libretro-kronos https://github.com/libretro/yabause.git kronos YES GENERIC Makefile yabause/src/libretro
 neocd libretro-neocd https://github.com/libretro/neocd_libretro.git master YES GENERIC Makefile .
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . PTR64=1
+mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . PTR64=1 download_github_linux_x64
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -52,7 +52,7 @@ higan_sfc_balanced libretro-nside https://github.com/libretro/nSide.git master Y
 kronos libretro-kronos https://github.com/libretro/yabause.git kronos YES GENERIC Makefile yabause/src/libretro
 neocd libretro-neocd https://github.com/libretro/neocd_libretro.git master YES GENERIC Makefile .
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . 
+mame libretro-mame https://github.com/libretro/mame.git master NO GENERIC Makefile.libretro . 
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -57,7 +57,7 @@ ishiiruka libretro-ishiiruka https://github.com/libretro/Ishiiruka.git master YE
 kronos libretro-kronos https://github.com/libretro/yabause.git kronos YES GENERIC Makefile yabause/src/libretro
 neocd libretro-neocd https://github.com/libretro/neocd_libretro.git master YES GENERIC Makefile .
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . download_github_windows_x64
+mame libretro-mame https://github.com/libretro/mame.git master NO GENERIC Makefile.libretro . download_github_windows_x64
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile . CCACHE_DISABLE=1
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master YES GENERIC Makefile . CCACHE_DISABLE=1

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -57,7 +57,7 @@ ishiiruka libretro-ishiiruka https://github.com/libretro/Ishiiruka.git master YE
 kronos libretro-kronos https://github.com/libretro/yabause.git kronos YES GENERIC Makefile yabause/src/libretro
 neocd libretro-neocd https://github.com/libretro/neocd_libretro.git master YES GENERIC Makefile .
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . PTR64=1
+mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . download_github_windows_x64
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile . CCACHE_DISABLE=1
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master YES GENERIC Makefile . CCACHE_DISABLE=1


### PR DESCRIPTION
This recipe bundles the core info files into an 'info' archive that is identical to what can be downloaded from the buildbot server via the online updater. It updates the package on each commit to master, or when any repo owner stars the repo (just a way to trigger manual builds, which github actions can't do for some reason).

Bundles are pushed to a single "Latest" tag, overwriting the previous bundle each time.