### PR TITLE
Add GAM4980 core

### DIFF
--- a/dist/info/gam4980_libretro.info
+++ b/dist/info/gam4980_libretro.info
@@ -1,0 +1,23 @@
+# Software Information
+display_name = "GAM4980"
+display_version = "0.1"
+authors = "Anonymous"
+categories = "Emulator"
+license = "GPLv3+"
+supported_extensions = "gam"
+
+# Hardware Information
+manufacturer = "BBK Electronics"
+systemname = "Longman 4980"
+systemid = "gam4980"
+
+# Libretro Features
+database = "gam4980"
+supports_no_game = "true"
+libretro_saves = "true"
+cheats = "false"
+needs_fullpath = "false"
+disk_control = "false"
+is_experimental = "true"
+
+description = "BBK A4980 game emulator for libretro."

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1614,6 +1614,14 @@ libretro_anarch_post_fetch_cmd="mkdir -p build && cd build && cmake .."
 libretro_anarch_git_url="https://codeberg.org/iyzsong/anarch-libretro.git"
 libretro_anarch_build_makefile="Makefile"
 
+include_core_gam4980() {
+        register_module core "gam4980"
+}
+libretro_gam4980_name="GAM4980"
+libretro_gam4980_git_url="https://codeberg.org/iyzsong/gam4980.git"
+libretro_gam4980_build_rule="cmake"
+libretro_gam4980_build_args="-DCMAKE_BUILD_TYPE=Release"
+
 include_core_emuscv() {
 	register_module core "emuscv"
 }


### PR DESCRIPTION
Hello, this is a emulator for a Chinese electronic dictionary named 步步高朗文4980.

It has:
- 6502 CPU
- 159x96 LCD
- Keyboard
- COM port (DATALINK)
- Speaker and Earphone
- 32 KiB memory
- 1 MiB flash (can be upgraded to 2 MiB)
- 20 MiB Mask ROM

Image: https://bkimg.cdn.bcebos.com/pic/91ef76c6a7efce1b9b437ac4af51f3deb48f6557

Thanks.
