### PR TITLE
Update pcsx2_libretro.info

### DIFF
--- a/dist/info/pcsx2_libretro.info
+++ b/dist/info/pcsx2_libretro.info
@@ -25,9 +25,8 @@ memory_descriptors = "false"
 
 # Firmware / BIOS
 firmware_count = 1
-firmware0_desc = "'pcsx2/bios' folder"
-firmware0_path = "pcsx2/bios"
+firmware0_path = "system"
 firmware0_opt = "false"
-notes = "[1] This only checks if the PCSX2 'bios' folder exists and is in the correct location.|[2] Because the core doesn't require any specific filename for the BIOS files,|[^] this info file cannot tell you if the content of your 'bios' folder is correct or not.|[3] Please check https://docs.libretro.com/library/pcsx2/#bios for more details."
+notes = "[1] The core doesn't require any specific filename for the BIOS files,|[^] this info file cannot tell you if the content of your system folder is correct or not.|[2] Please check https://docs.libretro.com/library/pcsx2/#bios for more details."
 
 description = "A port of the mature and highly-compatible PCSX2 Playstation 2 emulator to libretro. This core is a good first choice for most users as compared with the Play! core, which has lower compatibility with the PS2 library. Required BIOS files include EROM.BIN, rom1.bin, and at least one set of scph*.bin/.mec/.nvm dumps that match each region of games you wish to run. A newer BIOS than scph10000 is recommended, as this original BIOS has problems in memory card emulation and other sections."


### PR DESCRIPTION
Updates the Core Info File for the PCSX2 core to reflect a change which enables PS2 BIOS files to be loaded directly from the system folder.