### PR TITLE
atari800: Add .rom to the list of valid extensions

### DIFF
--- a/dist/info/atari800_libretro.info
+++ b/dist/info/atari800_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Atari - 5200 (Atari800)"
 authors = "Petr Stehlik"
-supported_extensions = "xfd|atr|cdm|cas|bin|a52|zip|atx|car|com|xex"
+supported_extensions = "xfd|atr|cdm|cas|bin|a52|zip|atx|car|rom|com|xex"
 corename = "Atari800"
 categories = "Emulator"
 license = "GPLv2"


### PR DESCRIPTION
Sometimes it's used interchangeably with .car