### PR TITLE
virtualjaguar: display_version v3.3.0

### DIFF
--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -5,7 +5,7 @@ supported_extensions = "j64|jag|rom|abs|cof|bin|prg|cue|cdi"
 corename = "Virtual Jaguar"
 license = "GPLv3"
 permissions = ""
-display_version = "v3.2.0"
+display_version = "v3.3.0"
 categories = "Emulator"
 
 # Hardware Information


### PR DESCRIPTION
Virtual Jaguar core released [v3.3.0](https://github.com/libretro/virtualjaguar-libretro/releases/tag/v3.3.0) — hi-res completion (RGB16 direct-mode renderer, OP scaled-object supersampling incl. 8bpp CLUT) plus correctness fixes (Val d'Isère ground via the OB register byte order from the original Flare netlists, Doom savestate/run-ahead determinism, savestate v11 with full backward compatibility to v3.2.0 states).

Matches `dist/info/virtualjaguar_libretro.info` in the core repo at tag `v3.3.0`; only `display_version` changed this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)