### PR TITLE
Don't try to download the unmaintained stonesoup core.

### DIFF
--- a/build-config.sh
+++ b/build-config.sh
@@ -274,7 +274,6 @@ include_core_daphne
 include_core_dinothawr
 include_core_3dengine
 include_core_2048
-include_core_stonesoup
 include_core_scummvm
 include_core_chailove
 include_core_thepowdertoy

--- a/libretro-build-bsd.sh
+++ b/libretro-build-bsd.sh
@@ -61,7 +61,6 @@ build_default_cores_little_endian_only() {
 
 build_default_cores_cpp11() {
 	libretro_build_core dinothawr
-	libretro_build_core stonesoup
 	libretro_build_core bsnes_accuracy
 	libretro_build_core bsnes_balanced
 	libretro_build_core bsnes_performance

--- a/libretro-build.sh
+++ b/libretro-build.sh
@@ -113,7 +113,6 @@ build_default_cores_little_endian_only() {
 
 build_default_cores_cpp11() {
 	libretro_build_core dinothawr
-	libretro_build_core stonesoup
 	libretro_build_core bsnes_accuracy
 	libretro_build_core bsnes_balanced
 	libretro_build_core bsnes_performance

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1282,15 +1282,6 @@ include_core_opera() {
 libretro_opera_name="Opera"
 libretro_opera_git_url="https://github.com/libretro/opera-libretro.git"
 
-include_core_stonesoup() {
-	register_module core "stonesoup" -ngc -ps3 -psp1 -qnx -wii
-}
-libretro_stonesoup_name="Dungeon Crawl Stone Soup"
-libretro_stonesoup_git_url="https://github.com/libretro/crawl-ref.git"
-libretro_stonesoup_git_submodules="clone"
-libretro_stonesoup_build_subdir="crawl-ref"
-libretro_stonesoup_build_makefile="Makefile.libretro"
-
 include_core_freechaf() {
 	register_module core "freechaf" -ngc -ps3 -psp1 -qnx -wii
 }


### PR DESCRIPTION
The stonesoup core pointed to by libretro-super has not been maintained since 2019 and the submodules config in that repo is now broken. It seems best to just remove it from here.
