### PR TITLE
Add DICE to rules, convenience update for libretro-fetch

### DIFF
--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1822,6 +1822,12 @@ include_core_vidtest() {
 libretro_vidtest_name="vidtest"
 libretro_vidtest_git_url="https://github.com/schellingb/vidtest_libretro.git"
 
+include_core_dice() {
+	register_module core "dice"
+}
+libretro_dice_name="dice"
+libretro_dice_git_url="https://github.com/mittonk/dice-libretro.git"
+
 
 # CORE RULE VARIABLES
 #

--- a/script-modules/fetch-rules.sh
+++ b/script-modules/fetch-rules.sh
@@ -14,18 +14,31 @@ fetch_git() {
 	if [ -d "$fetch_dir/.git" ]; then
 		echo_cmd "cd \"$fetch_dir\""
 		echo_cmd "git pull"
+		if [ $? -ne 0 ]; then
+			return 1
+		fi
 		if [ "$3" = "yes" ]; then
 			echo_cmd "git submodule foreach git pull origin master"
+			if [ $? -ne 0 ]; then
+				return 1
+			fi
 		fi
 	else
 		clone_type=
 		[ -n "$SHALLOW_CLONE" ] && depth="--depth 1 "
 		echo_cmd "git clone $depth\"$1\" \"$WORKDIR/$2\""
+		if [ $? -ne 0 ]; then
+			return 1
+		fi
 		if [[ "$3" = "yes" || "$3" = "clone" ]]; then
 			echo_cmd "cd \"$fetch_dir\""
 			echo_cmd "git submodule update --init --recursive"
+			if [ $? -ne 0 ]; then
+				return 1
+			fi
 		fi
 	fi
+	return $?
 }
 
 # fetch_revision_git: Output the hash of the last commit in a git repository


### PR DESCRIPTION
DICE added to core-rules.sh

There was already a summary function for building cores, it is now adapted to the fetch as well, as it could fail in numerous ways, especially when updating a lot of cores from existing checkouts where submodules have changed, etc., it is handy to have a summary at the end:
```
1 core(s) successfully processed:
	picodrive
```