### PR TITLE
Stylize PICO8 as PICO-8 for display name

### DIFF
--- a/dist/info/retro8_libretro.info
+++ b/dist/info/retro8_libretro.info
@@ -1,5 +1,5 @@
 # Software Information
-display_name = "PICO8 (Retro8)"
+display_name = "PICO-8 (Retro8)"
 authors = "jakz"
 supported_extensions = "p8|png"
 corename = "Retro8"


### PR DESCRIPTION
## Description

This PR does as the title says, it stylizes PICO8 as PICO-8 for the display name of Retro8. A quick google search confirms the stylization.

Remaining questions, should the following fields be updated with a hyphen?

* `systemname = "PICO8"`
* `systemid = "pico8"`
* `database = "PICO8"`