### PR TITLE
Update atari800_libretro.info

### DIFF
--- a/dist/info/atari800_libretro.info
+++ b/dist/info/atari800_libretro.info
@@ -32,10 +32,22 @@ is_experimental = "false"
 needs_kbd_mouse_focus = "true"
 
 # BIOS/Firmware
-firmware_count = 1
-firmware0_desc = "5200.rom (5200 BIOS)"
+firmware_count = 5
+firmware0_desc = "5200.rom (Atari 5200 BIOS)"
 firmware0_path = "5200.rom"
 firmware0_opt = "false"
-notes = "(!) 5200.rom (md5): 281f20ea4320404ec820fb7ec0693b38"
+firmware1_desc = "ATARIBAS.ROM (Atari BASIC)"
+firmware1_path = "ATARIBAS.ROM"
+firmware1_opt = "false"
+firmware2_desc = "ATARIOSA.ROM (Atari 400/800 OS A)"
+firmware2_path = "ATARIOSA.ROM"
+firmware2_opt = "false"
+firmware3_desc = "ATARIOSB.ROM (Atari 400/800 OS B)"
+firmware3_path = "ATARIOSB.ROM"
+firmware3_opt = "false"
+firmware4_desc = "ATARIXL.ROM (Atari XL/XE OS)"
+firmware4_path = "ATARIXL.ROM"
+firmware4_opt = "false"
+notes = "(!) 5200.rom (md5): 281f20ea4320404ec820fb7ec0693b38|(!) ATARIBAS.ROM (md5): 0bac0c6a50104045d902df4503a4c30b|(!) ATARIOSA.ROM (md5): eb1f32f5d9f382db1bbfb8d7f9cb343a|(!) ATARIOSB.ROM (md5): a3e8d617c95d08031fe1b20d541434b2|(!) ATARIXL.ROM (md5): 06daac977823773a3eea3422fd26a703"
 
 description = "A port of the free and portable Atari800 emulator to libretro. This core supports games and programs written for the Atari 8-bit computers (400, 800, 600 XL, 800XL, 130XE) and 5200 console. When loaded, the core should boot to the Atari Computer - Memo Pad screen and will generate a .atari800.cfg config file in the frontend's home directory and will add the required BIOS files it detects in the frontend's system directory to the config file. Once that is done, users may manually select which Atari system to emulate through the Atari System core option. These and other options can also be modified through the core's own menu, accessible through the retrokeyboard's F1 key."


### PR DESCRIPTION
Depending on the system you want to emulate, the Atari800 core requires more than just "5200.rom", see https://docs.libretro.com/library/atari800/#bios