### PR TITLE
Added rule for VirtualXT

### DIFF
--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1537,6 +1537,14 @@ libretro_onscripter_git_submodules="yes"
 libretro_onscripter_post_fetch_cmd="./update-deps.sh"
 libretro_onscripter_build_makefile="Makefile"
 
+include_core_virtualxt() {
+	register_module core "virtualxt"
+}
+libretro_virtualxt_name="VirtualXT"
+libretro_virtualxt_git_url="https://github.com/andreas-jonsson/virtualxt.git"
+libretro_virtualxt_post_fetch_cmd="git checkout edge"
+libretro_virtualxt_build_subdir="tools/package/libretro"
+
 
 # CORE RULE VARIABLES
 #


### PR DESCRIPTION
Added rule for VirtualXT.

I have worked under the assumption that I don't have to set 'build_products' since I specify 'build_subdir'.