### PR TITLE
Use the open source ps2dev compilers for Sony PS2

### DIFF
--- a/libretro-config.sh
+++ b/libretro-config.sh
@@ -528,8 +528,8 @@ case "$platform" in
 		FORMAT_COMPILER_TARGET=ps2
 		FORMAT_COMPILER_TARGET_ALT=ps2
 
-		CC="ee-gcc${BINARY_EXT}"
-		CXX="ee-g++${BINARY_EXT}"
+		CC="mips64r5900el-ps2-elf-gcc${BINARY_EXT}"
+		CXX="mips64r5900el-ps2-elf-g++${BINARY_EXT}"
 		;;
 
 	ctr)


### PR DESCRIPTION
Does anyone still use the ancient Sony PS2 SDK?

I had to change the definition of gcc and g++ for the PS2 before I could get libretro to build with the ps2dev toolchain:

https://github.com/ps2dev/ps2dev