### PR TITLE
virtualjaguar: bump info to v2.2.0

### DIFF
--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -1,11 +1,11 @@
 # Software Information
 display_name = "Atari - Jaguar (Virtual Jaguar)"
-authors = "David Raingeard|Shamus"
+authors = "David Raingeard|Shamus|Joseph Mattiello"
 supported_extensions = "j64|jag|rom|abs|cof|bin|prg"
 corename = "Virtual Jaguar"
 license = "GPLv3"
 permissions = ""
-display_version = "v2.1.0"
+display_version = "v2.2.0"
 categories = "Emulator"
 
 # Hardware Information
@@ -16,8 +16,9 @@ systemid = "atari_jaguar"
 # Libretro Features
 supports_no_game = "false"
 database = "Atari - Jaguar"
-savestate = "false"
-cheats = "false"
+savestate = "true"
+savestate_features = "2"
+cheats = "true"
 input_descriptors = "true"
 memory_descriptors = "true"
 libretro_saves = "true"
@@ -28,4 +29,4 @@ needs_fullpath = "false"
 disk_control = "false"
 is_experimental = "false"
 
-description = "A port of the Virtual Jaguar emulator, which itself is based on Potato Emulation, to libretro. This core has known issues with a number of popular games, but it still represents the state of the art for open source Atari Jaguar emulation at the time of this writing. It is quite demanding but also includes a core option--Fast Blitter--that forces the use of an older, less compatible but faster blitter, though some games will not work properly with this option enabled."
+description = "A port of the Virtual Jaguar emulator, originally based on Potato Emulation, to libretro. The accurate blitter is SIMD-accelerated (SSE2 on x86, NEON on ARM), and a Fast Blitter core option is available that trades some accuracy for additional speed on lower-end hardware. Supports a high-level BIOS that lets most commercial titles boot without a real BIOS image, plus save states, SRAM, cheat codes, and RetroAchievements."


### PR DESCRIPTION
Mirrors `dist/info/virtualjaguar_libretro.info` from libretro/virtualjaguar-libretro at tag [v2.2.0](https://github.com/libretro/virtualjaguar-libretro/releases/tag/v2.2.0).

Changes vs the on-file v2.1.0 entry:

- `display_version`: v2.1.0 → v2.2.0
- `authors`: appended "Joseph Mattiello"
- `savestate`: false → true
- `savestate_features`: 2 (deterministic for run-ahead)
- `cheats`: false → true
- `description`: shortened, mentions HLE BIOS / save states / SRAM / cheats / RetroAchievements

Memory-map / RetroAchievements wiring is exercised in CI by `test/tools/test_memory_map` and `test/tools/test_rcheevos_e2e` (the latter links rcheevos and verifies `rc_libretro_memory_init(RC_CONSOLE_ATARI_JAGUAR)` resolves the same bytes as host RAM).