### PR TITLE
Add SameDuck info file

### DIFF
--- a/dist/info/sameduck_libretro.info
+++ b/dist/info/sameduck_libretro.info
@@ -1,0 +1,22 @@
+# Software Information
+display_name = "Mega Duck / Cougar Boy (SameDuck)"
+authors = "LIJI32"
+supported_extensions = "bin"
+corename = "SameDuck"
+display_version = "git"
+categories = "Emulator"
+license = "MIT"
+permissions = ""
+
+# Hardware Information
+manufacturer = "Welback Holdings"
+systemname = "Mega Duck"
+systemid = "mega_duck"
+
+# Libretro Features
+supports_no_game = "false"
+
+# Firmware / BIOS
+firmware_count = 0
+
+description = "An adaptation of SameBoy to play Mega Duck games."


### PR DESCRIPTION
The core works, it just needs to be hooked up for the buildbot. This should take one task off the list, though I'm sure @hunterk will want to spice up the description at some point. Since this core is based on SameBoy, it should be compatible with every target that one is, except due to the lack of bioses it should be easier to compile for Windows systems.