### PR TITLE
info: fix field systemid

### DIFF
--- a/dist/info/jaxe_libretro.info
+++ b/dist/info/jaxe_libretro.info
@@ -9,7 +9,7 @@ categories = "Emulator"
 # Hardware Information
 systemname = "CHIP-8"
 database = "CHIP-8"
-system_id = "chip_8"
+systemid = "chip_8"
 license = "MIT"
 permissions = ""
 display_version = "GIT"

--- a/dist/info/minivmac_libretro.info
+++ b/dist/info/minivmac_libretro.info
@@ -9,7 +9,7 @@ categories = "Emulator"
 
 # Hardware Information
 systemname = "Mac68k"
-system_id = "mac68k"
+systemid = "mac68k"
 license = "GPLv2"
 permissions = ""
 display_version = "GIT"

--- a/dist/info/vaporspec_libretro.info
+++ b/dist/info/vaporspec_libretro.info
@@ -10,7 +10,7 @@ categories = "Emulator"
 # Hardware Information
 systemname = "VaporSpec"
 database = "VaporSpec"
-system_id = "vaporspec"
+systemid = "vaporspec"
 permissions = ""
 display_version = "GIT"
 supports_no_game = "false"


### PR DESCRIPTION
Rename field `system_id` to `systemid` as described in [dist/info/00_example_libretro.info#L37](https://github.com/libretro/libretro-super/blob/5af08f11ed949f42e1c243b6ed128dad75e94fed/dist/info/00_example_libretro.info#L37) in some files .info.