### PR TITLE
Add ardens_libretro.info

### DIFF
--- a/dist/info/ardens_libretro.info
+++ b/dist/info/ardens_libretro.info
@@ -1,0 +1,29 @@
+# Software Information
+display_name = "Arduboy (Ardens)"
+authors = "Peter Brown"
+supported_extensions = "hex|arduboy"
+corename = "Ardens"
+license = "MIT"
+permissions = ""
+display_version = "Git"
+categories = "Emulator"
+
+# Hardware Information
+manufacturer = "Arduboy"
+systemname = "Arduboy"
+systemid = "arduboy"
+
+# Libretro Features
+supports_no_game = "false"
+database = "Arduboy"
+savestate = "true"
+cheats = "false"
+core_options = "false"
+disk_control = "false"
+needs_fullpath = "false"
+is_experimental = "false"
+
+# Firmware / BIOS
+firmware_count = 0
+
+description = "Ardens is a simulator for the Arduboy FX that is designed especially for profiling and debugging Arduboy games."


### PR DESCRIPTION
Hi, I am pretty new to libretro dev so I apologize if I'm doing this wrong.

Ardens is an emulator for the Arduboy FX: [GitHub](https://github.com/tiberiusbrown/Ardens)
Originally it was written just to aid in developing Arduboy games but I have recently added an experimental [libretro core implementation](https://github.com/tiberiusbrown/Ardens/blob/master/src/libretro_core/libretro_impl.cpp).

I'm aware that Arduous exists, but Ardens does offer some additional benefit: FX emulation, PWM sound, grayscale support via temporal display frame filtering.

I've also added a .gitlab-ci.yml to the repo but I don't know how to test it.