### PR TITLE
Add mamemess core info file

### DIFF
--- a/dist/info/mamemess_libretro.info
+++ b/dist/info/mamemess_libretro.info
@@ -1,0 +1,32 @@
+# Software Information
+display_name = "Multi (MESS - Current)"
+authors = "MAMEdev"
+supported_extensions = "zip|chd|7z|cmd"
+corename = "MESS (Git)"
+license = "GPLv2+"
+permissions = ""
+display_version = "Git"
+categories = "Emulator"
+
+# Hardware Information
+manufacturer = "Various"
+systemname = "Multi (various)"
+systemid = "mess"
+
+# Libretro Features
+supports_no_game = "false"
+database = "MAME"
+savestate = "true"
+savestate_features = "deterministic"
+cheats = "false"
+input_descriptors = "false"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "true"
+core_options_version = "1.0"
+hw_render = "false"
+disk_control = "false"
+database_match_archive_member = "true"
+notes = "[1] MESS supports MAME save states.|[2] MESS supports extracted MAME cheats.|[3] The BIOS files must be inside the ROM directory.|[4] CHD files and their directories must be inside the ROM directory.|[5] ARTWORK, CHEATS, HASH, INI and SAMPLES directories can be placed|[^] inside the 'SYSTEMDIR\mame' directory. (INI/Source for drivers)|[6] When saving, the following directories will be created in the 'SAVEDIR\mame'|[^] directory: STATES, NVRAM, INPUT, SNAPS, CFG, MEMCARD, and DIFF.|[7] Default combo to call MAME GUI: Retropad Select + X|[^] Retropad Select + Start => CANCEL"
+
+description = "'MESS - Current' is compatible with the latest MAME ROM sets. MAME is the most compatible emulator in the world, and it can run almost any game from any platform (though running console games through this core requires additional steps). Its high compatibility makes it a good option for most users."


### PR DESCRIPTION
Added a core info file for a proposed new mamemess core. This goes along with the mame PR: https://github.com/libretro/mame/pull/342