### PR TITLE
Update picodrive_libretro.info (CHD support)

### DIFF
--- a/dist/info/picodrive_libretro.info
+++ b/dist/info/picodrive_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sega - MS/MD/CD/32X (PicoDrive)"
 authors = "notaz|fdave|irixxxx"
-supported_extensions = "bin|gen|smd|md|32x|cue|iso|sms|68k"
+supported_extensions = "bin|gen|smd|md|32x|chd|cue|iso|sms|68k"
 corename = "PicoDrive"
 license = "MAME"
 permissions = "dynarec_optional"


### PR DESCRIPTION
Thanks to irixxxx, the picodrive core now supports CD images in CHD format. This PR updates the core info file accordingly.