### PR TITLE
Update native32emu info for v1.1.0

### DIFF
--- a/dist/info/native32emu_libretro.info
+++ b/dist/info/native32emu_libretro.info
@@ -1,0 +1,32 @@
+# Software Information
+display_name = "Native32 (Native32Emu)"
+authors = "Aloys"
+supported_extensions = "smf|sgm|ssl|zip"
+corename = "native32emu"
+categories = "Emulator"
+license = "BSD-3-Clause"
+permissions = ""
+display_version = "1.1.0"
+
+# Hardware Information
+manufacturer = "Sunplus"
+systemname = "Native32"
+systemid = "native32"
+
+# Libretro Features
+database = "Native32"
+supports_no_game = "false"
+firmware_count = 0
+savestate = "true"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "false"
+is_experimental = "false"
+
+description = "Native32Emu is an emulator for the Native32 game format developed by Sunplus for DVD player and TV chipsets. This libretro core supports .smf, .sgm and .ssl content, as well as .zip game packages (extracted automatically, booting the FHUI.smf menu)."


### PR DESCRIPTION
Update native32emu libretro core info for v1.1.0

## Changes
- `display_version`: 0.1.0 → 1.1.0
- `savestate`: false → true

## Native32Emu Release
This update is for [Native32Emu v1.1.0](https://github.com/jiangxincode/Native32Emu/releases/tag/v1.1.0).

## Reference
- https://github.com/jiangxincode/Native32Emu/issues/20