### PR TITLE
Add missing 68k/sgd extensions for Genesis cores

### DIFF
--- a/dist/info/blastem_libretro.info
+++ b/dist/info/blastem_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sega - Mega Drive - Genesis (BlastEm)"
 authors = "Mike Pavone"
-supported_extensions = "md|bin|smd|gen"
+supported_extensions = "md|bin|smd|gen|68k|sgd"
 corename = "BlastEm"
 license = "GPLv3"
 permissions = ""

--- a/dist/info/genesis_plus_gx_libretro.info
+++ b/dist/info/genesis_plus_gx_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sega - MS/GG/MD/CD (Genesis Plus GX)"
 authors = "Charles McDonald|Eke-Eke"
-supported_extensions = "mdx|md|smd|gen|bin|cue|iso|sms|bms|gg|sg|68k|chd|m3u"
+supported_extensions = "mdx|md|smd|gen|bin|cue|iso|sms|bms|gg|sg|68k|sgd|chd|m3u"
 corename = "Genesis Plus GX"
 categories = "Emulator"
 license = "Non-commercial"

--- a/dist/info/genesis_plus_gx_wide_libretro.info
+++ b/dist/info/genesis_plus_gx_wide_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sega - MS/GG/MD/CD (Genesis Plus GX Wide)"
 authors = "Charles McDonald|Eke-Eke|heyjoeway"
-supported_extensions = "mdx|md|smd|gen|bin|cue|iso|sms|bms|gg|sg|68k|chd|m3u"
+supported_extensions = "mdx|md|smd|gen|bin|cue|iso|sms|bms|gg|sg|68k|sgd|chd|m3u"
 corename = "Genesis Plus GX Wide"
 categories = "Emulator"
 license = "Non-commercial"

--- a/dist/info/picodrive_libretro.info
+++ b/dist/info/picodrive_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sega - MS/MD/CD/32X (PicoDrive)"
 authors = "notaz|fdave|irixxxx"
-supported_extensions = "bin|gen|smd|md|32x|chd|cue|iso|sms|68k|m3u"
+supported_extensions = "bin|gen|smd|md|32x|chd|cue|iso|sms|68k|sgd|m3u"
 corename = "PicoDrive"
 license = "MAME"
 permissions = "dynarec_optional"


### PR DESCRIPTION
These extensions are used by games in the "SEGA Mega Drive and Genesis Classics" collection on Steam, which is one of the only easily accessible legal sources of roms. Format-wise, they're identical to any other Genesis extension.