### PR TITLE
Added m2000_libretro.info

### DIFF
--- a/dist/info/m2000_libretro.info
+++ b/dist/info/m2000_libretro.info
@@ -1,0 +1,31 @@
+# Core Information
+display_name = "Philips - P2000T (M2000)"
+authors = "Dion Olsthoorn|Marcel de Kogel"
+supported_extensions = "cas|p2000t"
+corename = "M2000"
+license = "GPLv3"
+permissions = ""
+display_version = "0.9"
+categories = "Emulator"
+
+# Hardware Information
+manufacturer = "Philips"
+systemname = "P2000T"
+systemid = "p2000t"
+
+# Libretro Features
+database = "Philips - P2000T"
+supports_no_game = "true"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "false"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "false"
+
+description = "M2000 is an emulator for the Philips P2000T home computer. Note that the keyboard works best in 'Game Focus' mode. Special keys: <ZOEK>: Shift + 1, <START>: Shift + 3 / Joypad Start, <STOP>: Shift + period / Joypad Select."


### PR DESCRIPTION
Hi Libretro team, I've ported the Philips P2000T emulator (M2000) to Libretro and now are looking for someone to talk to, so possibly my repo can be added to the Libretro CI/CD Gitlab server. The M2000 repo can be found here: https://github.com/p2000t/M2000 and contains a .gitlab-ci.yml file in the root.