### PR TITLE
Add ONScripter core

### DIFF
--- a/dist/info/onscripter_libretro.info
+++ b/dist/info/onscripter_libretro.info
@@ -1,0 +1,24 @@
+# Software Information
+display_name = "ONScripter"
+display_version = "0.1"
+authors = "Studio O.G.A."
+categories = "Game engine"
+license = "GPLv3+"
+permissions = ""
+supported_extensions = "txt|dat|___"
+
+# Hardware Information
+manufacturer = "ONScripter"
+systemname = "ONScripter"
+systemid = "onscripter"
+
+# Libretro Features
+database = "ONScripter"
+supports_no_game = "false"
+libretro_saves = "false"
+cheats = "false"
+needs_fullpath = "true"
+disk_control = "false"
+is_experimental = "true"
+
+description = "A port of the ONScripter visual novel games engine to libretro."

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1528,6 +1528,14 @@ libretro_bk_name="bk"
 libretro_bk_git_url="https://github.com/libretro/bk-emulator.git"
 libretro_bk_build_makefile="Makefile.libretro"
 
+include_core_onscripter() {
+	register_module core "onscripter"
+}
+libretro_onscripter_name="ONScripter"
+libretro_onscripter_git_url="https://github.com/iyzsong/onscripter-libretro.git"
+libretro_onscripter_git_submodules="yes"
+libretro_onscripter_post_fetch_cmd="./update-deps.sh"
+libretro_onscripter_build_makefile="Makefile"
 
 
 # CORE RULE VARIABLES


### PR DESCRIPTION
Hello, this add a core for the onscipter visual novel games.
A free game Narcissu can be found here: http://narcissu.gwathyr.net/ , get and unpack the 日本語 x86 Linux版,
then play with `retroarch -L PATH-TO/onscripter_libretro.so PATH-TO/nscript.dat`.

Issues:
1. This build the default onscripter for Japanese, not with `ENABLE_1BYTE_CHAR` for English, so only Japanese games works.
2. When paused, retroarch consume 100% cpu for me.
3. I only tested it on x86_64 archlinux so far.