### PR TITLE
Add a webOS platform target

### DIFF
--- a/libretro-build-webos.sh
+++ b/libretro-build-webos.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+# vim: set ts=3 sw=3 noet ft=sh : bash
+
+SCRIPT="${0#./}"
+BASE_DIR="${SCRIPT%/*}"
+WORKDIR="$PWD"
+
+if [ "$BASE_DIR" = "$SCRIPT" ]; then
+	BASE_DIR="$WORKDIR"
+else
+	if [[ "$0" != /* ]]; then
+		# Make the path absolute
+		BASE_DIR="$WORKDIR/$BASE_DIR"
+	fi
+fi
+
+platform=webos ${BASE_DIR}/libretro-build.sh $@

--- a/libretro-config.sh
+++ b/libretro-config.sh
@@ -678,6 +678,19 @@ case "$platform" in
 		CXX11="clang++ -std=c++11 -stdlib=libc++ -miphoneos-version-min=5.0"
 
 		;;
+        webos)
+		DIST_DIR="webos"
+		FORMAT_EXT=so
+		FORMAT_COMPILER_TARGET=webos
+
+		# Makefile.libretro per core will need a webos section, but for now:
+		WEBOS_CFLAGS="-mcpu=cortex-a9 -mtune=cortex-a53 -mfloat-abi=softfp"
+
+		CC="arm-webos-linux-gnueabi-gcc $WEBOS_CFLAGS"
+		CXX="arm-webos-linux-gnueabi-g++ $WEBOS_CFLAGS"
+		CXX11="arm-webos-linux-gnueabi-g++ -std=c++11 -stdlib=libc++ $WEBOS_CFLAGS"
+		CXX17="arm-webos-linux-gnueabi-g++ -std=c++17 -stdlib=libc++ $WEBOS_CFLAGS"
+		;;
 
 	##
 	## Original libretro-config path


### PR DESCRIPTION
Add a target for webOS. This will allow us to add the necessary platform to Makefile.libretro in relevant cores.

Needed for automated scripts.