### PR TITLE
info: add ARMSX2

### DIFF
--- a/dist/info/armsx2_libretro.info
+++ b/dist/info/armsx2_libretro.info
@@ -1,0 +1,44 @@
+# Software Information
+display_name = "Sony - PlayStation 2 (ARMSX2)"
+authors = "PCSX2 Team|ARMSX2 Team|bmdhacks|WizzardSK"
+supported_extensions = "elf|iso|ciso|chd|cso|zso|bin|mdf|nrg|dump|gz|img|irx|m3u"
+corename = "ARMSX2"
+categories = "Emulator"
+license = "GPLv3"
+permissions = ""
+display_version = "Git"
+
+# Hardware Information
+manufacturer = "Sony"
+systemname = "Sony PlayStation 2"
+systemid = "playstation2"
+
+# Libretro Features
+database = "Sony - PlayStation 2"
+supports_no_game = "false"
+savestate = "true"
+savestate_features = "basic"
+cheats = "false"
+input_descriptors = "false"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "true"
+core_options_version = "2.0"
+load_subsystem = "false"
+hw_render = "true"
+required_hw_api = "Vulkan >= 1.1|OpenGL >= 3.3|OpenGL ES >= 3.2"
+needs_fullpath = "true"
+disk_control = "true"
+is_experimental = "false"
+
+# Firmware / BIOS
+firmware_count = 2
+firmware0_desc = "'pcsx2/bios' folder (any valid PS2 BIOS dump, e.g. scph39001.bin)"
+firmware0_path = "pcsx2/bios"
+firmware0_opt = "false"
+firmware1_desc = "'pcsx2/resources' folder (shaders, GameIndex.yaml, fonts)"
+firmware1_path = "pcsx2/resources"
+firmware1_opt = "false"
+notes = "[1] This only checks that the folders exist in the correct location.|[2] The core does not require a specific BIOS filename, so this info file|[^] cannot tell you whether the content of your 'bios' folder is correct.|[3] The 'resources' folder must be copied from a matching ARMSX2/PCSX2 build;|[^] the core will not boot without it.|[4] The frontend's video driver must be Vulkan or OpenGL, whichever the|[^] renderer core option asks for; the emulator shares that context.|[5] ARM64 only: the buildbot builds Linux aarch64, macOS arm64 and Android|[^] arm64-v8a. On x86-64 use the PCEE2 or LRPS2 core instead."
+
+description = "A libretro port of ARMSX2, a PlayStation 2 emulator forked from PCSX2 and aimed at ARM64 platforms. The core renders through a hardware context it shares with the frontend: Vulkan by default, taking the VkInstance and VkPhysicalDevice from the context-negotiation interface and handing finished frames back through set_image, or an OpenGL core 3.3 context (OpenGL ES 3.2 on Android) when the renderer core option asks for it. A software GS renderer is selectable as well, and presents through that same context. Place a PS2 BIOS dump in 'system/pcsx2/bios' and a copy of the emulator's 'resources' directory in 'system/pcsx2/resources'. Save states, .m3u disc swapping and the usual renderer, upscale and speedhack core options are implemented."


### PR DESCRIPTION
`armsx2_libretro.info` exists in libretro-core-info but not here, so the source of truth does not have it; the next regeneration from this tree would drop it. This adds it, with two corrections against the copy that is shipping.

**What changed against the shipping file**

- `required_hw_api` was `Vulkan >= 1.1`. ARMSX2/ARMSX2#638 merged on 5 September added an OpenGL context path, so the core now asks for `RETRO_HW_CONTEXT_OPENGL_CORE` 3.3 (`OPENGLES3` 3.2 on Android) when its renderer option is set to OpenGL, and Vulkan otherwise. The notes and description said "Vulkan-only" and no longer should.
- `is_experimental` is `false` here. It was `true`; the core builds and runs on all three of its buildbot targets, and it reads as a normal core now.

**Where the rest of the fields come from** - the core's libretro layer (`pcsx2-libretro/Main.cpp`), not guesswork:

- `supported_extensions` and `needs_fullpath` are what `retro_get_system_info` sets.
- `core_options_version = 2.0`: it asks with `GET_CORE_OPTIONS_VERSION` and uses `SET_CORE_OPTIONS_V2`, falling back to `SET_VARIABLES`.
- `disk_control = true`: it installs `SET_DISK_CONTROL_EXT_INTERFACE`, hence `m3u`.
- `supports_no_game = false`, `cheats = false` (`retro_cheat_set` is an empty stub), `memory_descriptors` and `input_descriptors` false - it sets neither.
- `savestate = true`, `basic`: `retro_serialize`/`retro_unserialize` sit on PCSX2's state machinery.
- The firmware paths are the ones the core reads: `AppRoot` at `<system>/pcsx2`, `Resources` at `<system>/pcsx2/resources`, BIOS images enumerated from `<system>/pcsx2/bios`.

The buildbot builds this core for ARM64 only (Linux aarch64, macOS arm64, Android arm64-v8a) - `libretro/armsx2`, project 494, first green pipeline this morning - so the notes point x86-64 users at PCEE2 or LRPS2. I will send the same two corrections to libretro-core-info so the two do not drift.