### PR TITLE
Add native32emu core info file

### DIFF
--- a/dist/info/native32emu_libretro.info
+++ b/dist/info/native32emu_libretro.info
@@ -1,0 +1,32 @@
+# Software Information
+display_name = "Native32 (Native32Emu)"
+authors = "Aloys"
+supported_extensions = "smf|sgm|ssl"
+corename = "native32emu"
+categories = "Emulator"
+license = "BSD-3-Clause"
+permissions = ""
+display_version = "0.1.0"
+
+# Hardware Information
+manufacturer = "Sunplus"
+systemname = "Native32"
+systemid = "native32"
+
+# Libretro Features
+database = "Native32"
+supports_no_game = "false"
+firmware_count = 0
+savestate = "false"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "false"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "false"
+is_experimental = "true"
+
+description = "Native32Emu is an emulator for the Native32 game format developed by Sunplus for DVD player and TV chipsets. This libretro core supports .smf, .sgm and .ssl content. Audio is currently limited to RAW PCM (MP3 music is not yet played); save states and core options are not implemented."


### PR DESCRIPTION
## Summary

Adds a core info file for **Native32Emu**, a libretro core that emulates the Native32 game format developed by Sunplus for DVD player and TV chipsets (circa 2005–2011). Games use `.smf`, `.sgm`, and `.ssl` extensions.

This is the first step toward making the core available through RetroArch's Online Updater > Core Downloader.

- Core source: https://github.com/jiangxincode/Native32Emu
- Core type: emulator (Sunplus Native32 / `native32`)
- License: BSD-3-Clause
- Written in Rust; the source repo already includes a `Makefile` wrapper and a `.gitlab-ci.yml` buildbot recipe for Windows/Linux/macOS.

## Core capabilities reflected in the info file

| Feature | Value |
|---|---|
| `supported_extensions` | `smf\|sgm\|ssl` |
| `needs_fullpath` | `true` (loads sibling files for `.ssl` multi-file content) |
| `savestate` / `cheats` / `core_options` | `false` (not yet implemented) |
| `hw_render` | `false` (software rendering, XRGB8888) |
| `is_experimental` | `true` (new core; MP3 audio not yet supported) |

## Testing

Loaded the core in RetroArch with this info file placed in `libretro_info_path` and confirmed the metadata renders correctly under Information / Core Information.

## Notes

I marked the core `is_experimental = "true"` since it is newly published and a few features (MP3 audio, save states, core options) are still in progress. Happy to adjust any field to match project conventions.