### PR TITLE
Update nestopia savestate_features to deterministic

### DIFF
--- a/dist/info/nestopia_libretro.info
+++ b/dist/info/nestopia_libretro.info
@@ -16,7 +16,7 @@ systemid = "nes"
 # Libretro Features
 supports_no_game = "false"
 savestate = "true"
-savestate_features = "serialized"
+savestate_features = "deterministic"
 cheats = "true"
 input_descriptors = "true"
 memory_descriptors = "true"


### PR DESCRIPTION
This PR updates the `savestate_features` flag to `deterministic` in the nestopia core info file, allowing for Run-Ahead support - which has been tested to be working well with this core.