### PR TITLE
info: add EmuCV

### DIFF
--- a/dist/info/emucv_libretro.info
+++ b/dist/info/emucv_libretro.info
@@ -1,0 +1,33 @@
+# Software Information
+display_name = "EPOCH - Cassette Vision (EmuCV)"
+authors = "Maxime MARCONATO (aka MaaaX)"
+supported_extensions = "bin"
+corename = "EmuCV"
+categories = "Emulator"
+license = "GPLv3"
+permissions = ""
+display_version = "0.00"
+
+# Hardware Information
+manufacturer = "EPOCH"
+systemname = "Cassette Vision"
+
+# Libretro Features
+supports_no_game = "false"
+savestate = "false"
+savestate_features = "null"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "false"
+libretro_saves = "false"
+core_options = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "false"
+is_experimental = "true"
+
+# BIOS / Firmware
+firmware_count = 0
+
+description = "A libretro core for the EPOCH Cassette Vision, the 1981 Japanese console whose games carried their own CPU in the cartridge. The core is in early development: no save states and no core options yet."
+notes = "The Cassette Vision needs no BIOS - each cartridge contains the uPD777 (or uPD778) that runs it, so the ROM dump is the whole machine."


### PR DESCRIPTION
Adds `dist/info/emucv_libretro.info`.

**EmuCV** emulates the **EPOCH Cassette Vision** (1981) — the console whose cartridges carried the CPU, so there is no BIOS to speak of. It is by the same author as EmuSCV, whose info file is already here, and lives at [MaaaX-EPOCH84/libretro-emucv](https://gitlab.com/MaaaX-EPOCH84/libretro-emucv).

Everything in the file is read off the core rather than guessed:

| Field | Where it comes from |
|---|---|
| `corename = "EmuCV"` | `CORE_NAME` in `src/core.h`, which is what `retro_get_system_info` reports as `library_name` |
| `supported_extensions = "bin"` | `CORE_EXTENSIONS` |
| `needs_fullpath` | `need_fullpath = true` in `c_core::RetroGetSystemInfo` |
| `supports_no_game = "false"` | `CORE_SUPPORT_NO_GAME` |
| `savestate = "false"` | `f_retro_serialize_size()` returns 0 |
| `core_options = "false"` | the `SET_VARIABLES` calls are all commented out |
| `license = "GPLv3"` | `licence.txt` |

It is marked `is_experimental` because the repository describes itself as a work in progress.

The core has no buildbot recipe yet — I opened one at MaaaX-EPOCH84/libretro-emucv!1 — so this is the info half, the same order things happened in for the J2ME cores in #2093.