### PR TITLE
Fix Spectravideo database to Spectravideo - SVI-318 - SVI-328

### DIFF
--- a/dist/info/bluemsx_libretro.info
+++ b/dist/info/bluemsx_libretro.info
@@ -14,7 +14,7 @@ systemname = "MSX/SVI/ColecoVision/SG-1000"
 systemid = "msx"
 
 # Libretro Features
-database = "Microsoft - MSX|Microsoft - MSX2|Coleco - ColecoVision|Sega - SG-1000|Spectravideo"
+database = "Microsoft - MSX|Microsoft - MSX2|Coleco - ColecoVision|Sega - SG-1000|Spectravideo - SVI-318 - SVI-328"
 supports_no_game = "false"
 savestate = "true"
 savestate_features = "serialized"


### PR DESCRIPTION
This will match the TOSEC naming, along with the playlist naming scheme across the other platforms.