### PR TITLE
Remove 'firmware.bin' MD5 for DeSmuME and melonDS

### DIFF
--- a/dist/info/desmume2015_libretro.info
+++ b/dist/info/desmume2015_libretro.info
@@ -41,6 +41,6 @@ firmware1_opt = "true"
 firmware2_desc = "bios9.bin (ARM9 BIOS)"
 firmware2_path = "bios9.bin"
 firmware2_opt = "true"
-notes = "(!) firmware.bin (md5): 145eaef5bd3037cbc247c213bb3da1b3|(!) bios7.bin (md5): df692a80a5b1bc90728bc3dfc76cd948|(!) bios9.bin (md5): a392174eb3e572fed6447e956bde4b25|[1] Enable 'Use External BIOS/Firmware' core option to use firmware files"
+notes = "(!) bios7.bin (md5): df692a80a5b1bc90728bc3dfc76cd948|(!) bios9.bin (md5): a392174eb3e572fed6447e956bde4b25|[1] Enable 'Use External BIOS/Firmware' core option to use firmware files"
 
 description = "A port of the mature and longstanding DeSmuME emulator for Nintendo's DS console to libretro. The core has very good compatibility and many modern features, but since this is an older snapshot (circa 2015), most users should try the up-to-date core and only fall back to this one if needed for performance reasons."

--- a/dist/info/desmume_libretro.info
+++ b/dist/info/desmume_libretro.info
@@ -42,6 +42,6 @@ firmware1_opt = "true"
 firmware2_desc = "bios9.bin (ARM9 BIOS)"
 firmware2_path = "bios9.bin"
 firmware2_opt = "true"
-notes = "(!) firmware.bin (md5): 145eaef5bd3037cbc247c213bb3da1b3|(!) bios7.bin (md5): df692a80a5b1bc90728bc3dfc76cd948|(!) bios9.bin (md5): a392174eb3e572fed6447e956bde4b25|[1] Enable 'Use External BIOS/Firmware' core option to use firmware files"
+notes = "(!) bios7.bin (md5): df692a80a5b1bc90728bc3dfc76cd948|(!) bios9.bin (md5): a392174eb3e572fed6447e956bde4b25|[1] Enable 'Use External BIOS/Firmware' core option to use firmware files"
 
 description = "A port of the mature and longstanding DeSmuME emulator for Nintendo's DS console to libretro. The core has very good compatibility and many modern features, including increased internal resolution (very demanding)."

--- a/dist/info/melonds_libretro.info
+++ b/dist/info/melonds_libretro.info
@@ -40,6 +40,6 @@ firmware6_opt = "true"
 firmware7_desc = "dsi_sd_card.bin (DSi SD card)"
 firmware7_path = "dsi_sd_card.bin"
 firmware7_opt = "true"
-notes = "(!) firmware.bin (md5): 145eaef5bd3037cbc247c213bb3da1b3|(!) bios7.bin (md5): df692a80a5b1bc90728bc3dfc76cd948|(!) bios9.bin (md5): a392174eb3e572fed6447e956bde4b25"
+notes = "(!) bios7.bin (md5): df692a80a5b1bc90728bc3dfc76cd948|(!) bios9.bin (md5): a392174eb3e572fed6447e956bde4b25"
 
 description = "A port of the melonDS emulator to libretro. This core supports a variety of modern features, like hardware-accelerated internal res increases, as well as increased accuracy for some popular games. While not as mature as Desmume--and therefore not as compatible with the DS library as a whole--this core is a good first choice to try, with the Desmume core(s) as a fallback."


### PR DESCRIPTION
See https://github.com/libretro/docs/pull/766