### PR TITLE
vitaquake2-zaero_libretro.info: Fix core name

### DIFF
--- a/dist/info/vitaquake2-zaero_libretro.info
+++ b/dist/info/vitaquake2-zaero_libretro.info
@@ -1,5 +1,5 @@
 # Software Information
-display_name = "Quake II - The Reckoning (vitaQuake 2 [Zaero])"
+display_name = "Quake II - Zaero (vitaQuake 2 [Zaero])"
 authors = "Rinnegatamante"
 supported_extensions = "pak"
 corename = "vitaQuake 2 [Zaero]"


### PR DESCRIPTION
This trivial PR fixes the core display name in `vitaquake2-zaero_libretro.info`