### PR TITLE
Update Native32Emu info to v1.3.0

### DIFF
--- a/dist/info/native32emu_libretro.info
+++ b/dist/info/native32emu_libretro.info
@@ -6,7 +6,7 @@ corename = "native32emu"
 categories = "Emulator"
 license = "BSD-3-Clause"
 permissions = ""
-display_version = "1.2.0"
+display_version = "1.3.0"
 
 # Hardware Information
 manufacturer = "Sunplus"
@@ -29,4 +29,4 @@ needs_fullpath = "true"
 disk_control = "false"
 is_experimental = "false"
 
-description = "Native32Emu is an emulator for the Native32 game format developed by Sunplus for DVD player and TV chipsets. This libretro core supports .smf, .sgm and .ssl content, as well as .zip game packages (extracted automatically, booting the FHUI.smf menu)."
+description = "Native32Emu is an emulator for the Native32 game format developed by Sunplus for DVD player and TV chipsets. This libretro core supports .smf, .sgm and .ssl content, as well as .zip game packages (extracted automatically, booting an FHUI.smf or NA32UI.smf menu)."


### PR DESCRIPTION
## Changes

- Update  to 
- Reference: [Native32Emu v1.3.0 release](https://github.com/AloysHF/Native32Emu/releases/tag/v1.3.0)

## v1.3.0 Highlights

### New Features
- **webOS support**: New libretro core for LG webOS TVs
- **Shared cheats**: New shared cheats and target discovery tools

### Bug Fixes
- Fix KOK Native32 selector actions (#107)
- Support packed Native32 assets (#109)
- Correct ARGB1555 decoder red/blue channel layout (#40)
- Add libretro return action support (#96)
- Fix return to parent SMF applications (#115)