### PR TITLE
moonlight: Add Moonlight core .info file

### DIFF
--- a/dist/info/moonlight_libretro.info
+++ b/dist/info/moonlight_libretro.info
@@ -1,0 +1,34 @@
+# Software Information
+display_name = "Moonlight"
+authors = "Rock88"
+supported_extensions = ""
+corename = "Moonlight"
+categories = "Game engine"
+license = "GPLv2+"
+permissions = ""
+display_version = "Git"
+
+# Hardware Information
+manufacturer = "NVIDIA"
+systemname = "Moonlight"
+systemid = "moonlight"
+
+# Libretro Information
+database = "Moonlight"
+supports_no_game = "true"
+savestate = "false"
+savestate_features = "null"
+cheats = "false"
+input_descriptors = "false"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "true"
+core_options_version = "1.0"
+load_subsystem = "false"
+hw_render = "true"
+required_hw_api = "OpenGL Core >= 4.2"
+needs_fullpath = "true"
+disk_control = "false"
+is_experimental = "true"
+
+description = "A port of the NVIDIA streaming client Moonlight. Currently only tested using Lakka running on Nintendo Switch."


### PR DESCRIPTION
Brought to light by @plaidman over in https://github.com/libretro/libretro-core-info/pull/40 to bring in @rock88's [moonlight-libretro](https://github.com/rock88/moonlight-libretro)'s .info file.