### PR TITLE
lynx: Add `.lyx` file extension

### DIFF
--- a/dist/info/frodo_libretro.info
+++ b/dist/info/frodo_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Commodore - C64 (Frodo)"
 authors = "Frodo Team Members"
-supported_extensions = "d64|t64|x64|p00|lnx|zip"
+supported_extensions = "d64|t64|x64|p00|lnx|lyx|zip"
 corename = "Frodo"
 license = "GPLv2"
 permissions = ""

--- a/dist/info/handy_libretro.info
+++ b/dist/info/handy_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Atari - Lynx (Handy)"
 authors = "K. Wilkins"
-supported_extensions = "lnx|o"
+supported_extensions = "lnx|lyx|o"
 corename = "Handy"
 
 # Hardware Information

--- a/dist/info/mednafen_lynx_libretro.info
+++ b/dist/info/mednafen_lynx_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Atari - Lynx (Beetle Lynx)"
 authors = "K. Wilkins|Mednafen Team"
-supported_extensions = "lnx|o"
+supported_extensions = "lnx|lyx|o"
 corename = "Beetle Lynx"
 license = "Zlib|GPLv2"
 permissions = ""


### PR DESCRIPTION
No-Intro updated their Lynx file extension to `.lyx`, so this pull request adds it as an accepted extension for Lynx-based cores.