### PR TITLE
remove duplicate keys from core info files

### DIFF
--- a/dist/info/mednafen_psx_libretro.info
+++ b/dist/info/mednafen_psx_libretro.info
@@ -27,7 +27,6 @@ memory_descriptors = "true"
 libretro_saves = "true"
 core_options = "true"
 load_subsystem = "false"
-hw_render = "false"
 
 # Firmware / BIOS
 firmware_count = 3

--- a/dist/info/mednafen_saturn_libretro.info
+++ b/dist/info/mednafen_saturn_libretro.info
@@ -27,7 +27,6 @@ memory_descriptors = "true"
 libretro_saves = "true"
 core_options = "true"
 load_subsystem = "false"
-hw_render = "false"
 
 # Firmware / BIOS
 firmware_count = 4

--- a/dist/info/mednafen_snes_libretro.info
+++ b/dist/info/mednafen_snes_libretro.info
@@ -27,7 +27,6 @@ memory_descriptors = "false"
 libretro_saves = "true"
 core_options = "false"
 load_subsystem = "false"
-hw_render = "false"
 is_experimental = true
 
 description = "An older fork of Mednafen's original SNES emulator, which is itself based on an old fork of bsnes circa v059, this core does not have any compelling uses as compared with the other SNES cores that are available. It is not as fast as Snes9x nor as accurate as later bsnes forks or Mesen-S, and most users would be better off trying one of those cores instead. This core only exists for completionist's sake."

--- a/dist/info/mednafen_supergrafx_libretro.info
+++ b/dist/info/mednafen_supergrafx_libretro.info
@@ -27,7 +27,6 @@ memory_descriptors = "true"
 libretro_saves = "true"
 core_options = "true"
 load_subsystem = "false"
-hw_render = "false"
 
 # Firmware / BIOS
 firmware_count = 4

--- a/dist/info/mrboom_libretro.info
+++ b/dist/info/mrboom_libretro.info
@@ -1,7 +1,6 @@
 # Software Information
 display_name = "Mr.Boom (Bomberman)"
 authors = "Remdy"
-supported_extensions = ""
 corename = "Mr.Boom"
 categories = "Game"
 license = "MIT"

--- a/dist/info/vice_x128_libretro.info
+++ b/dist/info/vice_x128_libretro.info
@@ -36,5 +36,3 @@ firmware4_desc = "vice/JiffyDOS_1581.bin (JiffyDOS 1581 drive BIOS)"
 firmware4_path = "vice/JiffyDOS_1581.bin"
 firmware4_opt = "true"
 notes = "(!) JiffyDOS_C128.bin (md5): cbbd1bbcb5e4fd8046b6030ab71fc021|(!) JiffyDOS_C64.bin (md5): be09394f0576cf81fa8bacf634daf9a2|(!) JiffyDOS_1541-II.bin (md5): 1b1e985ea5325a1f46eb7fd9681707bf|(!) JiffyDOS_1571_repl310654.bin (md5): 41c6cc528e9515ffd0ed9b180f8467c0|(!) JiffyDOS_1581.bin (md5): 20b6885c6dc2d42c38754a365b043d71"
-
-description = "The VICE x128 Commodore 64 emulator, isolated and ported to libretro. This core features a complete emulation of the internal MMU (Memory Management Unit), 80 column VDC screen, fast IEC bust emulation, 2 HMz mode, Z80 emulation plus all the features of the other VICE C64 emulation."

--- a/dist/info/vice_x64_libretro.info
+++ b/dist/info/vice_x64_libretro.info
@@ -33,5 +33,3 @@ firmware3_desc = "vice/JiffyDOS_1581.bin (JiffyDOS 1581 drive BIOS)"
 firmware3_path = "vice/JiffyDOS_1581.bin"
 firmware3_opt = "true"
 notes = "(!) JiffyDOS_C64.bin (md5): be09394f0576cf81fa8bacf634daf9a2|(!) JiffyDOS_1541-II.bin (md5): 1b1e985ea5325a1f46eb7fd9681707bf|(!) JiffyDOS_1571_repl310654.bin (md5): 41c6cc528e9515ffd0ed9b180f8467c0|(!) JiffyDOS_1581.bin (md5): 20b6885c6dc2d42c38754a365b043d71"
-
-description = "The VICE x64 (fast) Commodore 64 emulator, isolated and ported to libretro. This core features a fairly complete emulation of the VIC-II video chip, with all sprites, registers and video modes emulated in a fully cycle-accurate manner. However, the 'x64sc' core's VIC-II emulation is both cycle-based and pixel-accurate, making it a better choice for devices powerful enough to run it. Both cores include options to switch between the original 'fastSID' sound chip emulation and the slower but much more accurate 'reSID' module."

--- a/dist/info/vice_x64sc_libretro.info
+++ b/dist/info/vice_x64sc_libretro.info
@@ -33,5 +33,3 @@ firmware3_desc = "vice/JiffyDOS_1581.bin (JiffyDOS 1581 drive BIOS)"
 firmware3_path = "vice/JiffyDOS_1581.bin"
 firmware3_opt = "true"
 notes = "(!) JiffyDOS_C64.bin (md5): be09394f0576cf81fa8bacf634daf9a2|(!) JiffyDOS_1541-II.bin (md5): 1b1e985ea5325a1f46eb7fd9681707bf|(!) JiffyDOS_1571_repl310654.bin (md5): 41c6cc528e9515ffd0ed9b180f8467c0|(!) JiffyDOS_1581.bin (md5): 20b6885c6dc2d42c38754a365b043d71"
-
-description = "The VICE x64sc (accurate) Commodore 64 emulator, isolated and ported to libretro. This core features a cycle-based and pixel-accurate emulation of the VIC-II video chip. In contrast, the 'x64' core's VIC-II emulation is faster but less accurate, making it a better choice for devices that are not powerful enough to run this more accurate core. Both cores include options to switch between the original 'fastSID' sound chip emulation and the slower but much more accurate 'reSID' module."

--- a/dist/info/vice_xcbm2_libretro.info
+++ b/dist/info/vice_xcbm2_libretro.info
@@ -17,5 +17,3 @@ systemid = "commodore_cbm2"
 # Libretro Features
 database = "Commodore - CBM-II"
 supports_no_game = "true"
-
-description = "The VICE xCBM-II emulator, isolated and ported to libretro. This core emulates several types of CBM-II models that were marketed under different names in the USA and Europe, including B128 and B256, and CBM 610, CBM 620, CBM 710 and CBM 720, respectively."

--- a/dist/info/vice_xcbm5x0_libretro.info
+++ b/dist/info/vice_xcbm5x0_libretro.info
@@ -17,5 +17,3 @@ systemid = "commodore_cbm5x0"
 # Libretro Features
 database = "Commodore - CBM-5x0"
 supports_no_game = "true"
-
-description = "The VICE xcbm5x0 emulator, isolated and ported to libretro. This core provides experimental emulation for the C510 model (also known as P500) of CBM-II, which is the 'little brother' of the C600/700 machines. It runs at roughly 1 MHz and use a VIC-II chip instead of the CRTC."

--- a/dist/info/vice_xpet_libretro.info
+++ b/dist/info/vice_xpet_libretro.info
@@ -17,5 +17,3 @@ systemid = "commodore_pet"
 # Libretro Features
 database = "Commodore - PET"
 supports_no_game = "true"
-
-description = "The VICE PET emulator, isolated and ported to libretro. This core emulates the 2001, 3032, 4032, 8032, 8096, 8296 and SuperPET (MicroMainFrame 9000) models, covering the whole series. Both the 40- and 80-column CRTC video chips are emulated (from the 4032 onward), but a few of the features that are not very important for average applications are not implemented yet, such as numbers of rasterlines per char and lines per screen."

--- a/dist/info/vice_xplus4_libretro.info
+++ b/dist/info/vice_xplus4_libretro.info
@@ -17,5 +17,3 @@ systemid = "commodore_plus4"
 # Libretro Features
 database = "Commodore - PLUS-4"
 supports_no_game = "true"
-
-description = "The VICE Plus/4 emulator, isolated and ported to libretro. This core provides experimental emulation for the bsuiness-focused Plus/4 model, the name for which refers to its built-in four-application ROM resident office suite (word processor, database, spreadsheet and graphing). Internally, the Plus/4 has the same basic architecture as the Commodore 16 and 116 models and can run software designed for those models, though it is incompatible with the Commodore 64's software."

--- a/dist/info/vice_xscpu64_libretro.info
+++ b/dist/info/vice_xscpu64_libretro.info
@@ -33,5 +33,3 @@ firmware3_desc = "vice/JiffyDOS_1581.bin (JiffyDOS 1581 drive BIOS)"
 firmware3_path = "vice/JiffyDOS_1581.bin"
 firmware3_opt = "true"
 notes = "(!) JiffyDOS_C64.bin (md5): be09394f0576cf81fa8bacf634daf9a2|(!) JiffyDOS_1541-II.bin (md5): 1b1e985ea5325a1f46eb7fd9681707bf|(!) JiffyDOS_1571_repl310654.bin (md5): 41c6cc528e9515ffd0ed9b180f8467c0|(!) JiffyDOS_1581.bin (md5): 20b6885c6dc2d42c38754a365b043d71"
-
-description = "The VICE xscpu64 emulator, isolated and ported to libretro. This core simulates a Commodore 64 equipped with a SuperCPU64 V2B, which provides a 20 MHz asynchronous single-cycle 65816 CPU core, 128 KiB static RAM, 0-16 MiB SIMM RAM and 64-512 KiB EPROM."

--- a/dist/info/vice_xvic_libretro.info
+++ b/dist/info/vice_xvic_libretro.info
@@ -17,5 +17,3 @@ systemid = "commodore_vic20"
 # Libretro Features
 database = "Commodore - VIC-20"
 supports_no_game = "true"
-
-description = "The VICE VIC-20 emulator, isolated and ported to libretro. This core emulates all of the internal hardware, including the VIA chips. The VIC-I video chip is fully emulated except for NTSC interlace mode."

--- a/dist/info/vitaquake2_libretro.info
+++ b/dist/info/vitaquake2_libretro.info
@@ -16,6 +16,5 @@ systemid = "quake_2"
 # Libretro Features
 database = "Quake II"
 supports_no_game = "false"
-database = "Quake II"
 
 description = "A port of the VitaQuake 2 source port of iD's Quake 2 engine to libretro. There is a separate core for each of the Quake 2 mission packs, 'Rogue', 'Zaero' and 'Xatrix'. This core is for the main game. This core loads games in the *.pak format."


### PR DESCRIPTION
There are duplicate keys in several of the core info files. I have removed the duplicates.