### PR TITLE
(Core Info) Fix supported file extensions for beetle-pce and beetle-pce-fast

### DIFF
--- a/dist/info/mednafen_pce_fast_libretro.info
+++ b/dist/info/mednafen_pce_fast_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "NEC - PC Engine / CD (Beetle PCE FAST)"
 authors = "Mednafen Team"
-supported_extensions = "pce|cue|ccd|iso|img|bin|chd"
+supported_extensions = "pce|cue|ccd|chd|toc|m3u"
 corename = "Beetle PCE Fast"
 license = "GPLv2"
 permissions = ""

--- a/dist/info/mednafen_pce_libretro.info
+++ b/dist/info/mednafen_pce_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "NEC - PC Engine / SuperGrafx / CD (Beetle PCE)"
 authors = "Mednafen Team"
-supported_extensions = "pce|cue|ccd|iso|img|bin|chd"
+supported_extensions = "pce|sgx|cue|ccd|chd|toc|m3u"
 corename = "Beetle PCE"
 license = "GPLv2"
 permissions = ""


### PR DESCRIPTION
At present, the info files for the `beetle-pce` and `beetle-pce-fast` cores contain incorrect 'supported file extension' lists. This PR fixes the issue.