### PR TITLE
Change bsnes2014 repository location

### DIFF
--- a/recipes/android/cores-android
+++ b/recipes/android/cores-android
@@ -6,7 +6,7 @@ bk libretro-bk https://github.com/libretro/bk-emulator.git master YES GENERIC_JN
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC_JNI Makefile jni
 bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC_JNI Makefile bsnes/target-libretro/jni
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC_JNI Makefile bsnes/target-libretro/jni
-bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC_JNI Makefile target-libretro/jni | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
+bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes2014.git libretro YES GENERIC_JNI Makefile target-libretro/jni | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES GENERIC_JNI Makefile target-libretro/jni | bsnes_mercury_accuracy:profile=accuracy bsnes_mercury_balanced:profile=balanced bsnes_mercury_performance:profile=performance
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC_JNI Makefile jni
 daphne libretro-daphne https://github.com/libretro/daphne.git master YES GENERIC_JNI Makefile jni

--- a/recipes/apple/cores-ios-arm64-generic
+++ b/recipes/apple/cores-ios-arm64-generic
@@ -4,7 +4,7 @@ atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git mas
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
 bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
-bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
+bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes2014.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master NO GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master NO GENERIC Makefile . | bsnes_mercury_accuracy:profile=accuracy bsnes_mercury_balanced:profile=balanced bsnes_mercury_performance:profile=performance
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-ios-generic
+++ b/recipes/apple/cores-ios-generic
@@ -4,7 +4,7 @@ atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git mas
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
 bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
-bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
+bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes2014.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES GENERIC Makefile . | bsnes_mercury_accuracy:profile=accuracy bsnes_mercury_balanced:profile=balanced bsnes_mercury_performance:profile=performance
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-ios9-generic
+++ b/recipes/apple/cores-ios9-generic
@@ -4,7 +4,7 @@ atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git mas
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
 bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
-bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
+bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes2014.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES GENERIC Makefile . | bsnes_mercury_accuracy:profile=accuracy bsnes_mercury_balanced:profile=balanced bsnes_mercury_performance:profile=performance
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -6,7 +6,7 @@ blastem libretro-blastem https://github.com/libretro/blastem.git libretro YES GE
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
 bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false platform=macos
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false platform=macos
-bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
+bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes2014.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES GENERIC Makefile . | bsnes_mercury_accuracy:profile=accuracy bsnes_mercury_balanced:profile=balanced bsnes_mercury_performance:profile=performance
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-tvos-arm64-generic
+++ b/recipes/apple/cores-tvos-arm64-generic
@@ -4,7 +4,7 @@ atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git mas
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
 bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false openmp=false
-bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
+bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes2014.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master NO GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master NO GENERIC Makefile . | bsnes_mercury_accuracy:profile=accuracy bsnes_mercury_balanced:profile=balanced bsnes_mercury_performance:profile=performance
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-arm7neonhf
+++ b/recipes/linux/cores-linux-arm7neonhf
@@ -5,7 +5,7 @@ opera libretro-opera https://github.com/libretro/opera-libretro.git master YES G
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
 bk libretro-bk https://github.com/libretro/bk-emulator.git master YES GENERIC Makefile.libretro .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes_accuracy:profile=accuracy bsnes_balanced:profile=balanced bsnes_performance:profile=performance
+bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes2014.git libretro YES GENERIC Makefile . | bsnes_accuracy:profile=accuracy bsnes_balanced:profile=balanced bsnes_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES GENERIC Makefile . | bsnes_mercury_accuracy:profile=accuracy bsnes_mercury_balanced:profile=balanced bsnes_mercury_performance:profile=performance
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -5,7 +5,7 @@ opera libretro-opera https://github.com/libretro/opera-libretro.git master YES G
 atari800 libretro-atari800 https://github.com/libretro/libretro-atari800.git master YES GENERIC Makefile .
 bk libretro-bk https://github.com/libretro/bk-emulator.git master YES GENERIC Makefile.libretro .
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
-bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes_accuracy:profile=accuracy bsnes_balanced:profile=balanced bsnes_performance:profile=performance
+bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes2014.git libretro YES GENERIC Makefile . | bsnes_accuracy:profile=accuracy bsnes_balanced:profile=balanced bsnes_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES GENERIC Makefile . | bsnes_mercury_accuracy:profile=accuracy bsnes_mercury_balanced:profile=balanced bsnes_mercury_performance:profile=performance
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -8,7 +8,7 @@ blastem libretro-blastem https://github.com/libretro/blastem.git libretro YES GE
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
 bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes compiler=g++-7 target=libretro binary=library local=false platform=linux
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes compiler=g++-7 target=libretro binary=library local=false platform=linux
-bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
+bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes2014.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES GENERIC Makefile . | bsnes_mercury_accuracy:profile=accuracy bsnes_mercury_balanced:profile=balanced bsnes_mercury_performance:profile=performance
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -7,7 +7,7 @@ bk libretro-bk https://github.com/libretro/bk-emulator.git master YES GENERIC Ma
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
 bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false platform=linux
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes compiler=g++-7 target=libretro binary=library local=false platform=linux
-bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
+bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes2014.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES GENERIC Makefile . | bsnes_mercury_accuracy:profile=accuracy bsnes_mercury_balanced:profile=balanced bsnes_mercury_performance:profile=performance
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -8,7 +8,7 @@ blastem libretro-blastem https://github.com/libretro/blastem.git libretro YES GE
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
 bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false platform=windows
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes target=libretro binary=library local=false platform=windows
-bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
+bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes2014.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES GENERIC Makefile . | bsnes_mercury_accuracy:profile=accuracy bsnes_mercury_balanced:profile=balanced bsnes_mercury_performance:profile=performance
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -8,7 +8,7 @@ blastem libretro-blastem https://github.com/libretro/blastem.git libretro YES GE
 bluemsx libretro-bluemsx https://github.com/libretro/blueMSX-libretro.git master YES GENERIC Makefile.libretro .
 bsnes libretro-bsnes https://github.com/libretro/bsnes-libretro.git master YES GENERIC GNUmakefile bsnes compiler=g++ target=libretro binary=library local=false platform=windows
 bsnes_hd_beta libretro-bsnes_hd_beta https://github.com/DerKoun/bsnes-hd.git master YES GENERIC GNUmakefile bsnes compiler=g++ target=libretro binary=library local=false platform=windows
-bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes-libretro.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
+bsnes2014 libretro-bsnes2014 https://github.com/libretro/bsnes2014.git libretro YES GENERIC Makefile . | bsnes2014_accuracy:profile=accuracy bsnes2014_balanced:profile=balanced bsnes2014_performance:profile=performance
 bsnes_cplusplus98 libretro-bsnes_cplusplus98 https://github.com/libretro/bsnes-libretro-cplusplus98.git master YES GENERIC Makefile .
 bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.git master YES GENERIC Makefile . | bsnes_mercury_accuracy:profile=accuracy bsnes_mercury_balanced:profile=balanced bsnes_mercury_performance:profile=performance
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -25,24 +25,24 @@ libretro_bsnes_hd_beta_build_products="out"
 include_core_bsnes_accuracy() {
 	register_module core "bsnes_accuracy" -theos_ios -ngc -sncps3 -ps3 -psp1 -qnx -wii
 }
-libretro_bsnes_accuracy_name="bsnes/higan (Accuracy)"
-libretro_bsnes_accuracy_git_url="https://github.com/libretro/bsnes-libretro.git"
+libretro_bsnes_accuracy_name="bsnes/higan 2014 (Accuracy)"
+libretro_bsnes_accuracy_git_url="https://github.com/libretro/bsnes2014.git"
 libretro_bsnes_accuracy_build_args="compiler=\"${CXX11}\" profile=\"accuracy\""
 libretro_bsnes_accuracy_build_products="out"
 
 include_core_bsnes_balanced() {
 	register_module core "bsnes_balanced" -theos_ios -ngc -sncps3 -ps3 -psp1 -qnx -wii
 }
-libretro_bsnes_balanced_name="bsnes/higan (Balanced)"
-libretro_bsnes_balanced_git_url="https://github.com/libretro/bsnes-libretro.git"
+libretro_bsnes_balanced_name="bsnes/higan 2014 (Balanced)"
+libretro_bsnes_balanced_git_url="https://github.com/libretro/bsnes2014.git"
 libretro_bsnes_balanced_build_args="compiler=\"${CXX11}\" profile=\"balanced\""
 libretro_bsnes_balanced_build_products="out"
 
 include_core_bsnes_performance() {
 	register_module core "bsnes_performance" -theos_ios -ngc -sncps3 -ps3 -psp1 -qnx -wii
 }
-libretro_bsnes_performance_name="bsnes/higan (Performance)"
-libretro_bsnes_performance_git_url="https://github.com/libretro/bsnes-libretro.git"
+libretro_bsnes_performance_name="bsnes/higan 2014 (Performance)"
+libretro_bsnes_performance_git_url="https://github.com/libretro/bsnes2014.git"
 libretro_bsnes_performance_build_args="compiler=\"${CXX11}\" profile=\"performance\""
 libretro_bsnes_performance_build_products="out"
 


### PR DESCRIPTION
This changes it from the old location https://github.com/libretro/bsnes-libretro, which is now used for the current bsnes core, to https://github.com/libretro/bsnes2014.