### PR TITLE
Add nuance (VM Labs NUON) core info

### DIFF
--- a/dist/info/nuance_libretro.info
+++ b/dist/info/nuance_libretro.info
@@ -1,0 +1,47 @@
+# Software Information
+display_name = "VM Labs - NUON (Nuance)"
+authors = "Mike Perry|Carsten Waechter|WizzardSK"
+supported_extensions = "run|cof|nuon|cd|iso|img"
+corename = "Nuance"
+categories = "Emulator"
+license = "Non-commercial"
+permissions = ""
+display_version = "0.6.7"
+
+# Hardware Information
+manufacturer = "VM Labs"
+systemname = "NUON"
+systemid = "nuon"
+
+# Libretro Features
+database = "VM Labs - NUON"
+supports_no_game = "false"
+hw_render = "true"
+required_hw_api = "OpenGL >= 2.1"
+needs_fullpath = "true"
+disk_control = "false"
+savestate = "false"
+savestate_features = "null"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "false"
+core_options_version = "null"
+load_subsystem = "false"
+is_experimental = "true"
+
+# Firmware / BIOS
+firmware_count = 3
+firmware0_desc = "bios.cof (NUON main BIOS, shipped with the emulator)"
+firmware0_path = "nuance/bios.cof"
+firmware0_opt = "false"
+firmware1_desc = "minibios.cof (NUON minibios for MPEs 0-2)"
+firmware1_path = "nuance/minibios.cof"
+firmware1_opt = "false"
+firmware2_desc = "minibiosX.cof (NUON extended minibios)"
+firmware2_path = "nuance/minibiosX.cof"
+firmware2_opt = "false"
+notes = "The bios.cof / minibios.cof / minibiosX.cof files are clean-room emulator stubs that ship with the Nuance source distribution (NOT proprietary firmware dumps). They must be copied into <system>/nuance/ before loading a game."
+
+description = "Nuance is a NUON (VM Labs) emulator. NUON was a media-processing architecture embedded in a handful of DVD players (Samsung DVD-N501/N2000, Toshiba SD-2300, RCA DRC-480N) and used to ship a small number of games (Ballistic, Tempest 3000, Merlin Racing, Iron Soldier 3, Freefall 3050 A.D., Space Invaders XL, etc.) on standard DVD discs. The Linux/libretro port adds an OpenGL render path, miniaudio output, FUSE/ISO9660 disc reading, and an asmjit-based 64-bit JIT on top of the original Windows codebase. Currently x86_64-only and considered experimental. Games are loaded from raw ISO/BIN/CUE disc images or from individual .run/.cof program files dumped out of the disc filesystem."


### PR DESCRIPTION
## Summary

Adds the core info file for **Nuance**, a NUON (VM Labs) emulator, so it shows up in RetroArch's Core Information and can be wired into the buildbot.

- System: NUON (VM Labs) — the media-processing architecture embedded in a few DVD players (Samsung DVD-N501/N2000, Toshiba SD-2300, RCA DRC-480N) that shipped games like Tempest 3000, Ballistic, Merlin Racing, Iron Soldier 3.
- Core repo: https://github.com/andkrau/NuanceResurrection (`.gitlab-ci.yml` present, builds with `-DBUILD_LIBRETRO=ON`).
- HW-rendered (OpenGL >= 2.1), `needs_fullpath`, x86_64-only and marked `is_experimental`.
- Firmware: `bios.cof` / `minibios.cof` / `minibiosX.cof` are clean-room emulator stubs shipped with the source (not proprietary dumps), expected under `<system>/nuance/`.