### PR TITLE
Add RVVM core

### DIFF
--- a/dist/info/rvvm_libretro.info
+++ b/dist/info/rvvm_libretro.info
@@ -1,0 +1,24 @@
+# Software Information
+display_name = "RVVM"
+display_version = "0.6-git"
+authors = "LekKit"
+categories = "Virtual machine"
+license = "GPLv3+"
+permissions = ""
+supported_extensions = "rvvm"
+
+# Hardware Information
+manufacturer = "RVVM"
+systemname = "RVVM"
+systemid = "rvvm"
+
+# Libretro Features
+database = "RVVM"
+supports_no_game = "false"
+libretro_saves = "false"
+cheats = "false"
+needs_fullpath = "true"
+disk_control = "false"
+is_experimental = "true"
+
+description = "A port of the RVVM (RISC-V Virtual Machine) to libretro."


### PR DESCRIPTION
Hello, RVVM is a RISC-V virtual machine which can boot Linux, FreeBSD, OpenBSD and other operating systems.
I have port it to libretro here. https://github.com/LekKit/RVVM/pull/96 (ready to be merged)

I'd like to upstream it to RetroArch, so
- I open this PR to add core info file.
- Add `.gitlab-ci` to RVVM
- icon and documentation can be added later..

Do I need test the CI setup outside libretro's GitLab?
Am I on the right road?  Thank you!