### PR TITLE
Update swanstation_libretro.info

### DIFF
--- a/dist/info/swanstation_libretro.info
+++ b/dist/info/swanstation_libretro.info
@@ -20,7 +20,7 @@ hw_render = "true"
 required_hw_api = "OpenGL >= 3.0 | OpenGL Core >= 3.1 | Vulkan >= 1.0 | Direct3D >= 11.0"
 is_experimental = "false"
 savestate = "true"
-savestate_features = "serialized"
+savestate_features = "basic"
 input_descriptors = "true"
 disk_control = "true"
 


### PR DESCRIPTION
Rewind does not work with SwanStation, so it's better to just disable it.