### PR TITLE
Update display name in atari800 info file

### DIFF
--- a/dist/info/atari800_libretro.info
+++ b/dist/info/atari800_libretro.info
@@ -1,5 +1,5 @@
 # Software Information
-display_name = "Atari - 5200 (Atari800)"
+display_name = "Atari - 400/800/600XL/800XL/130XE/5200 (Atari800)"
 authors = "Petr Stehlik"
 supported_extensions = "xfd|atr|dcm|cas|bin|a52|zip|atx|car|rom|com|xex|m3u"
 corename = "Atari800"


### PR DESCRIPTION
## Description

This PR updates the display name for the atari800 emulator. It was shortened to "Atari - 5200 (Atari800)" when display names were converted from long strings to `platform (name)` in commit: https://github.com/libretro/libretro-super/commit/bd7bc168d3da8497a30aa63d22abe4fbe0c46e9a#diff-14dad692fb490fa8582eadfc12c41eced0ee17849104e388c84f0ac55230bd0eL1-R1


```patch
-Atari 8-bit computer systems and 5200 (Atari800)
+Atari - 5200 (Atari800)
```

However, according to the Atari 800 "Features" page (https://atari800.github.io/features.html), atari800 supports "Atari 400, 800, 600 XL, 800XL, 130XE, 5200 Games System".

So a better name for the atari800 core would be:

* `Atari - 400/800/600XL/800XL/130XE/5200 (Atari800)`

## Screenshots

Before:

<img width="1267" alt="Screenshot 2024-12-26 at 6 35 14 PM" src="https://github.com/user-attachments/assets/3efa939e-352a-4f5e-a3fd-9d76330660de" />

After:

<img width="1273" alt="Screenshot 2024-12-26 at 6 21 02 PM" src="https://github.com/user-attachments/assets/9e42a66b-b694-4722-a01c-3bda38a013c4" />