### PR TITLE
Update Beetle Wonderswan name

### DIFF
--- a/dist/info/mednafen_wswan_libretro.info
+++ b/dist/info/mednafen_wswan_libretro.info
@@ -1,5 +1,5 @@
 # Software Information
-display_name = "Bandai - WonderSwan/Color (Beetle Cygne)"
+display_name = "Bandai - WonderSwan/Color (Beetle Wonderswan)"
 authors = "Dox|Mednafen Team"
 supported_extensions = "ws|wsc|pc2|pcv2"
 corename = "Beetle WonderSwan"


### PR DESCRIPTION
## Description

This PR fixes the name of Beetle Wonderswan. The core was forked from Cygne when it was integrated into Mednafen.
