### PR TITLE
Update pcsx2_libretro.info

### DIFF
--- a/dist/info/pcsx2_libretro.info
+++ b/dist/info/pcsx2_libretro.info
@@ -25,10 +25,13 @@ savestate_features = "basic"
 memory_descriptors = "false"
 
 # Firmware / BIOS
-firmware_count = 1
+firmware_count = 2
 firmware0_desc = "'pcsx2/bios' folder"
 firmware0_path = "pcsx2/bios"
 firmware0_opt = "false"
-notes = "[1] This only checks if the PCSX2 'bios' folder exists and is in the correct location.|[2] Because the core doesn't require any specific filename for the BIOS files,|[^] this info file cannot tell you if the content of your 'bios' folder is correct or not.|[3] Please check https://docs.libretro.com/library/pcsx2/#bios for more details."
+firmware1_desc = "pcsx2/resources/GameIndex.yaml (Game Database)"
+firmware1_path = "pcsx2/resources/GameIndex.yaml"
+firmware1_opt = "false"
+notes = "[1] This only checks if the PCSX2 'bios' folder exists and is in the correct location.|[2] Because the core doesn't require any specific filename for the BIOS files,|[^] this info file cannot tell you if the content of your 'bios' folder is correct or not.|[3] Please check https://docs.libretro.com/library/pcsx2/#bios for more details.|[4] The 'GameIndex.yaml' file can be downloaded from the Online Updater.|[^] It contains fixes for a lot of games and is mandatory|[^] for best compatibility. Some games may not even boot without it."
 
 description = "A hard fork/derivative of the mature and highly-compatible PCSX2 Playstation 2 emulator to libretro. This core is a good first choice for most users as compared with the Play! core, which has lower compatibility with the PS2 library. Required BIOS files include EROM.BIN, rom1.bin, and at least one set of scph*.bin/.mec/.nvm dumps that match each region of games you wish to run. A newer BIOS than scph10000 is recommended, as this original BIOS has problems in memory card emulation and other sections."


### PR DESCRIPTION
Adds a "GameIndex.yaml" check and a small description:

![image](https://github.com/user-attachments/assets/b6900be0-217b-4116-9627-588b46b2f9c5)

I marked it as required, although this isn't entirely true the file is soooo important that I feel like it would be very misleading to mark it as optional.

**edit:** My English isn't the best, if you have a better description please let me know, I'll update the PR :p 