### PR TITLE
info: Enable savestate support for px68k

### DIFF
--- a/dist/info/px68k_libretro.info
+++ b/dist/info/px68k_libretro.info
@@ -16,7 +16,7 @@ systemid = "sharp_x68000"
 # Libretro Features
 supports_no_game = "true"
 database = "Sharp - X68000"
-savestate = "false"
+savestate = "true"
 cheats = "false"
 input_descriptors = "true"
 memory_descriptors = "false"


### PR DESCRIPTION
Suggested by @negativeExponent over at https://github.com/libretro/libretro-core-info/pull/69 .