### PR TITLE
Add Eternal Computer core

### DIFF
--- a/dist/info/eternal_libretro.info
+++ b/dist/info/eternal_libretro.info
@@ -1,0 +1,23 @@
+# Software Information
+display_name = "Eternal Computer"
+display_version = "0.0"
+authors = "Adrian Cable"
+categories = "Emulator"
+license = "MIT"
+supported_extensions = "capsule|bootimage"
+
+# Hardware Information
+manufacturer = "Eternal Software Initiative"
+systemname = "Eternal Computer"
+systemid = "eternal"
+
+# Libretro Features
+database = "eternal"
+supports_no_game = "false"
+libretro_saves = "false"
+cheats = "false"
+needs_fullpath = "false"
+disk_control = "false"
+is_experimental = "false"
+
+description = "A port of the Subleq+ Eternal Computer to libretro."

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1687,6 +1687,14 @@ libretro_anarch_post_fetch_cmd="mkdir -p build && cd build && cmake .."
 libretro_anarch_git_url="https://codeberg.org/iyzsong/anarch-libretro.git"
 libretro_anarch_build_makefile="Makefile"
 
+include_core_eternal() {
+        register_module core "eternal"
+}
+libretro_eternal_name="Eternal"
+libretro_eternal_git_url="https://codeberg.org/iyzsong/eternal-libretro.git"
+libretro_eternal_build_rule="cmake"
+libretro_eternal_build_args="-DCMAKE_BUILD_TYPE=Release"
+
 include_core_gam4980() {
         register_module core "gam4980"
 }


### PR DESCRIPTION
Hello, here is a core for the Eternal Computer, which is a simple one instruction virtual machine.
It can run linux and doom, but no sound, only keyboard.

See:
  https://www.ioccc.org/2025/cable/index.html
  https://www.eternal-software.org
  https://github.com/adriancable/eternal
