### PR TITLE
Add same_cdi_libretro.info

### DIFF
--- a/dist/info/same_cdi_libretro.info
+++ b/dist/info/same_cdi_libretro.info
@@ -1,0 +1,46 @@
+# Software Information
+display_name = "Philips - CDi (SAME CDi)"
+authors = "MAMEdev"
+supported_extensions = "chd|iso"
+corename = "SAME CDi (Git)"
+license = "GPLv2+"
+permissions = ""
+display_version = "Git"
+categories = "Emulator"
+
+# Hardware Information
+manufacturer = "Philips"
+systemname = "CD-i"
+systemid = "cdi"
+
+# Libretro Features
+supports_no_game = "false"
+database = "MAME"
+savestate = "false"
+savestate_features = "null"
+cheats = "false"
+input_descriptors = "false"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "true"
+core_options_version = "1.0"
+hw_render = "false"
+disk_control = "false"
+database_match_archive_member = "true"
+
+# BIOS/Firmware
+firmware_count = 3
+
+firmware0_desc = "same_cdi/bios/cdimono1.zip"
+firmware0_path = "same_cdi/bios/cdimono1.zip"
+firmware0_opt = "false"
+
+firmware1_desc = "same_cdi/bios/cdimono2.zip"
+firmware1_path = "same_cdi/bios/cdimono2.zip"
+firmware1_opt = "true"
+
+firmware2_desc = "same_cdi/bios/cdibios.zip"
+firmware2_path = "same_cdi/bios/cdibios.zip"
+firmware2_opt = "true"
+
+description = "SAME CDi is a S(ingle) A(rcade) M(achine) E(mulator) for libretro, forked from MAME libretro, which is in turn a fork of MAME. It includes only the Philips CD-i driver, and simplifies the loading of CD content to provide a 'plug and play' experience."


### PR DESCRIPTION
This PR adds an info file for the new `SAME CDi` core