### PR TITLE
Add TamaLIBretro

### DIFF
--- a/build-config.sh
+++ b/build-config.sh
@@ -308,6 +308,7 @@ include_core_theodore
 include_core_vaporspec
 include_core_bk
 include_core_sameduck
+include_core_tamalibretro
 
 # -------------------------------------------------------------------------------------------------
 # Devkits

--- a/dist/info/tamalibretro_libretro.info
+++ b/dist/info/tamalibretro_libretro.info
@@ -1,0 +1,31 @@
+# Software Information
+display_name = "Bandai - Tamagotchi P1 (TamaLIBretro)"
+authors = "Jean-Christophe Rona, Keith Bourdon"
+supported_extensions = "b|bin|rom"
+corename = "TamaLIBretro"
+license = "GPL-2.0"
+permissions = ""
+display_version = "1.0"
+categories = "Emulator"
+
+# Hardware Information
+manufacturer = "Bandai"
+systemname = "Tamagotchi P1"
+systemid = "tamagotchi"
+
+# Libretro Features
+supports_no_game = "false"
+savestate = "true"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "false"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "false"
+disk_control = "false"
+is_experimental = "false"
+
+notes = "TamaLIB Copyright (C) 2021 Jean-Christophe Rona.|TamaLIBretro by Keith Bourdon.|TamaLIB and TamaLIBretro are distributed under the GPLv2 license.
+description = "A port of the TamaLIB emulator for first-generation Tamagotchi handhelds to libretro."

--- a/recipes/android/cores-android
+++ b/recipes/android/cores-android
@@ -103,6 +103,7 @@ snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC_JNI makefilelibretro ratufacoat/libretro/jni
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC_JNI Makefile jni
 stella libretro-stella https://github.com/stella-emu/stella.git master YES GENERIC_JNI Makefile src/libretro/jni
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC_JNI Makefile jni
 test libretro-samples https://github.com/libretro/libretro-samples.git master YES GENERIC_JNI Makefile tests/test/jni
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC_JNI Makefile jni
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC_JNI Makefile jni

--- a/recipes/apple/cores-ios-arm64-generic
+++ b/recipes/apple/cores-ios-arm64-generic
@@ -99,6 +99,7 @@ snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master YES GENERIC Makefile src/libretro
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-ios-generic
+++ b/recipes/apple/cores-ios-generic
@@ -98,6 +98,7 @@ snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master YES GENERIC Makefile src/libretro
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-ios9-generic
+++ b/recipes/apple/cores-ios9-generic
@@ -97,6 +97,7 @@ snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master YES GENERIC Makefile src/libretro
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 tyrquake libretro-tyrquake https://github.com/libretro/tyrquake.git master YES GENERIC Makefile .

--- a/recipes/apple/cores-osx-x64-generic
+++ b/recipes/apple/cores-osx-x64-generic
@@ -115,6 +115,7 @@ snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master YES GENERIC Makefile src/libretro
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DCMAKE_BUILD_TYPE="Release"

--- a/recipes/emscripten/emscripten
+++ b/recipes/emscripten/emscripten
@@ -69,6 +69,7 @@ snes9x libretro-snes9x https://github.com/libretro/snes9x.git master YES GENERIC
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master YES GENERIC Makefile src/libretro
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 test libretro-samples https://github.com/libretro/libretro-samples.git master YES GENERIC Makefile tests/test
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-arm7neonhf
+++ b/recipes/linux/cores-linux-arm7neonhf
@@ -108,6 +108,7 @@ snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master YES GENERIC Makefile src/libretro
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 test libretro-samples https://github.com/libretro/libretro-samples.git master YES GENERIC Makefile tests/test
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-armhf-generic
+++ b/recipes/linux/cores-linux-armhf-generic
@@ -107,6 +107,7 @@ snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master YES GENERIC Makefile src/libretro
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 test libretro-samples https://github.com/libretro/libretro-samples.git master YES GENERIC Makefile tests/test
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -146,6 +146,7 @@ squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.g
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master YES GENERIC Makefile src/os/libretro
 swanstation libretro-swanstation https://github.com/libretro/swanstation.git main YES CMAKE Makefile build -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBRETRO_CORE=ON
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 thepowdertoy libretro-thepowdertoy https://github.com/libretro/ThePowderToy.git master YES CMAKE Makefile build -DCMAKE_BUILD_TYPE=Release

--- a/recipes/linux/cores-linux-x86-generic
+++ b/recipes/linux/cores-linux-x86-generic
@@ -120,6 +120,7 @@ snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master YES GENERIC Makefile src/libretro
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 test libretro-samples https://github.com/libretro/libretro-samples.git master YES GENERIC Makefile tests/test
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .

--- a/recipes/nintendo/3ds
+++ b/recipes/nintendo/3ds
@@ -66,6 +66,7 @@ snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master NO GENERIC Makefile src/libretro
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 test libretro-samples https://github.com/libretro/libretro-samples.git master YES GENERIC Makefile tests/test
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .

--- a/recipes/nintendo/libnx
+++ b/recipes/nintendo/libnx
@@ -75,6 +75,7 @@ snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master YES GENERIC Makefile src/libretro
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 test libretro-samples https://github.com/libretro/libretro-samples.git master YES GENERIC Makefile tests/test
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .

--- a/recipes/playstation/vita
+++ b/recipes/playstation/vita
@@ -69,6 +69,7 @@ snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master NO GENERIC Makefile src/libretro
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 test libretro-samples https://github.com/libretro/libretro-samples.git master YES GENERIC Makefile tests/test
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .

--- a/recipes/windows/cores-windows-x64_seh-generic
+++ b/recipes/windows/cores-windows-x64_seh-generic
@@ -125,6 +125,7 @@ snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master YES GENERIC Makefile src/libretro
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .
 tic80 libretro-tic80 https://github.com/nesbox/TIC-80.git master YES CMAKE Makefile build -G\"Unix Makefiles\" -DBUILD_PLAYER=OFF -DBUILD_SOKOL=OFF -DBUILD_SDL=OFF -DBUILD_DEMO_CARTS=OFF -DBUILD_LIBRETRO=ON

--- a/recipes/windows/cores-windows-x86_dw2-generic
+++ b/recipes/windows/cores-windows-x86_dw2-generic
@@ -123,6 +123,7 @@ snes9x2010 libretro-snes9x2010 https://github.com/libretro/snes9x2010.git master
 stella2014 libretro-stella2014 https://github.com/libretro/stella2014-libretro.git master YES GENERIC Makefile .
 stella libretro-stella https://github.com/stella-emu/stella.git master YES GENERIC Makefile src/libretro
 squirreljme libretro-squirreljme https://github.com/XerTheSquirrel/SquirrelJME.git trunk YES GENERIC makefilelibretro ratufacoat
+tamalibretro libretro-tamalibretro https://github.com/celerizer/tamalibretro.git master YES GENERIC Makefile .
 test libretro-samples https://github.com/libretro/libretro-samples.git master YES GENERIC Makefile tests/test
 tgbdual libretro-tgbdual https://github.com/libretro/tgbdual-libretro.git master YES GENERIC Makefile .
 theodore libretro-theodore https://github.com/Zlika/theodore.git master YES GENERIC Makefile .

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1519,6 +1519,14 @@ libretro_quasi88_name="QUASI88"
 libretro_quasi88_git_url="https://github.com/libretro/quasi88-libretro.git"
 libretro_quasi88_build_makefile="Makefile"
 
+include_core_tamalibretro() {
+	register_module core "tamalibretro"
+}
+libretro_tamalibretro_name="TamaLIBretro"
+libretro_tamalibretro_git_url="https://github.com/celerizer/tamalibretro.git"
+libretro_tamalibretro_git_submodules="yes"
+libretro_tamalibretro_build_makefile="Makefile"
+
 include_core_ep128emu_core() {
 	register_module core "ep128emu_core"
 }


### PR DESCRIPTION
I added this core for the appropriate targets one of my other cores builds for, aside from big-endian consoles as I suspect there will be endianness issues. Please let me know if there is anything else that needs to be done to add it (I haven't touched these build scripts in a while).

TamaLIBretro is an implementation of TamaLIB, an emulator for first-generation Tamagotchi handhelds.

https://github.com/celerizer/tamalibretro
https://github.com/jcrona/tamalib