### PR TITLE
Update build arguments for AppleWin

### DIFF
--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1817,7 +1817,7 @@ libretro_applewin_name="AppleWin"
 libretro_applewin_git_url="https://github.com/audetto/AppleWin.git"
 libretro_applewin_git_submodules="yes"
 libretro_applewin_build_rule="cmake"
-libretro_applewin_build_args="-DBUILD_LIBRETRO=ON -G Ninja"
+libretro_applewin_build_args="-DBUILD_LIBRETRO=ON -DENABLE_NETWORKING=OFF -G Ninja"
 libretro_applewin_build_extradir="source/frontends/libretro/"
 
 include_core_panda3ds() {


### PR DESCRIPTION
Disable networking support in AppleWin build, to reduce library dependencies.