### PR TITLE
Add the new Holani core

### DIFF
--- a/dist/info/holani_libretro.info
+++ b/dist/info/holani_libretro.info
@@ -1,0 +1,39 @@
+# Software Information
+display_name = "Atari - Lynx (Holani)"
+authors = "https://github.com/LLeny"
+supported_extensions = "lnx|o"
+corename = "Holani"
+
+# Hardware Information
+manufacturer = "Atari"
+categories = "Emulator"
+systemname = "Lynx"
+systemid = "atari_lynx"
+database = "Atari - Lynx"
+license = "GPLv3"
+permissions = ""
+display_version = "0.6.0"
+
+# Libretro Features
+supports_no_game = "false"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "false"
+input_descriptors = "false"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "false"
+core_options_version = "1.0"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "false"
+disk_control = "false"
+
+# BIOS / Firmware
+firmware_count = 1
+firmware0_desc = "lynxboot.img (Lynx Boot Image)"
+firmware0_path = "lynxboot.img"
+firmware0_md5 = "fcd403db69f54290b51035d82f835e7b"
+firmware0_opt = "true"
+
+description = "This core's primary goal is to get closer to the Lynx hardware and provide a better emulation experience than the current Handy ports."


### PR DESCRIPTION
[Holani](https://github.com/LLeny/holani-retro) is a new cycle stepped Atari Lynx emulator made in rust. It is not a Handy port.
Its end goal is to get closer to the Lynx hardware to provide a more accurate emulation.
The current Gitlab CI should create the following targets:
* linux-x86_64
* windows-x86_64
* osx-x86_64
* osx-aarch64
* android-arm64-v8a
* android-armeabi-v7a

However, only the linux and windows cores have been tested at this point.
