### PR TITLE
Add a5200_libretro.info (info file for upcoming Atari 5200 core)

### DIFF
--- a/dist/info/a5200_libretro.info
+++ b/dist/info/a5200_libretro.info
@@ -1,0 +1,25 @@
+# Software Information
+display_name = "Atari - 5200 (a5200)"
+authors = "Petr Stehlik|zx81|Alekmaul"
+supported_extensions = "a52|bin"
+corename = "a5200"
+license = "GPLv2"
+permissions = ""
+display_version = "2.0.2"
+categories = "Emulator"
+
+# Hardware Information
+manufacturer = "Atari"
+systemname = "Atari 5200"
+systemid = "atari_5200"
+
+# Libretro Features
+supports_no_game = "false"
+database = "Atari - 5200"
+
+# Firmware / BIOS
+firmware_count = 1
+firmware0_desc = "5200.rom (5200 BIOS)"
+firmware0_path = "5200.rom"
+firmware0_opt = "false"
+notes = "(!) 5200.rom (md5): 281f20ea4320404ec820fb7ec0693b38"


### PR DESCRIPTION
This PR adds a core info file for a new upcoming Atari 5200 core: `a5200`