### PR TITLE
fuse: Add .zip to file extensions

### DIFF
--- a/dist/info/fuse_libretro.info
+++ b/dist/info/fuse_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sinclair - ZX Spectrum (Fuse)"
 authors = "Team Fuse"
-supported_extensions = "tzx|tap|z80|rzx|scl|trd|dsk"
+supported_extensions = "tzx|tap|z80|rzx|scl|trd|dsk|zip"
 corename = "Fuse"
 categories = "Emulator"
 license = "GPLv3"


### PR DESCRIPTION
This is ported from zach-morris over at https://github.com/libretro/libretro-core-info/pull/52 .