### PR TITLE
info: Update picodrive

### DIFF
--- a/dist/info/picodrive_libretro.info
+++ b/dist/info/picodrive_libretro.info
@@ -1,11 +1,11 @@
 # Software Information
-display_name = "Sega - GG/MS/MD/CD/32X (PicoDrive)"
+display_name = "Sega - MS/GG/MD/CD/32X (PicoDrive)"
 authors = "notaz|fdave|irixxxx"
 supported_extensions = "bin|gen|gg|smd|pco|md|32x|chd|cue|iso|sms|68k|sgd|m3u"
 corename = "PicoDrive"
 license = "MAME"
 permissions = "dynarec_optional"
-display_version = "1.91"
+display_version = "1.99"
 categories = "Emulator"
 
 # Hardware Information


### PR DESCRIPTION
Swap order of GG and MS in display_name for consistency with other Sega
cores.
Update display version to match the core.