### PR TITLE
Dolphin - add WIA as a supported extension

### DIFF
--- a/dist/info/dolphin_libretro.info
+++ b/dist/info/dolphin_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Nintendo - GameCube / Wii (Dolphin)"
 authors = "Team Dolphin"
-supported_extensions = "gcm|iso|wbfs|ciso|gcz|elf|dol|dff|tgc|wad|rvz|m3u"
+supported_extensions = "gcm|iso|wbfs|ciso|gcz|elf|dol|dff|tgc|wad|rvz|m3u|wia"
 corename = "Dolphin"
 categories = "Emulator"
 license = "GPLv2+"


### PR DESCRIPTION
WIA files work absolutely fine:

![image](https://user-images.githubusercontent.com/33353403/188309353-178b1f6e-8211-4800-9420-629a3df74380.png)

Will also support for WIA scanning: https://github.com/libretro/RetroArch/pull/14380