### PR TITLE
Update duckstation_libretro.info

### DIFF
--- a/dist/info/duckstation_libretro.info
+++ b/dist/info/duckstation_libretro.info
@@ -1,10 +1,10 @@
 # Software Information
 display_name = "Sony - PlayStation (DuckStation)"
 authors = "stenzek"
-supported_extensions = "cue|bin|img|chd|pbp|m3u"
+supported_extensions = "exe|psexe|cue|bin|img|iso|chd|pbp|ecm|mds|psf|m3u"
 corename = "DuckStation"
 categories = "Emulator"
-license = "GPLv3"
+license = "Non-commercial"
 permissions = ""
 
 # Hardware Information
@@ -37,4 +37,4 @@ firmware2_path = "scph5502.bin"
 firmware2_opt = "true"
 notes = "(!) scph5500.bin (md5): 8dd7d5296a650fac7319bce665a6a53c|(!) scph5501.bin (md5): 490f666e1afb15b7362b406ed1cea246|(!) scph5502.bin (md5): 32736f17079d0b2b7024407c39bd3050| This core also supports No-Intro BIOS images."
 
-description = "DuckStation is a port of the PlayStation 1 (aka PSX) emulator focusing on playability, speed, and long-term maintainability ported to libretro. Accuracy is not the main focus of the emulator, but the goal is to be as accurate as possible while maintaining performance suitable for low-end devices. 'Hack' options are discouraged, the default configuration should support all playable games with only some of the enhancements having compatibility issues. A 'BIOS' ROM image is required to start the emulator and to play games. You can use an image from any hardware version or region, although mismatching game regions and BIOS regions may have compatibility issues. A ROM image is not provided with the emulator for legal reasons, you should dump this from your own console using Caetla or other means. DuckStation includes hardware rendering (OpenGL, Vulkan and D3D11), upscaling and 24-bit color and a 64-bit dynarec."
+description = "DuckStation is a PlayStation 1 (aka PSX) emulator focusing on playability, speed, graphical enhancements, and long-term maintainability. A 'BIOS' ROM image is required to start the emulator and to play games. Features include hardware rendering (OpenGL, Vulkan and D3D11), upscaling, 24-bit color, and a dynamic recompiler (x86-64, ARMv7, AArch64)."


### PR DESCRIPTION
Updates supported image formats, license, and description.

A range of BIOSes are supported (all revisions, PS2 and PS3 BIOS), but I'm not sure it makes sense to include them in here.