### PR TITLE
Differentiate split MAME core display names

### DIFF
--- a/dist/info/mamearcade_libretro.info
+++ b/dist/info/mamearcade_libretro.info
@@ -1,5 +1,5 @@
 # Software Information
-display_name = "Arcade (MAME)"
+display_name = "Arcade (MAME/Arcade)"
 categories = "Emulator"
 authors = "MAMEdev"
 supported_extensions = "cmd|zip|7z"

--- a/dist/info/mamemess_libretro.info
+++ b/dist/info/mamemess_libretro.info
@@ -1,5 +1,5 @@
 # Software Information
-display_name = "Multi (MESS)"
+display_name = "Multi (MAME/MESS)"
 categories = "Emulator"
 authors = "MAMEdev"
 supported_extensions = "cmd|zip|7z"


### PR DESCRIPTION
Since the non-split MAME is also named as `Arcade (MAME)` let's make it more clear that the split versions are not complete MAME. And for also showing both cores when searching for "MAME".

