### PR TITLE
info: Add WASM-4 .info file

### DIFF
--- a/dist/info/wasm4_libretro.info
+++ b/dist/info/wasm4_libretro.info
@@ -1,0 +1,35 @@
+# Software Information
+display_name = "WASM-4"
+authors = "Bruno Garcia"
+supported_extensions = "wasm"
+corename = "WASM-4"
+license = "ISC"
+permissions = ""
+display_version = "2.1.0"
+categories = "Game engine"
+
+# Hardware Information
+systemname = "WASM-4"
+systemid = "wasm4"
+
+# Libretro Features
+supports_no_game = "false"
+savestate = "true"
+savestate_features = "deterministic"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "false"
+core_options_version = "1.0"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "false"
+disk_control = "false"
+database = "WASM-4"
+
+# BIOS / Firmware
+firmware_count = 0
+notes = "(!) Homepage: https://wasm4.org"
+
+description = "WASM-4 is a low-level fantasy game console for building small games with WebAssembly. Game cartridges (ROMs) are small, self-contained .wasm files that can be built with any programming language that compiles to WebAssembly."


### PR DESCRIPTION
[WASM-4](https://github.com/aduros/wasm4/) now has full libretro integration. Seems like a good idea to have a .info file to allow loading `.wasm` files directly.