### PR TITLE
Update mupen64plus to use different filenames for GLES 2 and 3

### DIFF
--- a/dist/info/mupen64plus_next_gles2_libretro.info
+++ b/dist/info/mupen64plus_next_gles2_libretro.info
@@ -1,7 +1,7 @@
 display_name = "Nintendo - Nintendo 64 (Mupen64Plus-Next GLES2)"
 authors = "m4xw|Hacktarux|gonetz|GLideN64 Contributors|Mupen64Plus Team"
 supported_extensions = "n64|v64|z64|ndd|bin|u1"
-corename = "Mupen64Plus-Next"
+corename = "mupen64plus_next_gles2"
 license = "GPLv2"
 permissions = "dynarec_optional"
 display_version = "1.0"

--- a/dist/info/mupen64plus_next_gles3_libretro.info
+++ b/dist/info/mupen64plus_next_gles3_libretro.info
@@ -1,7 +1,7 @@
 display_name = "Nintendo - Nintendo 64 (Mupen64Plus-Next GLES3)"
 authors = "m4xw|Hacktarux|gonetz|GLideN64 Contributors|Mupen64Plus Team"
 supported_extensions = "n64|v64|z64|ndd|bin|u1"
-corename = "Mupen64Plus-Next"
+corename = "mupen64plus_next_gles3"
 license = "GPLv2"
 permissions = "dynarec_optional"
 display_version = "1.0"


### PR DESCRIPTION
The gitlab CI builds the GLES 2 and GLES 3 versions but they have the same name so they cannot be distinguished in core downloader (only 1 is visible I think as it is overwritten).

See:
https://github.com/libretro/mupen64plus-libretro-nx/blob/develop/.gitlab-ci.yml#L115

This PR updates the GLES 2 and GLES 3 versions to have different filenames so they can both be offered for download depending on the users hardware. Applies to Linux, Android and webOS:

https://github.com/libretro/mupen64plus-libretro-nx/pull/609/changes