### PR TITLE
Update flycast_libretro.info

### DIFF
--- a/dist/info/flycast_libretro.info
+++ b/dist/info/flycast_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sega - Dreamcast/NAOMI (Flycast)"
 authors = "flyinghead"
-supported_extensions = "chd|cdi|iso|elf|bin|cue|gdi|lst|zip|dat|7z|m3u"
+supported_extensions = "chd|cdi|elf|bin|cue|gdi|lst|zip|dat|7z|m3u"
 corename = "Flycast"
 license = "GPLv2"
 permissions = ""


### PR DESCRIPTION
Flycast can't run .iso files.

Related: https://github.com/libretro/flycast/pull/1093 and https://github.com/libretro/docs/pull/649