### PR TITLE
virtualjaguar: update info to v3.6.1

### DIFF
--- a/dist/info/virtualjaguar_libretro.info
+++ b/dist/info/virtualjaguar_libretro.info
@@ -5,7 +5,7 @@ supported_extensions = "j64|jag|rom|abs|cof|bin|prg|cue|cdi|chd"
 corename = "Virtual Jaguar"
 license = "GPLv3"
 permissions = ""
-display_version = "v3.5.1"
+display_version = "v3.6.1"
 categories = "Emulator"
 
 # Hardware Information
@@ -14,7 +14,7 @@ systemname = "Jaguar"
 systemid = "atari_jaguar"
 
 # Libretro Features
-supports_no_game = "false"
+supports_no_game = "true"
 database = "Atari - Jaguar"
 savestate = "true"
 savestate_features = "3"
@@ -26,7 +26,7 @@ core_options = "true"
 load_subsystem = "false"
 hw_render = "false"
 needs_fullpath = "false"
-disk_control = "false"
+disk_control = "true"
 is_experimental = "false"
 
 # BIOS / Firmware (all optional -- embedded copies are used when absent)


### PR DESCRIPTION
Updates `dist/info/virtualjaguar_libretro.info` to match the file shipped in [libretro/virtualjaguar-libretro at tag `v3.6.1`](https://github.com/libretro/virtualjaguar-libretro/releases/tag/v3.6.1).

Three fields, verified by diffing the whole file against the tag:

| Field | Before | After |
|---|---|---|
| `display_version` | `v3.5.1` | `v3.6.1` |
| `supports_no_game` | `false` | `true` |
| `disk_control` | `false` | `true` |

**`disk_control`** — the core has implemented `RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE` since v3.6.0.

**`supports_no_game`** — the core has implemented `RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME` since v3.6.0, but the info file was never flipped, so frontends were never told. It is being flipped now rather than at v3.6.0 because v3.6.1 is the first release where a contentless launch reaches somewhere useful: it comes up in the CD BIOS on its insert-disc screen. In v3.6.0 it came up on an empty cartridge slot, which is a dead end — the CD BIOS is mapped as a cartridge, so nothing reachable from that screen could get to it.

Together these make "start the core with no content, insert a disc, reach the Virtual Light Machine with an audio CD" reachable from the frontend.

The libretro buildbot is green for this core (21/21 on the latest master pipeline).