### PR TITLE
Enable .pbp support for SwanStation

### DIFF
--- a/dist/info/duckstation_libretro.info
+++ b/dist/info/duckstation_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sony - PlayStation (SwanStation)"
 authors = "stenzek"
-supported_extensions = "cue|bin|img|chd|m3u"
+supported_extensions = "cue|bin|img|chd|pbp|m3u"
 corename = "SwanStation"
 categories = "Emulator"
 license = "GPLv3"


### PR DESCRIPTION
Support was implemented for it as of https://github.com/libretro/duckstation/commit/46ff2b553ddf2de81df472d443a4bd012fe69ce3