### PR TITLE
cannonball_libretro.info: Update 'supports_no_game' status and add 'single_purpose' flag

### DIFF
--- a/dist/info/cannonball_libretro.info
+++ b/dist/info/cannonball_libretro.info
@@ -14,7 +14,8 @@ systemname = "Outrun Game Engine"
 
 # Libretro Features
 database = "Cannonball"
-supports_no_game = "false"
+supports_no_game = "true"
+single_purpose = "true"
 savestate = "false"
 savestate_features = "null"
 cheats = "false"


### PR DESCRIPTION
This PR updates `cannonball_libretro.info` in line with the changes here: https://github.com/libretro/cannonball/pull/27