### PR TITLE
Add the yaps2 libretro core (info file + linux x64 recipe, experimental)

### DIFF
--- a/dist/info/yaps2_libretro.info
+++ b/dist/info/yaps2_libretro.info
@@ -1,0 +1,44 @@
+# Software Information
+display_name = "Sony - PlayStation 2 (yaps2)"
+authors = "PCSX2 Team|bmdhacks|WizzardSK"
+supported_extensions = "elf|iso|ciso|chd|cso|zso|bin|mdf|nrg|dump|gz|img|irx|m3u"
+corename = "yaps2"
+categories = "Emulator"
+license = "GPLv3"
+permissions = ""
+display_version = "Git"
+
+# Hardware Information
+manufacturer = "Sony"
+systemname = "Sony PlayStation 2"
+systemid = "playstation2"
+
+# Libretro Features
+database = "Sony - PlayStation 2"
+supports_no_game = "false"
+savestate = "true"
+savestate_features = "basic"
+cheats = "false"
+input_descriptors = "false"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "true"
+core_options_version = "2.0"
+load_subsystem = "false"
+hw_render = "true"
+required_hw_api = "Vulkan >= 1.1"
+needs_fullpath = "true"
+disk_control = "true"
+is_experimental = "true"
+
+# Firmware / BIOS
+firmware_count = 2
+firmware0_desc = "'pcsx2/bios' folder (any valid PS2 BIOS dump, e.g. scph39001.bin)"
+firmware0_path = "pcsx2/bios"
+firmware0_opt = "false"
+firmware1_desc = "'pcsx2/resources' folder (shaders, GameIndex.yaml, fonts)"
+firmware1_path = "pcsx2/resources"
+firmware1_opt = "false"
+notes = "[1] This only checks that the folders exist in the correct location.|[2] The core does not require a specific BIOS filename, so this info file|[^] cannot tell you whether the content of your 'bios' folder is correct.|[3] The 'resources' folder must be copied from a matching yaps2/PCSX2 build;|[^] the core will not boot without it.|[4] The core is Vulkan-only: the frontend's Vulkan context is shared with the|[^] emulator through the hardware-render negotiation interface."
+
+description = "A libretro port of yaps2, a PlayStation 2 emulator forked from PCSX2 and aimed at ARM handhelds (working arm64 recompilers, Adreno fixes). The core renders through the frontend's own Vulkan context -- it takes the VkInstance and VkPhysicalDevice from the hardware-render context-negotiation interface and hands finished frames back through set_image -- so a Vulkan-capable driver is required and no other video driver will work. Place a PS2 BIOS dump in 'system/pcsx2/bios' and a copy of the emulator's 'resources' directory in 'system/pcsx2/resources'. Save states, .m3u disc swapping and the usual renderer/upscale/speedhack core options are implemented. This core is experimental."

--- a/recipes/linux/cores-linux-x64-generic
+++ b/recipes/linux/cores-linux-x64-generic
@@ -179,5 +179,6 @@ x1 libretro-xmil https://github.com/libretro/xmil-libretro.git master YES GENERI
 xrick libretro-xrick https://github.com/libretro/xrick-libretro.git master YES GENERIC Makefile .
 yabasanshiro libretro-yabasanshiro https://github.com/libretro/yabause.git yabasanshiro YES GENERIC Makefile yabause/src/libretro
 yabause libretro-yabause https://github.com/libretro/yabause.git master YES GENERIC Makefile yabause/src/libretro
+yaps2 libretro-yaps2 https://github.com/yaps2/yaps2.git main YES CMAKE Makefile build -DENABLE_LIBRETRO=ON -DENABLE_QT_UI=OFF -DENABLE_TESTS=OFF -DCMAKE_BUILD_TYPE=Release
 test libretro-samples https://github.com/libretro/libretro-samples.git master YES GENERIC Makefile tests/test
 trident libretro-trident https://github.com/DanAlexMorton/3dsTrident.git main YES CMAKE Makefile build -DBUILD_LIBRETRO_CORE=ON -DUSE_LIBRETRO_AUDIO=ON -DENABLE_USER_BUILD=ON -DENABLE_VULKAN=OFF -DENABLE_LUAJIT=OFF -DENABLE_DISCORD_RPC=OFF -DENABLE_QT_GUI=OFF -DENABLE_OPENGL=ON -DENABLE_HTTP_SERVER=OFF -DENABLE_TESTS=OFF -DENABLE_METAL=OFF


### PR DESCRIPTION
Adds **yaps2**, a libretro core for the yaps2 PlayStation 2 emulator (a PCSX2 fork aimed at ARM handhelds: working arm64 recompilers, Adreno fixes). Marked `is_experimental = "true"`.

The libretro frontend was merged into `yaps2/yaps2` main as yaps2/yaps2#4 (`pcsx2-libretro/`, built with `-DENABLE_LIBRETRO=ON`, producing `yaps2_libretro.so`), so this PR adds both the info file and a build recipe pointing at upstream main.

Tested on a Snapdragon 720G handheld (Adreno 618, Turnip): GT3 boots and renders, save states, `.m3u` disc swapping and the core options all work.

Every info field was checked against `pcsx2-libretro/Main.cpp` rather than copied from another PS2 core:

- `hw_render = true`, `required_hw_api = "Vulkan >= 1.1"` — unlike the other PS2 cores, this one genuinely shares the frontend's Vulkan context: it takes the VkInstance/VkPhysicalDevice from `SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE` and hands finished frames back via `set_image`. There is no software/GL fallback toward the frontend, so a Vulkan driver is mandatory.
- `disk_control = true` — `SET_DISK_CONTROL_EXT_INTERFACE`, `.m3u` playlists and tray swap.
- `core_options_version = 2.0` — `SET_CORE_OPTIONS_V2`.
- `supports_no_game = false`, `savestate = true` (`savestate_features = basic`).
- `cheats = false`, `memory_descriptors = false`, `input_descriptors = false` — none of those interfaces are registered (`retro_cheat_set` is an empty stub, `retro_get_memory_data` returns null). The `yaps2_cheats` core option is the emulator's own pnach system, not libretro cheats.
- Firmware: `<system>/pcsx2/bios` and `<system>/pcsx2/resources`, both mandatory, following the folder mapping in `Main.cpp`.

`systemid`/`systemname` match the other PS2 cores in `dist/info`.

The recipe is the one that builds the core here (`-DENABLE_LIBRETRO=ON -DENABLE_QT_UI=OFF -DENABLE_TESTS=OFF`); I have not been able to try it on the buildbot image, so if its dependency set needs anything else, tell me and I will adjust.