### PR TITLE
Add psxonpsp660.bin to firmware

### DIFF
--- a/dist/info/swanstation_libretro.info
+++ b/dist/info/swanstation_libretro.info
@@ -25,16 +25,19 @@ input_descriptors = "true"
 disk_control = "true"
 
 # BIOS / Firmware
-firmware_count = 3
-firmware0_desc = "scph5500.bin (PS1 JP BIOS)"
-firmware0_path = "scph5500.bin"
+firmware_count = 4
+firmware0_desc = "psxonpsp660.bin (PSP PS1 BIOS)"
+firmware0_path = "psxonpsp660.bin"
 firmware0_opt = "true"
-firmware1_desc = "scph5501.bin (PS1 US BIOS)"
-firmware1_path = "scph5501.bin"
+firmware1_desc = "scph5500.bin (PS1 JP BIOS)"
+firmware1_path = "scph5500.bin"
 firmware1_opt = "true"
-firmware2_desc = "scph5502.bin (PS1 EU BIOS)"
-firmware2_path = "scph5502.bin"
+firmware2_desc = "scph5501.bin (PS1 US BIOS)"
+firmware2_path = "scph5501.bin"
 firmware2_opt = "true"
-notes = "(!) scph5500.bin (md5): 8dd7d5296a650fac7319bce665a6a53c|(!) scph5501.bin (md5): 490f666e1afb15b7362b406ed1cea246|(!) scph5502.bin (md5): 32736f17079d0b2b7024407c39bd3050| This core also supports No-Intro BIOS images."
+firmware3_desc = "scph5502.bin (PS1 EU BIOS)"
+firmware3_path = "scph5502.bin"
+firmware3_opt = "true"
+notes = "(!) psxonpsp660.bin (md5): c53ca5908936d412331790f4426c6c33|(!) scph5500.bin (md5): 8dd7d5296a650fac7319bce665a6a53c|(!) scph5501.bin (md5): 490f666e1afb15b7362b406ed1cea246|(!) scph5502.bin (md5): 32736f17079d0b2b7024407c39bd3050| This core also supports No-Intro BIOS images."
 
 description = "SwanStation is a fork of the Duckstation PlayStation 1 (aka PSX) emulator focusing on playability, speed, and long-term maintainability ported to libretro. Accuracy is not the main focus of the emulator, but the goal is to be as accurate as possible while maintaining performance suitable for low-end devices. 'Hack' options are discouraged, the default configuration should support all playable games with only some of the enhancements having compatibility issues. A 'BIOS' ROM image is required to start the emulator and to play games. You can use an image from any hardware version or region, although mismatching game regions and BIOS regions may have compatibility issues. A ROM image is not provided with the emulator for legal reasons, you should dump this from your own console using Caetla or other means. SwanStation includes hardware rendering (OpenGL, Vulkan and D3D11), upscaling and 24-bit color and a 64-bit dynarec."


### PR DESCRIPTION
It actually defaults to it when present in the system directory, so it's the preferred firmware file.