### PR TITLE
Update Mu to include pdb in the list of valid content extensions.

### DIFF
--- a/dist/info/mu_libretro.info
+++ b/dist/info/mu_libretro.info
@@ -1,7 +1,7 @@
 # Software Information  
 display_name = "Palm OS (Mu)"
 authors = "guicrith / meepingsnesroms"
-supported_extensions = "prc|pqa|img"
+supported_extensions = "prc|pqa|img|pdb"
 corename = "Mu"
 license = "Non-commercial"
 permissions = ""


### PR DESCRIPTION
This updates Mu to include PDB in the list of valid extensions, these represent databases and typically contain user data.