### PR TITLE
Add `cdf` as a valid extension for the ProSystem core.

### DIFF
--- a/dist/info/prosystem_libretro.info
+++ b/dist/info/prosystem_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Atari - 7800 (ProSystem)"
 authors = "Greg Stanton|Brian Berlin|Leonis|Greg DeMent"
-supported_extensions = "a78|bin"
+supported_extensions = "a78|bin|cdf"
 corename = "ProSystem"
 license = "GPLv2"
 permissions = ""


### PR DESCRIPTION
This is needed to open the Steam version of "Rikki & Vikki", once the
corresponding pull request for that game in `prosystem-libretro` is
merged. See [that pull request](https://github.com/libretro/prosystem-libretro/pull/71) for more details.