### PR TITLE
Fix Play! clone as branch is now main not master for a submodule

### DIFF
--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1316,7 +1316,7 @@ libretro_play_name="Play!"
 libretro_play_git_url="https://github.com/libretro/Play-.git"
 libretro_play_git_submodules="yes"
 libretro_play_build_opengl="yes"
-libretro_play_post_fetch_cmd="cd .. && git clone https://github.com/jpd002/Play-.git Play_tmp && cd Play_tmp && git submodule update -q --init --recursive && git submodule foreach \"git checkout -q master\" && cd deps && git submodule update --init && cd ../.. && rm -rf Play_tmp/Play && mv libretro-play/ Play_tmp/Play && mv Play_tmp libretro-play"
+libretro_play_post_fetch_cmd="cd .. && git clone https://github.com/jpd002/Play-.git Play_tmp && cd Play_tmp && git submodule update -q --init --recursive && git submodule foreach 'branch=\$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed s@^origin/@@); git checkout -q \"\$branch\"' && cd deps && git submodule update --init && cd ../.. && rm -rf Play_tmp/Play && mv libretro-play/ Play_tmp/Play && mv Play_tmp libretro-play"
 libretro_play_subdir="libretro-play/Play/build_retro"
 
 include_core_prosystem() {


### PR DESCRIPTION
A submodule used by Play! is https://github.com/altstoreio/AltKit. Its main branch is now "main" not "master" so it doesn't fetch without this fix.