### PR TITLE
add gba to supported noods extensions

### DIFF
--- a/dist/info/noods_libretro.info
+++ b/dist/info/noods_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Nintendo - DS (NooDS)"
 authors = "Hydr8gon|Jonian Guveli"
-supported_extensions = "nds"
+supported_extensions = "nds|gba"
 corename = "NooDS"
 license = "GPLv3"
 permissions = "microphone_optional"


### PR DESCRIPTION
closes https://github.com/libretro/RetroArch/issues/18063