### PR TITLE
Add a check for Dolphin system folder.

### DIFF
--- a/dist/info/dolphin_libretro.info
+++ b/dist/info/dolphin_libretro.info
@@ -32,4 +32,8 @@ disk_control = "false"
 is_experimental = "false"
 
 # BIOS/Firmware
-notes = "(!) You need to have Dolphin Sys folder in system/dolphin-emu/Sys.|(!) See: https://docs.libretro.com/library/dolphin/#setup"
+firmware_count = 1
+firmware0_desc = "Dolphin 'Sys' folder"
+firmware0_path = "dolphin-emu/Sys/codehandler.bin"
+firmware0_opt = "false"
+notes = "(!) You need the Dolphin 'Sys' folder in 'system/dolphin-emu'.|(!) Check https://docs.libretro.com/library/dolphin/#setup for more details."


### PR DESCRIPTION
Check internally for `system/dolphin-emu/Sys/codehandler.bin` (a file that should be here if the folder was set up properly), for the user it will just tell if "Sys" folder is present or not.

It will be useful for troubleshooting, because we'll know directly if the folder is there AND properly set up/not empty.

![image](https://user-images.githubusercontent.com/33353403/97105729-7e635080-16bd-11eb-95e8-6a3e664c832a.png)
