### PR TITLE
Add bms extension to emux_sms_libretro

### DIFF
--- a/dist/info/emux_sms_libretro.info
+++ b/dist/info/emux_sms_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sega - Master System (Emux SMS)"
 authors = "Sebastien Ronsse"
-supported_extensions = "sms|bin|rom"
+supported_extensions = "sms|bms|bin|rom"
 corename = "Emux SMS"
 license = "GPLv2"
 permissions = ""


### PR DESCRIPTION
Based on https://github.com/libretro/libretro-core-info/commit/fdf392037b224a75dfb778ddb157231614481bb3#diff-e56efeb6ada4655cc179c8e2666a4e5f0169c62ccb7182ff98e7eeb1cca6d65e , this change adds the .bms extension to emux_sms_libretro.info.