### PR TITLE
Update Beetle PSX info files for the "override BIOS" option

### DIFF
--- a/dist/info/mednafen_psx_hw_libretro.info
+++ b/dist/info/mednafen_psx_hw_libretro.info
@@ -30,7 +30,7 @@ hw_render = "true"
 required_hw_api = "OpenGL Core >= 3.3 | Vulkan >= 1.0"
 
 # Firmware / BIOS
-firmware_count = 3
+firmware_count = 5
 firmware0_desc = "scph5500.bin (PS1 JP BIOS)"
 firmware0_path = "scph5500.bin"
 firmware0_opt = "true"
@@ -40,6 +40,12 @@ firmware1_opt = "true"
 firmware2_desc = "scph5502.bin (PS1 EU BIOS)"
 firmware2_path = "scph5502.bin"
 firmware2_opt = "true"
-notes = "(!) scph5500.bin (md5): 8dd7d5296a650fac7319bce665a6a53c|(!) scph5501.bin (md5): 490f666e1afb15b7362b406ed1cea246|(!) scph5502.bin (md5): 32736f17079d0b2b7024407c39bd3050"
+firmware3_desc = "psxonpsp660.bin (PSP PS1 BIOS)"
+firmware3_path = "psxonpsp660.bin"
+firmware3_opt = "true"
+firmware4_desc = "ps1_rom.bin (PS3 PS1 BIOS)"
+firmware4_path = "ps1_rom.bin"
+firmware4_opt = "true"
+notes = "(!) scph5500.bin (md5): 8dd7d5296a650fac7319bce665a6a53c|(!) scph5501.bin (md5): 490f666e1afb15b7362b406ed1cea246|(!) scph5502.bin (md5): 32736f17079d0b2b7024407c39bd3050|(!) psxonpsp660.bin (md5): c53ca5908936d412331790f4426c6c33|(!) ps1_rom.bin (md5): 81bbe60ba7a3d1cea1d48c14cbcc647b"
 
 description = "A significantly modified fork of Mednafen's Playstation emulator, this core differs from the non-HW version by providing GPU-accelerated renderers for OpenGL and Vulkan. These renderers provide increased internal resolution for smooth, high-res polygons with minimal performance impact, texture filtering and other cosmetic changes. Both varieties of Beetle-PSX are more accurate than PCSX-ReARMed but also significantly slower, so they are generally a better choice for higher-specced devices that can benefit from the additional features and accuracy while maintaining full speed. The Beetle-PSX cores are also very particular about requiring BIOS images, so make sure you have the correct BIOS files available and make sure they are named exactly as the core expects."

--- a/dist/info/mednafen_psx_libretro.info
+++ b/dist/info/mednafen_psx_libretro.info
@@ -30,7 +30,7 @@ load_subsystem = "false"
 hw_render = "false"
 
 # Firmware / BIOS
-firmware_count = 3
+firmware_count = 5
 firmware0_desc = "scph5500.bin (PS1 JP BIOS)"
 firmware0_path = "scph5500.bin"
 firmware0_opt = "true"
@@ -40,6 +40,12 @@ firmware1_opt = "true"
 firmware2_desc = "scph5502.bin (PS1 EU BIOS)"
 firmware2_path = "scph5502.bin"
 firmware2_opt = "true"
-notes = "(!) scph5500.bin (md5): 8dd7d5296a650fac7319bce665a6a53c|(!) scph5501.bin (md5): 490f666e1afb15b7362b406ed1cea246|(!) scph5502.bin (md5): 32736f17079d0b2b7024407c39bd3050"
+firmware3_desc = "psxonpsp660.bin (PSP PS1 BIOS)"
+firmware3_path = "psxonpsp660.bin"
+firmware3_opt = "true"
+firmware4_desc = "ps1_rom.bin (PS3 PS1 BIOS)"
+firmware4_path = "ps1_rom.bin"
+firmware4_opt = "true"
+notes = "(!) scph5500.bin (md5): 8dd7d5296a650fac7319bce665a6a53c|(!) scph5501.bin (md5): 490f666e1afb15b7362b406ed1cea246|(!) scph5502.bin (md5): 32736f17079d0b2b7024407c39bd3050|(!) psxonpsp660.bin (md5): c53ca5908936d412331790f4426c6c33|(!) ps1_rom.bin (md5): 81bbe60ba7a3d1cea1d48c14cbcc647b"
 
 description = "A significantly modified fork of Mednafen's Playstation emulator, this core differs from the -HW version by focusing on software rendering (i.e., instead of hardware-accelerated rendering). The software renderer is more accurate than the OpenGL and Vulkan renderers used in the -HW core, but it lacks some of the cosmetic options and performs any internal resolution increases on the CPU instead of the GPU, which is very demanding (devices with fast CPUs may reach 2x scale but nothing can maintain full speed at 4x at the time of this writing). Both varieties of Beetle-PSX are more accurate than PCSX-ReARMed but also significantly slower, so they are generally a better choice for higher-specced devices that can benefit from the additional features and accuracy while maintaining full speed. The Beetle-PSX cores are also very particular about requiring BIOS images, so make sure you have the correct BIOS files available and make sure they are named exactly as the core expects."


### PR DESCRIPTION
The cores can now detect `psxonpsp660.bin` and `ps1_rom.bin` when the new option is enabled.