### PR TITLE
Update RustyNES core info to v2.2.1

### DIFF
--- a/dist/info/rustynes_libretro.info
+++ b/dist/info/rustynes_libretro.info
@@ -5,7 +5,7 @@ supported_extensions = "nes|fds"
 corename = "RustyNES"
 license = "MIT OR Apache-2.0"
 permissions = ""
-display_version = "v1.0.0"
+display_version = "v2.2.1"
 categories = "Emulator"
 
 # Hardware Information
@@ -25,7 +25,7 @@ core_options = "false"
 load_subsystem = "false"
 hw_render = "false"
 needs_fullpath = "false"
-disk_control = "false"
+disk_control = "true"
 database = "Nintendo - Nintendo Entertainment System|Nintendo - Family Computer Disk System"
 
 # Firmware / BIOS
@@ -35,4 +35,4 @@ firmware0_path = "disksys.rom"
 firmware0_opt = "true"
 notes = "(!) disksys.rom (md5): ca30b50f880eb660a320674ed365ef7a|RustyNES requires this BIOS in the system directory to boot Famicom Disk System games."
 
-description = "RustyNES is a cycle-accurate Nintendo Entertainment System emulator written entirely in safe Rust. Targeting the higan and Mesen2 accuracy tier, it relies on a strict, lockstep master-clock scheduler at PPU-dot resolution rather than per-game hacks. The core guarantees absolute determinism, making it an exceptional choice for advanced libretro features like run-ahead latency reduction, rollback netplay, and RetroAchievements. With high compatibility spanning over 168 mapper families, full Famicom Disk System support, and true RGB Vs. System arcade boards, RustyNES is ideal for users who seek reference-grade accuracy paired with modern stability."
+description = "RustyNES is a cycle-accurate Nintendo Entertainment System emulator written entirely in safe Rust. Targeting the higan and Mesen2 accuracy tier, it relies on a strict, lockstep master-clock scheduler at PPU-dot resolution rather than per-game hacks. The core guarantees absolute determinism, making it an exceptional choice for advanced libretro features like run-ahead latency reduction, rollback netplay, and RetroAchievements (native RETRO_ENVIRONMENT_SET_MEMORY_MAPS support). With high compatibility spanning over 172 mapper families, full Famicom Disk System support with multi-side disk-swap, native Game Genie cheats, and true RGB Vs. System arcade boards, RustyNES is ideal for users who seek reference-grade accuracy paired with modern stability."


### PR DESCRIPTION
## Summary

Refreshes `dist/info/rustynes_libretro.info`, which was still at the
`v1.0.0` display version from the core's initial submission:

- `display_version`: `v1.0.0` -> `v2.2.1`
- `disk_control`: `false` -> `true` (the core now implements
  `RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE` for FDS multi-side
  disk swapping)
- Description: mapper-family count `168` -> `172`, and mentions the
  now-real `RETRO_ENVIRONMENT_SET_MEMORY_MAPS`/native Game Genie
  cheat support backing the `memory_descriptors`/`cheats` flags that
  were already set

Companion to the buildbot CI recipe added in
https://github.com/doublegate/RustyNES/pull/312, for
https://github.com/doublegate/RustyNES/issues/311.

## Test plan

- Diffed against the file already merged on `master`; no other fields
  changed.