### PR TITLE
Update Native32Emu info to v1.2.0

### DIFF
--- a/dist/info/native32emu_libretro.info
+++ b/dist/info/native32emu_libretro.info
@@ -6,7 +6,7 @@ corename = "native32emu"
 categories = "Emulator"
 license = "BSD-3-Clause"
 permissions = ""
-display_version = "1.1.0"
+display_version = "1.2.0"
 
 # Hardware Information
 manufacturer = "Sunplus"


### PR DESCRIPTION
Updates `dist/info/native32emu_libretro.info` for the [Native32Emu v1.2.0 release](https://github.com/jiangxincode/Native32Emu/releases/tag/v1.2.0).

Changed field:
- `display_version`: `1.1.0` → `1.2.0`