### PR TITLE
Include irogb within info files and core rules

### DIFF
--- a/dist/info/irogb_libretro.info
+++ b/dist/info/irogb_libretro.info
@@ -1,0 +1,31 @@
+# Software Information
+display_name = "Nintendo - Game Boy / Color (IroGB)"
+authors = "Alex Sutila/Xuanli Lin"
+supported_extensions = "gb|gbc|dmg|cgb"
+corename = "IroGB"
+categories = "Emulator"
+license = "GPLv3"
+permissions = ""
+display_version = "v1.0.0"
+
+# Hardware Information
+manufacturer = "Nintendo"
+systemname = "Game Boy/Game Boy Color"
+systemid = "game_boy"
+
+# Libretro Features
+supports_no_game = "false"
+database = "Nintendo - Game Boy|Nintendo - Game Boy Color"
+savestate = "true"
+savestate_features = "deterministic"
+
+# Firmware info
+firmware_count = 2
+firmware0_desc = "dmg_boot.bin (DMG-BIOS)"
+firmware0_path = "dmg_boot.bin"
+firmware0_opt = "true"
+firmware1_desc = "cgb_bios.bin (CGB-BIOS)"
+firmware1_path = "cgb_bios.bin"
+firmware1_opt = "true"
+
+description = "A libretro port of the IroGB Game Boy Color emulator. IroGB is a reasonably accurate CGB emulator core that operates on a clock-cycle-stepped model and passes over 95% of the test cases across three of the most widely used GB/GBC emulator test suites (mooneye/blargg/acid), with improved test coverage yet to come. The project was developed as a passion project, aiming to balance emulation accuracy with practical system requirements."

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -286,6 +286,14 @@ libretro_fixgb_name="fixGB"
 libretro_fixgb_git_url="https://github.com/libretro/fixGB.git"
 libretro_fixgb_build_subdir="libretro"
 
+include_core_irogb() {
+	register_module core "irogb"
+}
+libretro_irogb_name="iroGB"
+libretro_irogb_git_url="https://github.com/AlexSutila/IroGB.git"
+libretro_dolphin_build_rule="cmake"
+libretro_dolphin_build_args="-DBUILD_LIBRETRO=ON -DNO_CORE_FILESYSTEM=ON"
+
 include_core_snes9x2002() {
 	register_module core "snes9x2002" -ngc -ps3 -psp1 -wii
 }


### PR DESCRIPTION
Brings in support for IroGB by including the [.info](https://github.com/AlexSutila/IroGB/blob/release/irogb_libretro.info) file and adding an entry into `core-rules.sh` to support compatability with libretro-fetch.

Other links that may be useful:
- Showcase of builds succeeding leveraging existing libretro CI: https://git.libretro.com/warmenhoven/irogb/-/pipelines/55997
- Original repository: https://github.com/AlexSutila/IroGB

Thanks!