### PR TITLE
info: pcee2 and nuance are no longer experimental

### DIFF
--- a/dist/info/nuance_libretro.info
+++ b/dist/info/nuance_libretro.info
@@ -29,7 +29,7 @@ libretro_saves = "false"
 core_options = "false"
 core_options_version = "null"
 load_subsystem = "false"
-is_experimental = "true"
+is_experimental = "false"
 
 # Firmware / BIOS
 firmware_count = 3

--- a/dist/info/pcee2_libretro.info
+++ b/dist/info/pcee2_libretro.info
@@ -28,7 +28,7 @@ load_subsystem = "false"
 hw_render = "false"
 needs_fullpath = "true"
 disk_control = "false"
-is_experimental = "true"
+is_experimental = "false"
 
 # Firmware / BIOS
 firmware_count = 2


### PR DESCRIPTION
Drops the `is_experimental` flag on two cores I maintain the libretro side of, so they show up in RetroArch's core downloader without "Show experimental cores" being turned on.

**`pcee2`** (PS2, PCSX2 fork with a native ARM64 recompiler) — it boots and plays commercial titles at full speed on the hardware I test on, with a zero-copy Vulkan hardware-render path, and it has been building green on the buildbot for Linux x64/aarch64 (aarch64 native, plus a musl variant) for weeks. For calibration: `pcsx2`, `dolphin`, `citra`, `kronos`, `flycast`, `swanstation` and `melondsds` all ship without the flag today.

**`nuance`** (NUON) — the libretro frontend has had its audio and ARM64 (interpreter) issues fixed upstream (andkrau/NuanceResurrection#72, #73, both merged) and it builds and runs on x86_64 and aarch64.

Only the `is_experimental` line changes in each file; nothing else is touched.
