### PR TITLE
(Core Info) Update 'supports_no_game' status, add 'single_purpose' flag

### DIFF
--- a/dist/info/00_example_libretro.info
+++ b/dist/info/00_example_libretro.info
@@ -71,12 +71,14 @@
 # load_subsystem = "false"
 # Whether or not the core requires an external file to work:
 # supports_no_game = "false"
+# Does the core have a single purpose? Does it represent one game or application, requiring predetermined support files or no external data? Used to indicate to a frontend that the core may be presented/handled independently from 'regular' cores that run a variety of content.
+# single_purpose = "false"
 # Name of the database that the core supports (optional):
 # database = "Nintendo - Nintendo Entertainment System|Nintendo - Famicom Disk System"
 # Does the core support/require support for libretro-gl or other hardware-acceleration in the frontend?
 # hw_render = "false"
 # Which hardware-rendering APIs does the core support? Delimited by pipe characters.
-required_hw_api = "Vulkan >= 1.0 | Direct3D >= 10.0 | OpenGL Core >= 3.3 | OpenGL ES >= 3.0"
+# required_hw_api = "Vulkan >= 1.0 | Direct3D >= 10.0 | OpenGL Core >= 3.3 | OpenGL ES >= 3.0"
 # Does the core require ongoing access to the file after loading? Mostly used for softpatching and streaming of data
 # needs_fullpath = "false"
 # Does the core support the libretro disk control interface for swapping disks on the fly?

--- a/dist/info/2048_libretro.info
+++ b/dist/info/2048_libretro.info
@@ -14,7 +14,9 @@ systemid = "2048"
 manufacturer = "N/A"
 
 # Libretro Features
+database = "2048"
 supports_no_game = "true"
+single_purpose = "true"
 savestate = "true"
 savestate_features = "serialized"
 cheats = "false"

--- a/dist/info/craft_libretro.info
+++ b/dist/info/craft_libretro.info
@@ -14,7 +14,9 @@ systemname = "Minecraft Game Clone"
 systemid = "craft"
 
 # Libretro Features
+database = "Minecraft"
 supports_no_game = "true"
+single_purpose = "true"
 savestate = "false"
 savestate_features = "null"
 cheats = "false"

--- a/dist/info/dinothawr_libretro.info
+++ b/dist/info/dinothawr_libretro.info
@@ -15,7 +15,8 @@ systemid = "dinothawr"
 
 # Libretro Features
 database = "Dinothawr"
-supports_no_game = "false"
+supports_no_game = "true"
+single_purpose = "true"
 savestate = "false"
 savestate_features = "null"
 libretro_saves = "true"

--- a/dist/info/gong_libretro.info
+++ b/dist/info/gong_libretro.info
@@ -15,6 +15,7 @@ manufacturer = "N/A"
 
 # Libretro Features
 supports_no_game = "true"
+single_purpose = "true"
 savestate = "true"
 savestate_features = "serialized"
 cheats = "false"

--- a/dist/info/mrboom_libretro.info
+++ b/dist/info/mrboom_libretro.info
@@ -14,6 +14,7 @@ systemid = "bomberman"
 
 # Libretro Features
 supports_no_game = "true"
+single_purpose = "true"
 database = "MrBoom"
 savestate = "true"
 savestate_features = "deterministic"

--- a/dist/info/nxengine_libretro.info
+++ b/dist/info/nxengine_libretro.info
@@ -14,7 +14,8 @@ systemid = "nxengine"
 
 # Libretro Features
 database = "Cave Story"
-supports_no_game = "false"
+supports_no_game = "true"
+single_purpose = "true"
 savestate = "false"
 cheats = "false"
 input_descriptors = "true"

--- a/dist/info/thepowdertoy_libretro.info
+++ b/dist/info/thepowdertoy_libretro.info
@@ -13,6 +13,7 @@ systemname = "Physics Toy"
 
 # Libretro Features
 supports_no_game = "true"
+single_purpose = "true"
 savestate = "true"
 savestate_features = "serialized"
 cheats = "false"

--- a/dist/info/xrick_libretro.info
+++ b/dist/info/xrick_libretro.info
@@ -14,7 +14,8 @@ systemid = "xrick"
 
 # Libretro Features
 database = "Rick Dangerous"
-supports_no_game = "false"
+supports_no_game = "true"
+single_purpose = "true"
 savestate = "false"
 
 notes = "(!) XRick requires data ROM 'data.zip'.|(!) Load Content 'data.zip'"


### PR DESCRIPTION
This PR makes the following core info changes:

- The `supports_no_game` status of a number of cores has been modified to reflect recent code updates
- A new `single_purpose` status entry has been added, to indicate that a core is intended for a single application (e.g. that the core represents a single standalone game). This is required for a forthcoming RetroArch menu addition.
- Missing `database` entries have also been added for a couple of `single_purpose` cores