### PR TITLE
Remove unnecessary BIOS from freej2me

### DIFF
--- a/dist/info/freej2me_libretro.info
+++ b/dist/info/freej2me_libretro.info
@@ -17,14 +17,8 @@ supports_no_game = "false"
 database = "J2ME"
 
 # BIOS / Firmware
-firmware_count = 3
-firmware0_desc = "freej2me-fx.jar"
-firmware0_path = "freej2me-fx.jar"
+firmware_count = 1
+firmware0_desc = "freej2me-lr.jar"
+firmware0_path = "freej2me-lr.jar"
 firmware0_opt = "false"
-firmware1_desc = "freej2me.jar"
-firmware1_path = "freej2me.jar"
-firmware1_opt = "false"
-firmware2_desc = "freej2me-lr.jar"
-firmware2_path = "freej2me-lr.jar"
-firmware2_opt = "false"
-notes = "(!) freej2me-fx.jar (md5): 86fdd1ff260cd5a8f4c4d46bdde1a78a|(!) freej2me.jar (md5): 707cbaabaafc2a4f9726a5c03449406a|(!) freej2me-lr.jar (md5): d8aec1b68dc4e2ffc5eeff4e22fd607b"
+notes = "(!) freej2me-lr.jar (md5): d8aec1b68dc4e2ffc5eeff4e22fd607b"


### PR DESCRIPTION
Reference: https://github.com/hex007/freej2me

Only -lr is needed for the libretro core