### PR TITLE
database: Build the PuzzleScript RDB

### DIFF
--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -366,6 +366,7 @@ build_libretro_databases() {
 	build_libretro_database "WASM-4" "rom.crc"
 	build_libretro_database "Wolfenstein 3D" "rom.crc"
 	build_libretro_database "Atomiswave" "rom.crc"
+	build_libretro_database "PuzzleScript" "rom.crc"
 }
 
 build_libretrodb


### PR DESCRIPTION
This will build the PuzzleScript.rdb from [PuzzleScript.dat](https://github.com/libretro/libretro-database/blob/master/dat/PuzzleScript.dat) for [pzretro](https://github.com/nwhitehead/pzretro).