### PR TITLE
Fix cmake parameter for EasyRPG.

### DIFF
--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -252,10 +252,9 @@ include_core_easyrpg() {
 }
 libretro_easyrpg_name="EasyRPG"
 libretro_easyrpg_git_url="https://github.com/EasyRPG/Player.git"
-libretro_easyrpg_build_subdir="build"
 libretro_easyrpg_git_submodules="yes"
-libretro_easyrpg_post_fetch_cmd="cmake . -DPLAYER_TARGET_PLATFORM=libretro -t build"
-libretro_easyrpg_build_makefile="Makefile"
+libretro_easyrpg_build_rule="cmake"
+libretro_easyrpg_build_args="-DPLAYER_TARGET_PLATFORM=libretro -DBUILD_SHARED_LIBS=ON"
 
 include_core_gme() {
 	register_module core "gme" -ngc -ps3 -psp1 -wii


### PR DESCRIPTION
Fixes #1897 by bringing the procedure in line with https://github.com/EasyRPG/Player/blob/master/docs/BUILDING.md#libretro-core

In general, building will need more actions, since liblcf is required and it is a part of EasyRPG. The libretro repo does more magic in the [buildbot script](https://github.com/libretro/easyrpg-libretro/blob/master/.gitlab-ci.yml) to get that, but that repo is indicated as not supported for manual building, so I guess it is better if this script refers to the original.