### PR TITLE
git: Force LF line endings in the dist directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.sh eol=lf
 recipes/** eol=lf
+dist/** eol=lf


### PR DESCRIPTION
Use .gitattributes to force use of LF line endings in the dist/info directory.