### PR TITLE
Update m2000_libretro.info

### DIFF
--- a/dist/info/m2000_libretro.info
+++ b/dist/info/m2000_libretro.info
@@ -1,7 +1,7 @@
 # Core Information
 display_name = "Philips - P2000T (M2000)"
 authors = "Dion Olsthoorn|Marcel de Kogel"
-supported_extensions = "cas|p2000t"
+supported_extensions = "cas"
 corename = "M2000"
 license = "GPLv3"
 permissions = ""


### PR DESCRIPTION
M2000 only supports the .cas extension. The .p2000t extension was experimental, but turned out to be confusing and actually never used.