### PR TITLE
Change bsnes repository location

### DIFF
--- a/recipes/android/cores-android
+++ b/recipes/android/cores-android
@@ -4,7 +4,7 @@ opera libretro-opera https://github.com/libretro/opera-libretro.git master YES G
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC_JNI Makefile jni
 bk libretro-bk https://github.com/libretro/bk-emulator.git master YES GENERIC_JNI Makefile.libretro jni
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC_JNI Makefile jni
-bsnes libretro-bsnes https://github.com/libretro/bsnes.git master YES GENERIC_JNI Makefile bsnes/target-libretro/jni
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC_JNI Makefile bsnes/target-libretro/jni
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC_JNI Makefile bsnes/target-libretro/jni
 bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC_JNI Makefile target-libretro/jni | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES GENERIC_JNI Makefile target-libretro/jni | bsnes_mercury_accuracy:profile=accuracy bsnes_mercury_balanced:profile=balanced bsnes_mercury_performance:profile=performance

--- a/recipes/apple/cores-ios-arm64-generic
+++ b/recipes/apple/cores-ios-arm64-generic
@@ -2,7 +2,7 @@
 opera libretro-opera https://github.com/libretro/opera-libretro.git master YES GENERIC Makefile .
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master NO GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
 bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master NO GENERIC Makefile .

--- a/recipes/apple/cores-ios-generic
+++ b/recipes/apple/cores-ios-generic
@@ -2,7 +2,7 @@
 opera libretro-opera https://github.com/libretro/opera-libretro.git master YES GENERIC Makefile .
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
 bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-ios9-generic
+++ b/recipes/apple/cores-ios9-generic
@@ -2,7 +2,7 @@
 opera libretro-opera https://github.com/libretro/opera-libretro.git master YES GENERIC Makefile .
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
 bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -4,7 +4,7 @@ atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git mas
 bk libretro-bk https://github.com/libretro/bk-emulator.git master YES GENERIC Makefile.libretro .
 blastem libretro-blastem https://github.com/libretro/blastem.git libretro YES GENERIC Makefile.libretro .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false platform=macos
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false platform=macos
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false platform=macos
 bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-tvos-arm64-generic
+++ b/recipes/apple/cores-tvos-arm64-generic
@@ -2,7 +2,7 @@
 opera libretro-opera https://github.com/libretro/opera-libretro.git master YES GENERIC Makefile .
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master NO GENERIC Makefile .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
 bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master NO GENERIC Makefile .

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -6,7 +6,7 @@ atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git mas
 bk libretro-bk https://github.com/libretro/bk-emulator.git master YES GENERIC Makefile.libretro .
 blastem libretro-blastem https://github.com/libretro/blastem.git libretro YES GENERIC Makefile.libretro .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes.git master YES GENERIC GNUmakefile bsnes compiler=g++-7 target=libretro binary=library local=false platform=linux
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes compiler=g++-7 target=libretro binary=library local=false platform=linux
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes compiler=g++-7 target=libretro binary=library local=false platform=linux
 bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -5,7 +5,7 @@ opera libretro-opera https://github.com/libretro/opera-libretro.git master YES G
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
 bk libretro-bk https://github.com/libretro/bk-emulator.git master YES GENERIC Makefile.libretro .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false platform=linux
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false platform=linux
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes compiler=g++-7 target=libretro binary=library local=false platform=linux
 bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .

--- a/recipes/nintendo/libnx
+++ b/recipes/nintendo/libnx
@@ -3,6 +3,7 @@ opera libretro-opera https://github.com/libretro/opera-libretro.git master YES G
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
 bk libretro-bk https://github.com/libretro/bk-emulator.git master YES GENERIC Makefile.libretro .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .
 cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -6,7 +6,7 @@ atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git mas
 bk libretro-bk https://github.com/libretro/bk-emulator.git master YES GENERIC Makefile.libretro .
 blastem libretro-blastem https://github.com/libretro/blastem.git libretro YES GENERIC Makefile.libretro .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false platform=windows
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false platform=windows
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false platform=windows
 bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -6,7 +6,7 @@ atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git mas
 bk libretro-bk https://github.com/libretro/bk-emulator.git master YES GENERIC Makefile.libretro .
 blastem libretro-blastem https://github.com/libretro/blastem.git libretro YES GENERIC Makefile.libretro .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes.git master YES GENERIC GNUmakefile bsnes compiler=g++ target=libretro binary=library local=false platform=windows
+bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes compiler=g++ target=libretro binary=library local=false platform=windows
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes compiler=g++ target=libretro binary=library local=false platform=windows
 bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .


### PR DESCRIPTION
This changes it from the old location https://github.com/libretro/bsnes to the new https://github.com/libretro/bsnes-libretro location.