### PR TITLE
Add zip to native32emu supported_extensions

### DIFF
--- a/dist/info/native32emu_libretro.info
+++ b/dist/info/native32emu_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Native32 (Native32Emu)"
 authors = "Aloys"
-supported_extensions = "smf|sgm|ssl"
+supported_extensions = "smf|sgm|ssl|zip"
 corename = "native32emu"
 categories = "Emulator"
 license = "BSD-3-Clause"
@@ -29,4 +29,4 @@ needs_fullpath = "true"
 disk_control = "false"
 is_experimental = "true"
 
-description = "Native32Emu is an emulator for the Native32 game format developed by Sunplus for DVD player and TV chipsets. This libretro core supports .smf, .sgm and .ssl content. Audio is currently limited to RAW PCM (MP3 music is not yet played); save states and core options are not implemented."
+description = "Native32Emu is an emulator for the Native32 game format developed by Sunplus for DVD player and TV chipsets. This libretro core supports .smf, .sgm and .ssl content, as well as .zip game packages (extracted automatically, booting the FHUI.smf menu). Audio is currently limited to RAW PCM (MP3 music is not yet played); save states and core options are not implemented."


### PR DESCRIPTION
## Summary

Follow-up to #1982. The Native32Emu libretro core now also advertises `.zip` game packages (the core extracts the archive and boots `FHUI.smf`), so this updates the info file to keep `supported_extensions` in sync with the core.

## Changes

- `dist/info/native32emu_libretro.info`:
  - `supported_extensions`: `smf|sgm|ssl` → `smf|sgm|ssl|zip`
  - description mentions `.zip` package support

## Core-side change

The matching change in the core declares `zip` in `valid_extensions` and sets `block_extract = true` so RetroArch hands the whole archive to the core:
- jiangxincode/Native32Emu#35

Core source: https://github.com/jiangxincode/Native32Emu