### PR TITLE
atari800_libretro.info: sync supported_extensions with core

### DIFF
--- a/dist/info/atari800_libretro.info
+++ b/dist/info/atari800_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Atari - 5200 (Atari800)"
 authors = "Petr Stehlik"
-supported_extensions = "xfd|atr|atx|cdm|cas|bin|a52|xex|zip"
+supported_extensions = "xfd|atr|cdm|cas|bin|a52|zip|atx|car|com|xex"
 corename = "Atari800"
 categories = "Emulator"
 license = "GPLv2"


### PR DESCRIPTION
Add car and com extensions which were added in
https://github.com/libretro/libretro-atari800/pull/61
and change the order so it matches valid_extensions from
the libretro-atari800 core