### PR TITLE
PCSX2: Add m3u as a supported extension

### DIFF
--- a/dist/info/pcsx2_libretro.info
+++ b/dist/info/pcsx2_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sony - PlayStation 2 (PCSX2)"
 authors = "PCSX2 Team"
-supported_extensions = "elf|iso|ciso|chd|cso|cue|bin|mdf|nrg|dump|gz|img"
+supported_extensions = "elf|iso|ciso|chd|cso|cue|bin|mdf|nrg|dump|gz|img|m3u"
 corename = "PCSX2"
 license = "GPL"
 permissions = ""


### PR DESCRIPTION
Support for m3u playlists was added in libretro/pcsx2#6