### PR TITLE
atari800: bump info to 5.2.0, fix ATARIOSB.ROM md5

### DIFF
--- a/dist/info/atari800_libretro.info
+++ b/dist/info/atari800_libretro.info
@@ -11,7 +11,7 @@ permissions = ""
 manufacturer = "Atari"
 systemname = "Atari 8-bit Family"
 systemid = "atari_5200"
-display_version = "3.1.0"
+display_version = "5.2.0"
 
 # Libretro Features
 database = "Atari - 5200|Atari - 8-bit Family"
@@ -54,6 +54,6 @@ firmware5_opt = "true"
 firmware6_desc = "XEGAME.ROM (Atari XEGS Missile Command)"
 firmware6_path = "XEGAME.ROM"
 firmware6_opt = "true"
-notes = "(!) 5200.rom (md5): 281f20ea4320404ec820fb7ec0693b38|(!) ATARIBAS.ROM (md5): 0bac0c6a50104045d902df4503a4c30b|(!) ATARIOSA.ROM (md5): eb1f32f5d9f382db1bbfb8d7f9cb343a|(!) ATARIOSB.ROM (md5): a3e8d617c95d08031fe1b20d541434b2|(!) ATARIXL.ROM (md5): 06daac977823773a3eea3422fd26a703|(!) BB01R4_OS.ROM (md5): b7a2a04677d34f069eeb643d5238bf86|(!) XEGAME.ROM (md5): d7eb37aec6960cba36bc500e0e5d00bc"
+notes = "(!) 5200.rom (md5): 281f20ea4320404ec820fb7ec0693b38|(!) ATARIBAS.ROM (md5): 0bac0c6a50104045d902df4503a4c30b|(!) ATARIOSA.ROM (md5): eb1f32f5d9f382db1bbfb8d7f9cb343a|(!) ATARIOSB.ROM (md5): 4177f386a3bac989a981d3fe3388cb6c|(!) ATARIXL.ROM (md5): 06daac977823773a3eea3422fd26a703|(!) BB01R4_OS.ROM (md5): b7a2a04677d34f069eeb643d5238bf86|(!) XEGAME.ROM (md5): d7eb37aec6960cba36bc500e0e5d00bc"
 
 description = "A port of the free and portable Atari800 emulator to libretro. This core supports games and programs written for the Atari 8-bit computers (400, 800, 600 XL, 800XL, 130XE) and 5200 console. When loaded, the core should boot to the Atari Computer - Memo Pad screen and will generate a .atari800.cfg config file in the frontend's home directory and will add the required BIOS files it detects in the frontend's system directory to the config file. Once that is done, users may manually select which Atari system to emulate through the Atari System core option. These and other options can also be modified through the core's own menu, accessible through the retrokeyboard's F1 key."


### PR DESCRIPTION
## Summary

Sync `dist/info/atari800_libretro.info` with the file shipped by [libretro-atari800](https://github.com/libretro/libretro-atari800).

- `display_version` 3.1.0 → 5.2.0 to track the core update merged in libretro/libretro-atari800#123 (2026-05). The core's bundled `.info` already advertises 5.2.0; the dist copy still says 3.1.0.
- `ATARIOSB.ROM` md5 `a3e8d617...` → `4177f386...`. The previous hash pointed at a wrong/older dump; the correct one was committed to the core in libretro/libretro-atari800#115. Users with the canonical Atari OS B ROM were not matching the BIOS check.

`systemname` / `display_name` / `database` are left at the existing dual `Atari - 5200 | Atari - 8-bit Family` form. A companion PR (libretro/libretro-atari800#129) realigns the core's bundled `.info` to match this layout — once that lands the two files will be byte-identical aside from comments.
