### PR TITLE
Mupen64plus Next BIOS

### DIFF
--- a/dist/info/mupen64plus_next_develop_libretro.info
+++ b/dist/info/mupen64plus_next_develop_libretro.info
@@ -29,4 +29,11 @@ needs_fullpath = "false"
 disk_control = "false"
 is_experimental = "true"
 
+# Firmware / BIOS
+firmware_count = 1
+firmware0_desc = "IPL.n64 (64DD IPL ROM)"
+firmware0_path = "Mupen64plus/IPL.n64"
+firmware0_opt = "true"
+notes = "(!) IPL.n64 (md5): 8d3d9f294b6e174bc7b1d2fd1c727530"
+
 description = "An up-to-date port of the Mupen64Plus N64 emulator, ported to libretro. It uses up-to-date GLideN64 plugin as its default graphics plug, though the high-accuracy Angrylion and ParaLLEl-RDP plugins are also available. This core is a good first choice for most users and should generally work better than the ParaLLEl-N64 core, which is mainly useful for its support for legacy graphics plugins that can run on older/low-power devices that are too weak for the modern plugins. This core is intended for development/testing purposes, so users who just want to play games should use the non-develop version instead."

--- a/dist/info/mupen64plus_next_gles2_libretro.info
+++ b/dist/info/mupen64plus_next_gles2_libretro.info
@@ -29,4 +29,11 @@ needs_fullpath = "false"
 disk_control = "false"
 is_experimental = "false"
 
+# Firmware / BIOS
+firmware_count = 1
+firmware0_desc = "IPL.n64 (64DD IPL ROM)"
+firmware0_path = "Mupen64plus/IPL.n64"
+firmware0_opt = "true"
+notes = "(!) IPL.n64 (md5): 8d3d9f294b6e174bc7b1d2fd1c727530"
+
 description = "An up-to-date port of the Mupen64Plus N64 emulator, ported to libretro. It uses up-to-date GLideN64 plugin as its default graphics plug, though the high-accuracy Angrylion and ParaLLEl-RDP plugins are also available. This core is a good first choice for most users and should generally work better than the ParaLLEl-N64 core, which is mainly useful for its support for legacy graphics plugins that can run on older/low-power devices that are too weak for the modern plugins. This core is designed for devices that support OpenGL ES 2.0 and will have graphical errors on devices that support OpenGL ES 3.0+, so users with those devices should use the GLES3 version instead."

--- a/dist/info/mupen64plus_next_gles3_libretro.info
+++ b/dist/info/mupen64plus_next_gles3_libretro.info
@@ -29,4 +29,11 @@ needs_fullpath = "false"
 disk_control = "false"
 is_experimental = "false"
 
+# Firmware / BIOS
+firmware_count = 1
+firmware0_desc = "IPL.n64 (64DD IPL ROM)"
+firmware0_path = "Mupen64plus/IPL.n64"
+firmware0_opt = "true"
+notes = "(!) IPL.n64 (md5): 8d3d9f294b6e174bc7b1d2fd1c727530"
+
 description = "An up-to-date port of the Mupen64Plus N64 emulator, ported to libretro. It uses up-to-date GLideN64 plugin as its default graphics plug, though the high-accuracy Angrylion and ParaLLEl-RDP plugins are also available. This core is a good first choice for most users and should generally work better than the ParaLLEl-N64 core, which is mainly useful for its support for legacy graphics plugins that can run on older/low-power devices that are too weak for the modern plugins. This core is designed for devices that support OpenGL ES 3.0+ and will not function on other devices."

--- a/dist/info/mupen64plus_next_libretro.info
+++ b/dist/info/mupen64plus_next_libretro.info
@@ -30,4 +30,11 @@ needs_fullpath = "false"
 disk_control = "false"
 is_experimental = "false"
 
+# Firmware / BIOS
+firmware_count = 1
+firmware0_desc = "IPL.n64 (64DD IPL ROM)"
+firmware0_path = "Mupen64plus/IPL.n64"
+firmware0_opt = "true"
+notes = "(!) IPL.n64 (md5): 8d3d9f294b6e174bc7b1d2fd1c727530"
+
 description = "An up-to-date port of the Mupen64Plus N64 emulator, ported to libretro. It uses up-to-date GLideN64 plugin as its default graphics plug, though the high-accuracy Angrylion and ParaLLEl-RDP plugins are also available. This core is a good first choice for most users and should generally work better than the ParaLLEl-N64 core, which is mainly useful for its support for legacy graphics plugins that can run on older/low-power devices that are too weak for the modern plugins."


### PR DESCRIPTION
strcat(pathname, "IPL.n64");
https://github.com/libretro/mupen64plus-libretro-nx/blob/develop/mupen64plus-core/src/main/main.c
Mupen64Plus Next GLES3 64DD Nintendo 64 Disk Drive RetroArch subsystem tutorial
YouTube Description
https://youtu.be/fF8fVTh1F3Y