### PR TITLE
Add system identifiers to corename in VICE cores

### DIFF
--- a/dist/info/vice_x128_libretro.info
+++ b/dist/info/vice_x128_libretro.info
@@ -1,7 +1,7 @@
 display_name = "Commodore - C128 (VICE x128)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib|nbz"
-corename = "VICE"
+corename = "VICE x128"
 manufacturer = "Commodore"
 categories = "Emulator"
 systemname = "C128"

--- a/dist/info/vice_x64_libretro.info
+++ b/dist/info/vice_x64_libretro.info
@@ -1,7 +1,7 @@
 display_name = "Commodore - C64 (VICE x64, fast)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib|nbz"
-corename = "VICE"
+corename = "VICE x64"
 manufacturer = "Commodore"
 categories = "Emulator"
 systemname = "C64"

--- a/dist/info/vice_x64sc_libretro.info
+++ b/dist/info/vice_x64sc_libretro.info
@@ -1,7 +1,7 @@
 display_name = "Commodore - C64 (VICE x64sc, accurate)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib|nbz"
-corename = "VICE"
+corename = "VICE x64sc"
 manufacturer = "Commodore"
 categories = "Emulator"
 systemname = "C64"

--- a/dist/info/vice_xcbm2_libretro.info
+++ b/dist/info/vice_xcbm2_libretro.info
@@ -1,7 +1,7 @@
 display_name = "Commodore - CBM-II (VICE xcbm2)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib|nbz"
-corename = "VICE"
+corename = "VICE xcbm2"
 manufacturer = "Commodore"
 categories = "Emulator"
 systemname = "CBM-II"

--- a/dist/info/vice_xcbm5x0_libretro.info
+++ b/dist/info/vice_xcbm5x0_libretro.info
@@ -1,7 +1,7 @@
 display_name = "Commodore - CBM-5x0 (VICE xcbm5x0)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib|nbz"
-corename = "VICE"
+corename = "VICE xcbm5x0"
 manufacturer = "Commodore"
 categories = "Emulator"
 systemname = "CBM-5x0"

--- a/dist/info/vice_xpet_libretro.info
+++ b/dist/info/vice_xpet_libretro.info
@@ -1,7 +1,7 @@
 display_name = "Commodore - PET (VICE xpet)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib|nbz"
-corename = "VICE"
+corename = "VICE xpet"
 manufacturer = "Commodore"
 categories = "Emulator"
 systemname = "PET"

--- a/dist/info/vice_xplus4_libretro.info
+++ b/dist/info/vice_xplus4_libretro.info
@@ -1,7 +1,7 @@
 display_name = "Commodore - PLUS/4 (VICE xplus4)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib|nbz"
-corename = "VICE"
+corename = "VICE xplus4"
 manufacturer = "Commodore"
 categories = "Emulator"
 systemname = "PLUS/4"

--- a/dist/info/vice_xscpu64_libretro.info
+++ b/dist/info/vice_xscpu64_libretro.info
@@ -1,7 +1,7 @@
 display_name = "Commodore - C64 SuperCPU (VICE xscpu64)"
 authors = "VICE Core Team Members"
 supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib|nbz"
-corename = "VICE"
+corename = "VICE xscpu64"
 manufacturer = "Commodore"
 categories = "Emulator"
 systemname = "C64 SuperCPU"

--- a/dist/info/vice_xvic_libretro.info
+++ b/dist/info/vice_xvic_libretro.info
@@ -1,7 +1,7 @@
 display_name = "Commodore - VIC-20 (VICE xvic)"
 authors = "VICE Core Team Members"
 supported_extensions = "20|40|60|a0|b0|d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vsf|nib|nbz"
-corename = "VICE"
+corename = "VICE xvic"
 manufacturer = "Commodore"
 categories = "Emulator"
 systemname = "VIC-20"


### PR DESCRIPTION
Cosmetic maybe, but more consistent this way.

Closes #1435 