### PR TITLE
disable all mame-git recipes temporarily; most didn't work anyway AFAIK

### DIFF
--- a/recipes/android/cores-android-armv7-ndk-mame
+++ b/recipes/android/cores-android-armv7-ndk-mame
@@ -1,1 +1,1 @@
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC makefile . OSD=retro verbose=1 RETRO=1 NOWERROR=1 NOASM=1 gcc=android-arm OS=linux TARGETOS=android-arm CONFIG=libretro NO_USE_MIDI=1 TARGET=mame
+mame libretro-mame https://github.com/libretro/mame.git master NO GENERIC makefile . OSD=retro verbose=1 RETRO=1 NOWERROR=1 NOASM=1 gcc=android-arm OS=linux TARGETOS=android-arm CONFIG=libretro NO_USE_MIDI=1 TARGET=mame

--- a/recipes/apple/cores-ios-arm64-generic
+++ b/recipes/apple/cores-ios-arm64-generic
@@ -37,7 +37,7 @@ handy libretro-handy https://github.com/libretro/libretro-handy.git master YES G
 hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
 kronos libretro-kronos https://github.com/libretro/yabause.git kronos NO GENERIC Makefile yabause/src/libretro
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master NO GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC makefile .
+mame libretro-mame https://github.com/libretro/mame.git master NO GENERIC makefile .
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master NO GENERIC Makefile .
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master NO GENERIC Makefile .

--- a/recipes/apple/cores-ios-generic
+++ b/recipes/apple/cores-ios-generic
@@ -37,7 +37,7 @@ handy libretro-handy https://github.com/libretro/libretro-handy.git master YES G
 hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
 kronos libretro-kronos https://github.com/libretro/yabause.git kronos NO GENERIC Makefile yabause/src/libretro
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC makefile . OSD=retro RETRO=1 NOWERROR=1 NOASM=1 TARGETOS=ios-arm CONFIG=libretro USE_BGFX=0 NO_USE_MIDI=1 VERBOSE=1 verbose=1
+mame libretro-mame https://github.com/libretro/mame.git master NO GENERIC makefile . OSD=retro RETRO=1 NOWERROR=1 NOASM=1 TARGETOS=ios-arm CONFIG=libretro USE_BGFX=0 NO_USE_MIDI=1 VERBOSE=1 verbose=1
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-ios9-generic
+++ b/recipes/apple/cores-ios9-generic
@@ -36,7 +36,7 @@ handy libretro-handy https://github.com/libretro/libretro-handy.git master YES G
 hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
 kronos libretro-kronos https://github.com/libretro/yabause.git kronos NO GENERIC Makefile yabause/src/libretro
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC makefile . OSD=retro RETRO=1 NOWERROR=1 NOASM=1 TARGETOS=ios-arm CONFIG=libretro USE_BGFX=0 NO_USE_MIDI=1 VERBOSE=1 verbose=1
+mame libretro-mame https://github.com/libretro/mame.git master NO GENERIC makefile . OSD=retro RETRO=1 NOWERROR=1 NOASM=1 TARGETOS=ios-arm CONFIG=libretro USE_BGFX=0 NO_USE_MIDI=1 VERBOSE=1 verbose=1
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-tvos-arm64-generic
+++ b/recipes/apple/cores-tvos-arm64-generic
@@ -37,7 +37,7 @@ handy libretro-handy https://github.com/libretro/libretro-handy.git master YES G
 hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC Makefile.libretro .
 kronos libretro-kronos https://github.com/libretro/yabause.git kronos NO GENERIC Makefile yabause/src/libretro
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master NO GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC makefile .
+mame libretro-mame https://github.com/libretro/mame.git master NO GENERIC makefile .
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master NO GENERIC Makefile .
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master NO GENERIC Makefile .

--- a/recipes/linux/cores-linux-arm7neonhf
+++ b/recipes/linux/cores-linux-arm7neonhf
@@ -46,7 +46,7 @@ higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro YES GENERIC
 higan_sfc_balanced libretro-nside https://github.com/libretro/nSide.git master YES GENERIC GNUmakefile nSide compiler=g++ target=libretro binary=library
 kronos libretro-kronos https://github.com/libretro/yabause.git kronos NO GENERIC Makefile yabause/src/libretro
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . PTR64=1
+mame libretro-mame https://github.com/libretro/mame.git master NO GENERIC Makefile.libretro . PTR64=1
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -45,7 +45,7 @@ hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC
 higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro YES GENERIC GNUmakefile higan compiler=g++ target=libretro binary=library
 higan_sfc_balanced libretro-nside https://github.com/libretro/nSide.git master YES GENERIC GNUmakefile nSide compiler=g++ target=libretro binary=library
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . PTR64=1
+mame libretro-mame https://github.com/libretro/mame.git master NO GENERIC Makefile.libretro . PTR64=1
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -60,7 +60,7 @@ ishiiruka libretro-ishiiruka https://github.com/libretro/Ishiiruka.git master YE
 kronos libretro-kronos https://github.com/libretro/yabause.git kronos YES GENERIC Makefile yabause/src/libretro
 neocd libretro-neocd https://github.com/libretro/neocd_libretro.git master YES GENERIC Makefile .
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . PTR64=1 download_github_linux_x64
+mame libretro-mame https://github.com/libretro/mame.git master NO GENERIC Makefile.libretro . PTR64=1 download_github_linux_x64
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -54,7 +54,7 @@ higan_sfc_balanced libretro-nside https://github.com/libretro/nSide.git master Y
 kronos libretro-kronos https://github.com/libretro/yabause.git kronos YES GENERIC Makefile yabause/src/libretro
 neocd libretro-neocd https://github.com/libretro/neocd_libretro.git master YES GENERIC Makefile .
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
-mame libretro-mame https://github.com/libretro/mame.git master YES GENERIC Makefile.libretro . PTR64=0
+mame libretro-mame https://github.com/libretro/mame.git master NO GENERIC Makefile.libretro . PTR64=0
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .
 mame2003 libretro-mame2003 https://github.com/libretro/mame2003-libretro.git master YES GENERIC Makefile .
 mame2003_plus libretro-mame2003-plus https://github.com/libretro/mame2003-plus-libretro.git master YES GENERIC Makefile .


### PR DESCRIPTION
This will keep the buildbot from spinning unnecessarily for hours on end.