### PR TITLE
info: Update data for ChaiLove

### DIFF
--- a/dist/info/chailove_libretro.info
+++ b/dist/info/chailove_libretro.info
@@ -6,7 +6,7 @@ corename = "ChaiLove"
 categories = "Game engine"
 license = "MIT"
 permissions = ""
-display_version = "1.3.0"
+display_version = "2.0.0"
 
 # Hardware Information
 manufacturer = "N/A"
@@ -26,7 +26,7 @@ core_options = "true"
 core_options_version = "1.0"
 load_subsystem = "false"
 hw_render = "false"
-needs_fullpath = "true"
+needs_fullpath = "false"
 disk_control = "false"
 is_experimental = "false"
 


### PR DESCRIPTION
ChaiLove 2.0 is out. No longer needs the full path to the files.