### PR TITLE
Add chd to supported extensions for Play!

### DIFF
--- a/dist/info/play_libretro.info
+++ b/dist/info/play_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sony - PlayStation 2 (Play!)"
 authors = "Jean-Philip Desjardins"
-supported_extensions = "iso|isz|cso|bin|elf"
+supported_extensions = "iso|isz|cso|bin|elf|chd"
 corename = "Play!"
 license = "MIT"
 permissions = "dynarec"


### PR DESCRIPTION
Currently only DVDs are supported, not CDs, but I did personally verify they work fine in the core.