### PR TITLE
Add Videoton TV-Computer database support via ep128emu.

### DIFF
--- a/dist/info/ep128emu_core_libretro.info
+++ b/dist/info/ep128emu_core_libretro.info
@@ -154,7 +154,7 @@ supports_no_game = "true"
 # Does the core have a single purpose? Does it represent one game or application, requiring predetermined support files or no external data? Used to indicate to a frontend that the core may be presented/handled independently from 'regular' cores that run a variety of content.
 single_purpose = "false"
 # Name of the database that the core supports (optional):
-database = "Enterprise - 128|Amstrad - CPC|Sinclair - ZX Spectrum"
+database = "Enterprise - 128|Amstrad - CPC|Sinclair - ZX Spectrum|Videoton - TV-Computer"
 # Does the core support/require support for libretro-gl or other hardware-acceleration in the frontend?
 hw_render = "false"
 # Which hardware-rendering APIs does the core support? Delimited by pipe characters.

--- a/libretro-build-database.sh
+++ b/libretro-build-database.sh
@@ -383,6 +383,7 @@ build_libretro_databases() {
 	build_libretro_database "MicroW8" "rom.crc"
 	build_libretro_database "Spectravideo - SVI-318 - SVI-328" "rom.crc"
 	build_libretro_database "PICO-8" "rom.crc"
+	build_libretro_database "Videoton - TV-Computer" "rom.crc"
 }
 
 build_libretrodb


### PR DESCRIPTION
Needs https://github.com/libretro/libretro-database/pull/1574 first to be merged. Tested locally, scanning works.