### PR TITLE
dist/info: add pcee2_libretro.info

### DIFF
--- a/dist/info/pcee2_libretro.info
+++ b/dist/info/pcee2_libretro.info
@@ -1,0 +1,43 @@
+# Software Information
+display_name = "Sony - PlayStation 2 (PCEE2)"
+authors = "PCSX2 Team|WizzardSK"
+supported_extensions = "iso|chd|cso|zso|gz|bin|mdf|nrg|elf|irx"
+corename = "PCEE2"
+categories = "Emulator"
+license = "GPLv3"
+permissions = ""
+display_version = "v2.7.x"
+
+# Hardware Information
+manufacturer = "Sony"
+systemname = "Sony PlayStation 2"
+systemid = "playstation2"
+
+# Libretro Features
+database = "Sony - PlayStation 2"
+supports_no_game = "false"
+savestate = "true"
+savestate_features = "basic"
+cheats = "false"
+input_descriptors = "false"
+memory_descriptors = "true"
+libretro_saves = "false"
+core_options = "true"
+core_options_version = "2.0"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "false"
+is_experimental = "true"
+
+# Firmware / BIOS
+firmware_count = 2
+firmware0_desc = "'pcsx2/bios' folder (any valid PS2 BIOS dump, e.g. scph39001.bin)"
+firmware0_path = "pcsx2/bios"
+firmware0_opt = "false"
+firmware1_desc = "'pcsx2/resources' folder (shaders, GameIndex.yaml, fonts)"
+firmware1_path = "pcsx2/resources"
+firmware1_opt = "false"
+notes = "[1] This only checks that the folders exist in the correct location.|[2] The core does not require a specific BIOS filename, so this info file|[^] cannot tell you whether the content of your 'bios' folder is correct.|[3] The 'resources' folder must be copied from a PCSX2 installation of the|[^] same version; the core will not boot without it.|[4] Currently built for Linux x86_64 with a Vulkan-capable GPU."
+
+description = "A libretro port of current upstream PCSX2, the mature and highly-compatible PlayStation 2 emulator. Unlike the LRPS2 core, which is a hard fork of an older PCSX2, PCEE2 tracks the modern PCSX2 codebase. The emulator renders internally (Vulkan, OpenGL or software) and hands finished frames to the frontend, so no hardware-render context is requested from RetroArch. Place a PS2 BIOS dump in 'system/pcsx2/bios' and a copy of the PCSX2 'resources' directory in 'system/pcsx2/resources'. This core is experimental."


### PR DESCRIPTION
Fixes #2007.

The buildbot ships `pcee2_libretro.so` (nightly, linux/x86_64), but `dist/info/pcee2_libretro.info` never existed, so `Update Core Info Files` leaves the downloaded core without metadata.

Every field was checked against the core sources (`pcee2-libretro/Libretro.cpp`) and against the nightly binary from the buildbot (same `corename`, same extension list, same option keys):

- `supported_extensions` / `needs_fullpath` / `corename` — from `retro_get_system_info()`.
- `supports_no_game = false` — the core passes `false` to `SET_SUPPORT_NO_GAME`.
- `core_options_version = 2.0` — the core calls `RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2`.
- `memory_descriptors = true` — the core sends `SET_MEMORY_MAPS`.
- `hw_render = false` — the emulator renders on its own device (Vulkan/OpenGL/software) and pushes finished XRGB8888 frames through the video callback; it never requests `SET_HW_RENDER`.
- `cheats = false`, `disk_control = false`, `input_descriptors = false` — no such interfaces are registered (`retro_cheat_set` is an empty stub).
- Firmware paths follow the core's folder mapping: `<system>/pcsx2/bios` and `<system>/pcsx2/resources`, both mandatory.

`systemid`/`systemname` match the other PS2 cores in `dist/info` (`playstation2` / `Sony PlayStation 2`). The core is marked `is_experimental = true`.