### PR TITLE
Fix citra and add pcsx2

### DIFF
--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -14,7 +14,7 @@ bsnes_mercury libretro-bsnes_mercury https://github.com/libretro/bsnes-mercury.g
 cannonball libretro-cannonball https://github.com/libretro/cannonball.git master YES GENERIC Makefile .
 cap32 libretro-cap32 https://github.com/libretro/libretro-cap32.git master YES GENERIC Makefile .
 chailove libretro-chailove https://github.com/libretro/libretro-chailove.git master YES GENERIC Makefile .
-citra libretro-citra https://github.com/libretro/citra.git master YES CMAKE Makefile build -DENABLE_LIBRETRO=1 -DLIBRETRO_STATIC=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DCMAKE_BUILD_TYPE="Release" -DENABLE_WEB_SERVICE=0 -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10
+citra libretro-citra https://github.com/libretro/citra.git master YES GENERIC Makefile .
 citra_canary libretro-citra_canary https://github.com/libretro/citra.git canary YES CMAKE Makefile build -DENABLE_LIBRETRO=1 -DLIBRETRO_STATIC=1 -DENABLE_SDL2=0 -DENABLE_QT=0 -DCMAKE_BUILD_TYPE="Release" -DENABLE_WEB_SERVICE=0
 craft libretro-craft https://github.com/libretro/craft master YES GENERIC Makefile.libretro .
 crocods libretro-crocods https://github.com/libretro/libretro-crocods.git master YES GENERIC Makefile .
@@ -99,6 +99,7 @@ oberon libretro-oberon https://github.com/libretro/oberon-risc-emu.git master YE
 openlara libretro-openlara https://github.com/libretro/OpenLara.git master YES GENERIC Makefile src/platform/libretro
 parallel_n64 libretro-parallel_n64 https://github.com/libretro/parallel-n64.git master YES GENERIC_GL Makefile . WITH_DYNAREC=x86_64 HAVE_PARALLEL=1 HAVE_PARALLEL_RSP=1 HAVE_THR_AL=1
 pcsx_rearmed libretro-pcsx_rearmed https://github.com/libretro/pcsx_rearmed.git master YES GENERIC Makefile.libretro . DYNAREC=lightrec
+pcsx2 pcsx2 https://github.com/libretro/pcsx2.git main YES CMAKE Makefile build -DLIBRETRO=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_QT=OFF -DCMAKE_LINK_WHAT_YOU_USE=TRUE
 play libretro-play https://github.com/jpd002/Play-.git master YES CMAKE Makefile build -DBUILD_LIBRETRO_CORE=yes -DBUILD_PLAY=off -DBUILD_TESTS=no -DENABLE_AMAZON_S3=no -DCMAKE_BUILD_TYPE="Release"
 picodrive libretro-picodrive https://github.com/libretro/picodrive.git master YES GENERIC Makefile.libretro .
 pocketcdg libretro-pocketcdg https://github.com/libretro/libretro-pocketcdg.git master YES GENERIC Makefile .


### PR DESCRIPTION
Citra no longer compiles using the CMake process that the script previously used, so reverted to the generic Makefile process that's been tested as working.  

The pcsx2 core addition has also been tested as working.  For some reason the CMake flag `-DENABLE_QT=OFF` is not used, even though it's listed [here](https://github.com/libretro/pcsx2/blob/main/.gitlab-ci.yml#L20), so I've left it in for now since it still compiles with it there and it may be needed in the future.