### PR TITLE
Add same_cdi to armhf

### DIFF
--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -93,6 +93,7 @@ quasi88 libretro-quasi88 https://github.com/libretro/quasi88-libretro.git master
 quicknes libretro-quicknes https://github.com/libretro/QuickNES_Core.git master YES GENERIC Makefile .
 reminiscence libretro-reminiscence https://github.com/libretro/REminiscence.git master YES GENERIC Makefile .
 remotejoy libretro-remotejoy https://github.com/libretro/libretro-remotejoy.git master YES GENERIC Makefile .
+same_cdi libretro-same_cdi https://github.com/libretro/same_cdi.git master NO GENERIC Makefile.libretro . PTR64=1
 sameboy libretro-sameboy https://github.com/libretro/SameBoy.git buildbot YES GENERIC Makefile libretro
 scummvm libretro-scummvm https://github.com/libretro/scummvm.git master YES GENERIC Makefile backends/platform/libretro/build
 snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC Makefile libretro


### PR DESCRIPTION
Add same_cdi to armhf.  Note that I have not tested this as I don't know how.  However I've just copied the recipe for mame to same_cdi, they use pretty much the same makefile so it should in theory work.
Fixes https://github.com/zach-morris/same_cdi/issues/5