### PR TITLE
database: Add Jump 'n Bump database

### DIFF
--- a/dist/info/jumpnbump_libretro.info
+++ b/dist/info/jumpnbump_libretro.info
@@ -8,6 +8,8 @@ display_version = "v0.1"
 manufacturer = "Brainchild Design"
 systemid = "jumpnbump"
 
+# Libretro Features
+database = "Jump 'n Bump"
 savestate = "false"
 cheats = "false"
 input_descriptors = "true"

--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -243,6 +243,7 @@ build_libretro_databases() {
 	build_libretro_database "Mattel - Intellivision" "rom.crc"
 	build_libretro_database "ScummVM" "rom.crc"
 	build_libretro_database "DOS" "rom.crc"
+	build_libretro_database "Jump 'n Bump" "rom.crc"
 	build_libretro_database "LowRes NX" "rom.crc"
 	build_libretro_database "Lutro" "rom.name"
 	build_libretro_database "ChaiLove" "rom.crc"


### PR DESCRIPTION
This allows referencing the Jump 'n Bump database of levels: https://github.com/libretro/libretro-database/pull/1271