### PR TITLE
Add Cemu (Wii U) core rule and info file

### DIFF
--- a/dist/info/cemu_libretro.info
+++ b/dist/info/cemu_libretro.info
@@ -1,0 +1,35 @@
+# Software Information
+display_name = "Nintendo - Wii U (Cemu)"
+authors = "Cemu Project|WizzardSK"
+supported_extensions = "wud|wux|wua|iso|rpx|elf"
+corename = "Cemu"
+categories = "Emulator"
+license = "MPL-2.0"
+permissions = ""
+display_version = "2.6"
+
+# Hardware Information
+manufacturer = "Nintendo"
+systemname = "Wii U"
+systemid = "wiiu"
+database = "Nintendo - Wii U"
+
+# Libretro Features
+supports_no_game = "false"
+hw_render = "true"
+needs_fullpath = "true"
+disk_control = "false"
+savestate = "false"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "false"
+libretro_saves = "true"
+core_options = "true"
+load_subsystem = "false"
+is_experimental = "true"
+
+# Firmware / BIOS
+firmware_count = 0
+notes = "(!) Save states are not supported - Cemu has no state serialization.|(!) Requires keys.txt in system/Cemu/ to load encrypted titles.|(!) MLC storage is created in saves/Cemu/mlc01/.|(!) Shared fonts go in system/Cemu/resources/sharedFonts/, graphic packs in system/Cemu/graphicPacks/.|(!) Needs a Vulkan or OpenGL 4.5 capable GPU. On Wayland use the Vulkan graphics API core option - the OpenGL path renders black there."
+
+description = "A port of the Cemu Wii U emulator to libretro. Renders through the frontend's hardware context, either Vulkan (sharing RetroArch's instance, device and queue) or OpenGL 4.5 core profile, and can composite the GamePad (DRC) screen next to the TV screen in several layouts. Save states are not supported and never will be, as Cemu has no infrastructure for serializing emulator state."

--- a/dist/info/cemu_libretro.info
+++ b/dist/info/cemu_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Nintendo - Wii U (Cemu)"
 authors = "Cemu Project|WizzardSK"
-supported_extensions = "wud|wux|wua|iso|rpx|elf"
+supported_extensions = "wud|wux|wua|iso|rpx|elf|tmd"
 corename = "Cemu"
 categories = "Emulator"
 license = "MPL-2.0"

--- a/rules.d/core-rules.sh
+++ b/rules.d/core-rules.sh
@@ -1949,6 +1949,18 @@ libretro_radio_name="Radio"
 libretro_radio_git_url="https://github.com/fpscan/libretro-radio.git"
 libretro_radio_build_makefile="Makefile"
 
+include_core_cemu() {
+	register_module core "cemu" -ios -theos_ios -ngc -ps3 -psp1 -qnx -wii
+}
+libretro_cemu_name="Cemu"
+libretro_cemu_git_url="https://github.com/WizzardSK/cemu-libretro.git"
+libretro_cemu_git_submodules="yes"
+libretro_cemu_build_rule="cmake"
+libretro_cemu_build_opengl="yes"
+libretro_cemu_build_args="-DENABLE_LIBRETRO=ON -DENABLE_BLUEZ=OFF -DENABLE_FERAL_GAMEMODE=OFF"
+# CMake writes cemu_libretro.so to <source>/bin, not into the build directory.
+libretro_cemu_build_extradir="../bin/"
+
 # CORE RULE VARIABLES
 #
 # All variables follow the format of libretro_<core>_<setting> where <core> is


### PR DESCRIPTION
There is no Wii U core on the buildbot at the moment. [Cemu](https://github.com/cemu-project/Cemu) has a libretro port that builds and runs on Linux, so this registers it: a core rule plus a `.info` file.

### What was verified

I built the core natively on aarch64 (GCC 15) and ran it in RetroArch on an Adreno 618 / Turnip machine. New Super Mario Bros. U boots and renders on the Vulkan path at ~33 FPS on the title screen.

Every field in the info file was read off the core, not guessed:

| field | where it comes from |
| --- | --- |
| `supported_extensions`, `needs_fullpath`, `display_version` | `retro_get_system_info` |
| `hw_render = "true"` | core requests a HW render context (Vulkan or GL 4.5 core profile) |
| `input_descriptors = "true"` | `RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS` |
| `libretro_saves = "true"` | MLC storage is created under `GET_SAVE_DIRECTORY` |
| `savestate = "false"` | `retro_serialize_size` returns 0 by design - Cemu has no state serialization |
| `cheats = "false"` | `retro_cheat_set` is an empty stub |
| `memory_descriptors = "false"` | the core never calls `SET_MEMORY_MAPS` |

Marked `is_experimental = "true"`.

`build_extradir` is `../bin/` because Cemu's CMake writes `cemu_libretro.so` to `<source>/bin` rather than into the build directory.

### Two things worth flagging

- **The URL points at my fork.** Upstream `danprice142/Cemu-Libretro` has been dead since January and is ~119 commits behind; the libretro work (Vulkan HW render via context negotiation, DRC screen layouts, core options) lives on my branch. Happy to retarget if the core gets a home under the libretro organisation.
- **There is no project for cemu on git.libretro.com** (`/api/v4/projects?search=cemu` returns `[]`), so nothing will actually build until a mirror is registered. The repository has a `.gitlab-ci.yml` with a `libretro-build-linux-aarch64` job ready and its default branch is set to the branch carrying it - but that job has not been run yet, since I have no way to trigger a pipeline.

Builds are heavy: vcpkg compiles roughly 30 ports from source, Boost included.