### PR TITLE
fetch: Allow skipping undefined URL fetches un multi-core fetch rules

### DIFF
--- a/libretro-fetch.sh
+++ b/libretro-fetch.sh
@@ -54,7 +54,11 @@ libretro_fetch() {
 			eval "git_url=\$libretro_${1}_git_url"
 			if [ -z "$git_url" ]; then
 				echo "libretro_fetch:No URL set to fetch $1 via git."
-				exit 1
+				if [[ "$SKIP_UNKNOWN_URL_FETCH" -ne 1 ]]; then
+					exit 1
+				else
+					echo "libretro_fetch:Skipping core $1"
+				fi
 			fi
 
 			eval "git_submodules=\$libretro_${1}_git_submodules"


### PR DESCRIPTION
Currently libretro-fetch if invoked with a multi-core list ends if one of the cores could not be fetched - i.e: when I tried the following and blastem failed to fetch the script ended there and promptly started the build of the previous 3 cores:

```shell
./libretro-fetch.sh mednafen_psx_hw mednafen_supafaust mednafen_gba blastem bsnes_mercury citra_canary desmume dosbox_core easyrpg fbalpha2012_neogeo flycast gearboy mupen64plus_next pcsx2
```

This PR adds a check for an user-definable variable `SKIP_UNKNOWN_URL_FETCH` which allows to skip each core instead of terminating the script upon URL retrieval errors
