### PR TITLE
MAME: Remove chd from valid extensions

### DIFF
--- a/dist/info/mame2000_libretro.info
+++ b/dist/info/mame2000_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Arcade (MAME 2000)"
 authors = "MAMEdev"
-supported_extensions = "zip|7z|chd"
+supported_extensions = "zip|7z"
 corename = "MAME 2000 (0.37b5)"
 license = "MAME"
 permissions = ""

--- a/dist/info/mame2009_libretro.info
+++ b/dist/info/mame2009_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Arcade (MAME 2009)"
 authors = "MAMEdev"
-supported_extensions = "zip|7z|chd"
+supported_extensions = "zip|7z"
 corename = "MAME 2009 (0.135u4)"
 license = "MAME"
 permissions = ""

--- a/dist/info/mame2010_libretro.info
+++ b/dist/info/mame2010_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Arcade (MAME 2010)"
 authors = "MAMEdev"
-supported_extensions = "zip|7z|chd"
+supported_extensions = "zip|7z"
 corename = "MAME 2010 (0.139)"
 license = "MAME"
 permissions = ""

--- a/dist/info/mame2015_libretro.info
+++ b/dist/info/mame2015_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Arcade (MAME 2015)"
 authors = "MAMEdev"
-supported_extensions = "zip|chd|7z|cmd"
+supported_extensions = "cmd|zip|7z"
 corename = "MAME 2015 (0.160)"
 license = "MAME"
 permissions = ""

--- a/dist/info/mame2016_libretro.info
+++ b/dist/info/mame2016_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Arcade (MAME 2016)"
 authors = "MAMEdev"
-supported_extensions = "zip|chd|7z|cmd"
+supported_extensions = "cmd|zip|7z"
 corename = "MAME 2016 (0.174)"
 license = "GPLv2+"
 permissions = ""

--- a/dist/info/mame_libretro.info
+++ b/dist/info/mame_libretro.info
@@ -2,7 +2,7 @@
 display_name = "Arcade (MAME)"
 categories = "Emulator"
 authors = "MAMEdev"
-supported_extensions = "zip|chd|7z|cmd"
+supported_extensions = "cmd|zip|7z"
 corename = "MAME"
 license = "GPLv2+"
 permissions = ""

--- a/dist/info/mamearcade_libretro.info
+++ b/dist/info/mamearcade_libretro.info
@@ -2,7 +2,7 @@
 display_name = "Arcade (MAME)"
 categories = "Emulator"
 authors = "MAMEdev"
-supported_extensions = "zip|chd|7z|cmd"
+supported_extensions = "cmd|zip|7z"
 corename = "MAME (Git)"
 license = "GPLv2+"
 permissions = ""

--- a/dist/info/mamemess_libretro.info
+++ b/dist/info/mamemess_libretro.info
@@ -2,7 +2,7 @@
 display_name = "Multi (MESS)"
 categories = "Emulator"
 authors = "MAMEdev"
-supported_extensions = "zip|chd|7z|cmd"
+supported_extensions = "cmd|zip|7z"
 corename = "MESS (Git)"
 license = "GPLv2+"
 permissions = ""


### PR DESCRIPTION
CHD does not belong in the extension list, since otherwise they get scanned for no reason, since they can not be used directly for launching.

Related: https://github.com/libretro/RetroArch/issues/16945