### PR TITLE
Update platform name for Nintendo Switch

### DIFF
--- a/libretro-build-switch.sh
+++ b/libretro-build-switch.sh
@@ -14,4 +14,4 @@ else
 	fi
 fi
 
-platform=switch ${BASE_DIR}/libretro-build.sh $@
+platform=libnx ${BASE_DIR}/libretro-build.sh $@


### PR DESCRIPTION
Most libretro cores do not identify the Switch's platform as "switch." Instead, most use "libnx" to identify the Switch's platform when building.