### PR TITLE
info: add FreeJ2ME-Plus, and complete FreeJ2ME's file

### DIFF
--- a/dist/info/freej2me_libretro.info
+++ b/dist/info/freej2me_libretro.info
@@ -23,6 +23,9 @@ input_descriptors = "true"
 memory_descriptors = "false"
 libretro_saves = "false"
 core_options = "true"
+core_options_version = "2.0"
+hw_render = "false"
+needs_fullpath = "true"
 
 # BIOS / Firmware
 firmware_count = 1

--- a/dist/info/freej2me_plus_libretro.info
+++ b/dist/info/freej2me_plus_libretro.info
@@ -1,0 +1,36 @@
+# Software Information
+display_name = "Mobile - J2ME (FreeJ2ME-Plus)"
+authors = "Paulo Sousa(AShiningRay)|David Richardson(recompileorg)|Saket Dandawate(hex007)"
+supported_extensions = "jar|kjx"
+corename = "FreeJ2ME-Plus"
+categories = "Emulator"
+license = "GPLv3"
+permissions = ""
+display_version = "1.52-GIT"
+
+# Hardware Information
+manufacturer = "Oracle Corporation"
+systemname = "J2ME"
+systemid = "j2me"
+
+# Libretro Features
+supports_no_game = "false"
+database = "Mobile - J2ME"
+savestate = "false"
+savestate_features = "null"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "false"
+libretro_saves = "false"
+hw_render = "false"
+core_options = "true"
+core_options_version = "2.0"
+needs_fullpath = "true"
+
+# BIOS / Firmware
+firmware_count = 1
+firmware0_desc = "freej2me_plus-lr.jar (Main Application)"
+firmware0_path = "freej2me_plus-lr.jar"
+firmware0_opt = "false"
+
+description = "A fork of FreeJ2ME with improved compatibility and better libretro support. This core emulates Java ME applications and games for Java-based mobile phones."


### PR DESCRIPTION
Both J2ME cores now carry a buildbot CI recipe in their own repositories - hex007/freej2me#237 and TASEmulators/freej2me-plus#251, both merged - so their info files should be here and correct. `freej2me_plus_libretro.info` is missing entirely, and `freej2me_libretro.info` is missing three fields the core actually reports.

**FreeJ2ME-Plus.** The file the core's own repository ships (`src/libretro/freej2me_plus_libretro.info`), with one change: `systemid` is `j2me`, which is what `freej2me_libretro.info` and `squirreljme_libretro.info` already use here, rather than the `mobile_j2me` in the repository's copy. The core is built as `freej2me_plus_libretro` - the rename in that PR, since both repositories previously produced `freej2me_libretro` and would have collided.

**FreeJ2ME.** Added `core_options_version = "2.0"`, `needs_fullpath = "true"` and `hw_render = "false"`. Not guesses - from `src/libretro/freej2me_libretro.c`:

```c
if (core_opt_version >= 2) { Environ(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2, &core_exposed_options); }
else                       { Environ(RETRO_ENVIRONMENT_SET_VARIABLES, (void*)vars); }
...
info->valid_extensions = "jar";
info->need_fullpath    = true;
```

The same three lines in freej2me-plus, where `valid_extensions` is `"jar|kjx"` and the version is 1.52, both of which its file already had.