### PR TITLE
Update dingooemu_libretro.info to v0.2.0

### DIFF
--- a/dist/info/dingooemu_libretro.info
+++ b/dist/info/dingooemu_libretro.info
@@ -6,7 +6,7 @@ corename = "dingooemu"
 categories = "Emulator"
 license = "BSD-3-Clause"
 permissions = ""
-display_version = "0.1.0"
+display_version = "0.2.0"
 
 # Hardware Information
 manufacturer = "Ingenic"


### PR DESCRIPTION
Update DingooEmu core info file for v0.2.0 release.

Changes:
- Bump `display_version` from `0.1.0` to `0.2.0`

Release: https://github.com/jiangxincode/DingooEmu/releases/tag/v0.2.0