### PR TITLE
disable kronos on osx

### DIFF
--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -49,7 +49,7 @@ hatari libretro-hatari https://github.com/libretro/hatari.git master YES GENERIC
 hbmame libretro-hbmame https://github.com/libretro/hbmame-libretro.git master YES GENERIC Makefile.libretro .
 higan_sfc libretro-higan https://gitlab.com/higan/higan.git libretro YES GENERIC GNUmakefile higan compiler=clang++ target=libretro binary=library
 higan_sfc_balanced libretro-nside https://github.com/libretro/nSide.git master NO GENERIC GNUmakefile nSide compiler=clang++ target=libretro binary=library
-kronos libretro-kronos https://github.com/libretro/yabause.git kronos YES GENERIC Makefile yabause/src/libretro
+kronos libretro-kronos https://github.com/libretro/yabause.git kronos NO GENERIC Makefile yabause/src/libretro
 lutro libretro-lutro https://github.com/libretro/libretro-lutro master YES GENERIC Makefile .
 mame libretro-mame https://github.com/libretro/mame.git master NO GENERIC Makefile.libretro . download_github_macos
 mame2000 libretro-mame2000 https://github.com/libretro/mame2000-libretro.git master YES GENERIC Makefile .


### PR DESCRIPTION
kronos requires gl 4.2, there is no gl 4.2 afaik on osx