### PR TITLE
virtualjaguar: update info to v2.3.2

### DIFF
--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -5,7 +5,7 @@ supported_extensions = "j64|jag|rom|abs|cof|bin|prg"
 corename = "Virtual Jaguar"
 license = "GPLv3"
 permissions = ""
-display_version = "v2.2.0"
+display_version = "v2.3.2"
 categories = "Emulator"
 
 # Hardware Information
@@ -29,4 +29,4 @@ needs_fullpath = "false"
 disk_control = "false"
 is_experimental = "false"
 
-description = "A port of the Virtual Jaguar emulator, originally based on Potato Emulation, to libretro. The accurate blitter is SIMD-accelerated (SSE2 on x86, NEON on ARM), and a Fast Blitter core option is available that trades some accuracy for additional speed on lower-end hardware. Supports a high-level BIOS that lets most commercial titles boot without a real BIOS image, plus save states, SRAM, cheat codes, and RetroAchievements."
+description = "A port of the Virtual Jaguar emulator, originally based on Potato Emulation, to libretro. The accurate blitter is SIMD-accelerated (SSE2 on x86, NEON on ARM), and the Blitter core option can be set to 'Fast' to trade some accuracy for additional speed on lower-end hardware. Supports a high-level BIOS that lets most commercial titles boot without a real BIOS image, plus save states, SRAM, cheat codes, and RetroAchievements."


### PR DESCRIPTION
Syncs `dist/info/virtualjaguar_libretro.info` with the core repo at the newly published [v2.3.2](https://github.com/libretro/virtualjaguar-libretro/releases/tag/v2.3.2) tag. The file here was still at v2.2.0, so this catches up two releases.

The committed file is byte-identical to `dist/info/virtualjaguar_libretro.info` at tag `v2.3.2` in libretro/virtualjaguar-libretro. Two lines change:

**1. `display_version`** — `v2.2.0` → `v2.3.2`.

**2. `description`** — one clause went stale in v2.3.2, when the core option was renamed. It previously read "a Fast Blitter core option is available that trades some accuracy for additional speed"; the option is now presented as **Blitter: Accurate / Fast**, so the sentence now reads "the Blitter core option can be set to 'Fast' to trade some accuracy for additional speed". Same meaning, matches what users actually see in the menu.

No feature flags changed: `savestate`, `savestate_features`, `cheats`, `memory_descriptors`, `libretro_saves`, `core_options`, `hw_render`, `needs_fullpath`, `disk_control` and the rest are unchanged, as are `supported_extensions` and all hardware fields.

### About v2.3.2

Correctness and housekeeping — full notes in the [release](https://github.com/libretro/virtualjaguar-libretro/releases/tag/v2.3.2). Briefly: Battle Sphere Gold now launches with the HLE BIOS, ten blitter accuracy fixes checked against the Jaguar Technical Reference Manual, clearer Blitter/BIOS option wording, a corrected `max_height` in `retro_get_system_av_info` (the core could emit 241-line NTSC frames while advertising 240), and ~258 KB smaller binaries from dropping two unused boot-ROM blobs. Save states from v2.3.0/v2.3.1 continue to load.

All 16 platforms built and published successfully for this tag.
