### PR TITLE
Revert "Update swanstation_libretro.info"

### DIFF
--- a/dist/info/swanstation_libretro.info
+++ b/dist/info/swanstation_libretro.info
@@ -20,7 +20,7 @@ hw_render = "true"
 required_hw_api = "OpenGL >= 3.0 | OpenGL Core >= 3.1 | Vulkan >= 1.0 | Direct3D >= 11.0"
 is_experimental = "false"
 savestate = "true"
-savestate_features = "basic"
+savestate_features = "serialized"
 input_descriptors = "true"
 disk_control = "true"
 


### PR DESCRIPTION
As I commented on libretro/libretro-super#1823 rewind works perfectly fine on the Swanstation core. 
