### PR TITLE
Add firmware checks for blueMSX

### DIFF
--- a/dist/info/bluemsx_libretro.info
+++ b/dist/info/bluemsx_libretro.info
@@ -30,6 +30,15 @@ needs_fullpath = "true"
 disk_control = "true"
 is_experimental = "false"
 needs_kbd_mouse_focus = "true"
+
+# BIOS/Firmware
+firmware_count = 2
+firmware0_desc = "'Databases' folder"
+firmware0_path = "Databases/msxromdb.xml"
+firmware0_opt = "false"
+firmware1_desc = "'Machines' folder"
+firmware1_path = "Machines/Shared Roms/MSX.rom"
+firmware1_opt = "false"
 notes = "(!) The libretro port of blueMSX requires the BIOS files|from full standalone package inside the 'System\Machines' directory |and media database files into 'System\Databases' directory.|https://docs.libretro.com/library/bluemsx/#bios|(!) ColecoVision Gamepad Mapping is as follow:|Button 1 as Retropad A|Button 2 as Retropad B|Dial keys 1 to 8 as X, Y, R, L, R2, L2, R3, L3|Star as Select, Hash as Start|0 & 9 are on keyboard 1 & 2 for Player 1|0 & 9 are on keyboard 3 & 4 for Player 2.|(!) To play SpectraVideo cassettes type 'cload' then 'run'|or BLOAD ''CAS:'',R depending of game."
 
 description = "A port of the blueMSX emulator to libretro. This emulator is cycle accurate and covers all generations of MSX computers, as well as SVI, ColecoVision and Sega SG-1000 machines. This core requires the 'Databases' and 'Machines' folders from a standalone installation of blueMSX to be placed in the frontend's system directory to function."


### PR DESCRIPTION
Similar to how Dolphin info file checks for the system folder: it internally checks for a specific file (here I chose the MSX database file and the MSX ROM) but only mentions the required folder to the user (here "Databases" and "Machines"):

![image](https://github.com/libretro/libretro-super/assets/33353403/7c317190-da07-449f-9c8c-8ab4bacff35c)
