### PR TITLE
Add SG-1000 .sg files as a valid extension

### DIFF
--- a/dist/info/smsplus_libretro.info
+++ b/dist/info/smsplus_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Sega - MS/GG (SMS Plus GX)"
 authors = "Charles MacDonald|gameblabla"
-supported_extensions = "sms|bin|rom|col|gg"
+supported_extensions = "sms|bin|rom|col|gg|sg"
 corename = "SMS Plus GX"
 manufacturer = "Sega"
 categories = "Emulator"


### PR DESCRIPTION
As of libretro/smsplus-gx@079a03b SMS Plus GX has experimental support for SG-1000 games.
You can however currently only load them when added to a playlist, as .sg files aren't valid according to the info file.