### PR TITLE
Add DingooEmu core info file

### DIFF
--- a/dist/info/dingooemu_libretro.info
+++ b/dist/info/dingooemu_libretro.info
@@ -1,0 +1,32 @@
+# Software Information
+display_name = "Dingoo A320 (DingooEmu)"
+authors = "Aloys"
+supported_extensions = "app"
+corename = "dingooemu"
+categories = "Emulator"
+license = "BSD-3-Clause"
+permissions = ""
+display_version = "0.1.0"
+
+# Hardware Information
+manufacturer = "Ingenic"
+systemname = "Dingoo A320"
+systemid = "dingoo-a320"
+
+# Libretro Features
+database = "Dingoo A320"
+supports_no_game = "false"
+firmware_count = 0
+savestate = "true"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "false"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "false"
+is_experimental = "false"
+
+description = "DingooEmu is an emulator for the Dingoo A320 handheld game console powered by the Ingenic JZ4740 MIPS SoC. This libretro core supports .app game files from the Dingoo ecosystem."


### PR DESCRIPTION
## Description

This PR adds the core info file for **DingooEmu**, an emulator for the Dingoo A320 handheld game console.

## Core Information

- **Core name**: `dingooemu`
- **Display name**: Dingoo A320 (DingooEmu)
- **Supported extensions**: `.app`
- **System**: Dingoo A320 (Ingenic JZ4740 MIPS)
- **License**: BSD-3-Clause

## Related

- Project: https://github.com/jiangxincode/DingooEmu