### PR TITLE
database: Add Amstrad GX4000 database

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -239,6 +239,7 @@ build_libretro_database() {
 
 build_libretro_databases() {
 	build_libretro_database "Amstrad - CPC" "rom.crc"
+	build_libretro_database "Amstrad - GX4000" "rom.crc"
 	build_libretro_database "Mattel - Intellivision" "rom.crc"
 	build_libretro_database "ScummVM" "rom.crc"
 	build_libretro_database "DOS" "rom.crc"


### PR DESCRIPTION
Somehow we weren't considering GX4000, even though Caprice can run it. TOSEC provides a database for it, which I'll be able to build next cycle.