### PR TITLE
Add info file for experimental vidtest core

### DIFF
--- a/dist/info/vidtest_libretro.info
+++ b/dist/info/vidtest_libretro.info
@@ -1,0 +1,26 @@
+# Software Information
+display_name = "VidTest"
+authors = "Psyraven"
+corename = "vidtest"
+categories = "Test"
+license = "GPLv2"
+display_version = "0.1"
+
+# Libretro Features
+supports_no_game = "true"
+is_experimental = "true"
+input_descriptors = "true"
+savestate = "false"
+savestate_features = "null"
+libretro_saves = "false"
+cheats = "false"
+memory_descriptors = "false"
+core_options = "false"
+core_options_version = "2.0"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "false"
+disk_control = "false"
+needs_kbd_mouse_focus = "false"
+
+description = "Video mode and input test core"


### PR DESCRIPTION
vidtest_libretro is a test core to test video modes, aspect ratios and input states.

It has a simple interface which can be controlled via mouse, retropad or touch screen to set a custom resolution, custom aspect ratio, custom frame rate and custom sample rate. That can then be used to test things like scaling of various modes in a frontend or to test how input behaves.

It can be found at https://github.com/schellingb/vidtest_libretro

Screenshot:
![image](https://github.com/user-attachments/assets/567d77ce-bf81-491a-89ee-89e25da95cc1)
