### PR TITLE
Remove VeMUlator core (Developer's request)

### DIFF
--- a/recipes/android/cores-android
+++ b/recipes/android/cores-android
@@ -108,7 +108,6 @@ uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENE
 vba_next libretro-vba-next https://github.com/libretro/vba-next.git master YES GENERIC_JNI Makefile libretro/jni
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC_JNI Makefile src/libretro/jni
 vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC_JNI Makefile.libretro jni
-vemulator libretro-vemulator https://github.com/MJaoune/vemulator-libretro.git master YES GENERIC_JNI Makefile jni
 vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC_JNI Makefile jni EMUTYPE=x128
 vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC_JNI Makefile jni
 vice_x64sc libretro-vice_x64sc https://github.com/libretro/vice-libretro.git master YES GENERIC_JNI Makefile jni EMUTYPE=x64sc

--- a/recipes/linux/cores-linux-arm7neonhf
+++ b/recipes/linux/cores-linux-arm7neonhf
@@ -113,7 +113,6 @@ uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENE
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
 vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
-vemulator libretro-vemulator https://github.com/MJaoune/vemulator-libretro.git master YES GENERIC Makefile .
 vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
 vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
 vice_x64sc libretro-vice_x64sc https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x64sc

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -111,7 +111,6 @@ uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENE
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
 vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
-vemulator libretro-vemulator https://github.com/MJaoune/vemulator-libretro.git master YES GENERIC Makefile .
 vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
 vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
 vice_x64sc libretro-vice_x64sc https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x64sc

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -136,7 +136,6 @@ uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENE
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
 vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
-vemulator libretro-vemulator https://github.com/MJaoune/vemulator-libretro.git master YES GENERIC Makefile .
 vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
 vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
 vice_x64sc libretro-vice_x64sc https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x64sc

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -128,7 +128,6 @@ uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENE
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
 vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
-vemulator libretro-vemulator https://github.com/MJaoune/vemulator-libretro.git master YES GENERIC Makefile .
 vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
 vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
 vice_x64sc libretro-vice_x64sc https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x64sc

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -130,7 +130,6 @@ uzem libretro-uzem https://github.com/libretro/libretro-uzem.git master YES GENE
 vba_next libretro-vba_next https://github.com/libretro/vba-next.git master YES GENERIC Makefile.libretro .
 vbam libretro-vbam https://github.com/libretro/vbam-libretro.git master YES GENERIC Makefile src/libretro
 vecx libretro-vecx https://github.com/libretro/libretro-vecx.git master YES GENERIC Makefile.libretro .
-vemulator libretro-vemulator https://github.com/MJaoune/vemulator-libretro.git master YES GENERIC Makefile .
 vice_x128 libretro-vice_x128 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x128
 vice_x64 libretro-vice_x64 https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile .
 vice_x64sc libretro-vice_x64sc https://github.com/libretro/vice-libretro.git master YES GENERIC Makefile . EMUTYPE=x64sc

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1127,13 +1127,6 @@ libretro_atari800_name="Atari800"
 libretro_atari800_git_url="https://github.com/libretro/libretro-atari800.git"
 libretro_atari800_build_makefile="Makefile"
 
-include_core_vemulator() {
-	register_module core "vemulator" -theos_ios -ngc -sncps3 -ps3 -psp1 -qnx -wii
-}
-libretro_vemulator_name="VEmulator"
-libretro_vemulator_git_url="https://github.com/MJaoune/vemulator-libretro.git"
-libretro_vemulator_build_makefile="Makefile"
-
 include_core_mu() {
 	register_module core "mu" -theos_ios -ngc -sncps3 -ps3 -psp1 -qnx -wii
 }


### PR DESCRIPTION
I am the main (And only) developer of the SEGA VMU's core named VeMUlator, and I would like the core to be removed from RetroArch for some reasons. The core might also have some game-breaking timer bugs and sound emulation bugs. It also has no practical way to access saves (Memory cards) for other cores such as Dreamcast ones (Which is almost the main reason why people would want to use this core in the first place). It is also not tested enough and might have some RetroArch crashing glitches.

I also have other reasons why I would want it removed.

Please accept,
Thanks in advance.